### PR TITLE
[BUGFIX] Require typo3/minimal for installing TYPO3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,9 +20,14 @@ before_install:
 - phpenv config-rm xdebug.ini
 
 install:
-- composer require-typo3-version "$TYPO3_VERSION"
-- git checkout .
-- export TYPO3_PATH_ROOT=$PWD/.Build/public
+- >
+  composer require typo3/minimal=$TYPO3_VERSION;
+- >
+  echo;
+  echo "Restoring the composer.json";
+  git checkout .;
+- >
+  export TYPO3_PATH_ROOT=$PWD/.Build/public;
 
 script:
 - >

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ## 1.4.1
 
 ### Fixed
+- Require typo3/minimal for installing TYPO3 (#38)
 - fix the sorting in the daily registration digest (#23)
 - require mkforms >= 3.0.14 (#22)
 

--- a/composer.json
+++ b/composer.json
@@ -68,10 +68,6 @@
         "ci": [
             "@ci:static"
         ],
-        "require-typo3-version": [
-            "@php -r '$conf=json_decode(file_get_contents(__DIR__.\"/composer.json\"),true);$conf[\"require\"][\"typo3/cms-core\"]=$_SERVER[\"argv\"][1];file_put_contents(__DIR__.\"/composer.json\",json_encode($conf,JSON_UNESCAPED_SLASHES|JSON_PRETTY_PRINT).chr(10));'",
-            "@composer install"
-        ],
         "link-extension": [
             "@php -r 'is_dir($extFolder=__DIR__.\"/.Build/public/typo3conf/ext/\") || mkdir($extFolder, 0777, true);'",
             "@php -r 'file_exists($extFolder=__DIR__.\"/.Build/public/typo3conf/ext/seminars\") || symlink(__DIR__,$extFolder);'"


### PR DESCRIPTION
This fixes the TYPO3 installation process using Composer on Travis
both for 7.6 as well as 8.7.