### PR TITLE
[BUGFIX] Provide time zone information in the iCal files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Drop the incorrect TYPO3 Core license headers (#41)
 
 ### Fixed
+- Provide time zone information in the iCal files (#44)
 - Provide cli_dispatch.phpsh for 8.7 on Travis (#40)
 - Adapt the calls to cObj->IMAGE to TYPO3 8.7 (#28)
 - Increase the maximum file sizes for images (#27)

--- a/Classes/Model/Event.php
+++ b/Classes/Model/Event.php
@@ -262,6 +262,24 @@ class Tx_Seminars_Model_Event extends Tx_Seminars_Model_AbstractTimeSpan
     }
 
     /**
+     * @return string
+     */
+    public function getTimeZone()
+    {
+        return $this->getAsString('time_zone');
+    }
+
+    /**
+     * @param string $timeZone
+     *
+     * @return void
+     */
+    public function setTimeZone($timeZone)
+    {
+        $this->setAsString('time_zone', $timeZone);
+    }
+
+    /**
      * Returns our accreditation number.
      *
      * @return string our accreditation number, will be empty if this event has

--- a/Classes/Service/RegistrationManager.php
+++ b/Classes/Service/RegistrationManager.php
@@ -881,6 +881,7 @@ class Tx_Seminars_Service_RegistrationManager extends Tx_Oelib_TemplateHelper
     private function addCalendarAttachment(\Tx_Oelib_Mail $email, \Tx_Seminars_Model_Registration $registration)
     {
         $event = $registration->getEvent();
+        $timeZone = $event->getTimeZone() ?: $this->getConfValueString('defaultTimeZone');
 
         /** @var \Tx_Oelib_Attachment $calendarEntry */
         $calendarEntry = GeneralUtility::makeInstance(\Tx_Oelib_Attachment::class);
@@ -895,10 +896,10 @@ class Tx_Seminars_Service_RegistrationManager extends Tx_Oelib_TemplateHelper
             'DTSTAMP:' . strftime('%Y%m%dT%H%M%S', $GLOBALS['SIM_EXEC_TIME']) . CRLF .
             'SUMMARY:' . $event->getTitle() . CRLF .
             'DESCRIPTION:' . $event->getSubtitle() . CRLF .
-            'DTSTART:' . strftime('%Y%m%dT%H%M%S', $event->getBeginDateAsUnixTimeStamp()) . CRLF;
+            'DTSTART' . $this->formatDateForWithZone($event->getBeginDateAsUnixTimeStamp(), $timeZone) . CRLF;
 
         if ($event->hasEndDate()) {
-            $content .= 'DTEND:' . strftime('%Y%m%dT%H%M%S', $event->getEndDateAsUnixTimeStamp()) . CRLF;
+            $content .= 'DTEND' . $this->formatDateForWithZone($event->getEndDateAsUnixTimeStamp(), $timeZone) . CRLF;
         }
         if (!$event->getPlaces()->isEmpty()) {
             /** @var \Tx_Seminars_Model_Place $firstPlace */
@@ -919,6 +920,17 @@ class Tx_Seminars_Service_RegistrationManager extends Tx_Oelib_TemplateHelper
         $calendarEntry->setContent($content);
 
         $email->addAttachment($calendarEntry);
+    }
+
+    /**
+     * @param int $dateAsUnixTimeStamp
+     * @param string $timeZone
+     *
+     * @return string
+     */
+    private function formatDateForWithZone($dateAsUnixTimeStamp, $timeZone)
+    {
+        return ';TZID=/' . $timeZone . ':' . strftime('%Y%m%dT%H%M%S', $dateAsUnixTimeStamp);
     }
 
     /**

--- a/Configuration/TCA/tx_seminars_seminars.php
+++ b/Configuration/TCA/tx_seminars_seminars.php
@@ -32,7 +32,7 @@ $tca = [
         'searchFields' => 'title,accreditation_number',
     ],
     'interface' => [
-        'showRecordFieldList' => 'title,subtitle,categories,teaser,description,accreditation_number,credit_points,begin_date,end_date,timeslots,begin_date_registration,deadline_registration,deadline_unregistration,expiry,details_page,place,room,speakers,price_regular,price_special,payment_methods,organizers,organizing_partners,event_takes_place_reminder_sent,cancelation_deadline_reminder_sent,needs_registration,allows_multiple_registrations,attendees_min,attendees_max,queue_size,offline_attendees,organizers_notified_about_minimum_reached,mute_notification_emails,target_groups,skip_collision_check,registrations,cancelled,automatic_confirmation_cancelation,notes,attached_files,hidden,starttime,endtime,owner_feuser,vips,price_on_request,date_of_last_registration_digest',
+        'showRecordFieldList' => 'title,subtitle,categories,teaser,description,accreditation_number,credit_points,begin_date,end_date,time_zone,timeslots,begin_date_registration,deadline_registration,deadline_unregistration,expiry,details_page,place,room,speakers,price_regular,price_special,payment_methods,organizers,organizing_partners,event_takes_place_reminder_sent,cancelation_deadline_reminder_sent,needs_registration,allows_multiple_registrations,attendees_min,attendees_max,queue_size,offline_attendees,organizers_notified_about_minimum_reached,mute_notification_emails,target_groups,skip_collision_check,registrations,cancelled,automatic_confirmation_cancelation,notes,attached_files,hidden,starttime,endtime,owner_feuser,vips,price_on_request,date_of_last_registration_digest',
     ],
     'columns' => [
         'object_type' => [
@@ -213,6 +213,15 @@ $tca = [
                 'eval' => 'datetime',
                 'checkbox' => '0',
                 'default' => '0',
+            ],
+        ],
+        'time_zone' => [
+            'exclude' => 1,
+            'label' => \OliverKlee\Seminars\BackEnd\TceForms::getPathToDbLL() . 'tx_seminars_seminars.time_zone',
+            'config' => [
+                'type' => 'input',
+                'size' => '30',
+                'eval' => 'trim',
             ],
         ],
         'timeslots' => [
@@ -1000,7 +1009,7 @@ $tca = [
         '0' => [
             'showitem' => '' .
                 '--div--;LLL:EXT:seminars/Resources/Private/Language/locallang_db:tx_seminars_seminars.divLabelGeneral, object_type, title;;;;2-2-2, subtitle;;;;3-3-3, image, categories, teaser, description;;;richtext[paste|bold|italic|formatblock|class|left|center|right|orderedlist|unorderedlist|outdent|indent|link|image]:rte_transform[mode=ts_css], event_type, language, accreditation_number, credit_points, details_page, additional_information;;;richtext[paste|bold|italic|formatblock|class|left|center|right|orderedlist|unorderedlist|outdent|indent|link|image]:rte_transform[mode=ts_css], checkboxes, uses_terms_2, cancelled, automatic_confirmation_cancelation, notes, attached_files, ' .
-                '--div--;LLL:EXT:seminars/Resources/Private/Language/locallang_db:tx_seminars_seminars.divLabelPlaceTime, begin_date, end_date, timeslots, begin_date_registration, deadline_registration, deadline_early_bird, deadline_unregistration, place, room, ' .
+                '--div--;LLL:EXT:seminars/Resources/Private/Language/locallang_db:tx_seminars_seminars.divLabelPlaceTime, begin_date, end_date, time_zone, timeslots, begin_date_registration, deadline_registration, deadline_early_bird, deadline_unregistration, place, room, ' .
                 '--div--;LLL:EXT:seminars/Resources/Private/Language/locallang_db:tx_seminars_seminars.divLabelSpeakers, speakers, partners, tutors, leaders, ' .
                 '--div--;LLL:EXT:seminars/Resources/Private/Language/locallang_db:tx_seminars_seminars.divLabelOrganizers, organizers, organizing_partners, event_takes_place_reminder_sent, cancelation_deadline_reminder_sent, ' .
                 '--div--;LLL:EXT:seminars/Resources/Private/Language/locallang_db:tx_seminars_seminars.divLabelAttendees, needs_registration, allows_multiple_registrations, attendees_min, attendees_max, queue_size, offline_attendees, organizers_notified_about_minimum_reached, mute_notification_emails, target_groups, skip_collision_check, date_of_last_registration_digest, registrations, ' .
@@ -1020,7 +1029,7 @@ $tca = [
         '2' => [
             'showitem' =>
                 '--div--;LLL:EXT:seminars/Resources/Private/Language/locallang_db:tx_seminars_seminars.divLabelGeneral, object_type, title;;;;2-2-2, topic, language, accreditation_number, details_page, cancelled, automatic_confirmation_cancelation, notes, attached_files, ' .
-                '--div--;LLL:EXT:seminars/Resources/Private/Language/locallang_db:tx_seminars_seminars.divLabelPlaceTime, begin_date, end_date, timeslots, begin_date_registration, deadline_registration, deadline_early_bird, deadline_unregistration, expiry, place, room, ' .
+                '--div--;LLL:EXT:seminars/Resources/Private/Language/locallang_db:tx_seminars_seminars.divLabelPlaceTime, begin_date, end_date, time_zone, timeslots, begin_date_registration, deadline_registration, deadline_early_bird, deadline_unregistration, expiry, place, room, ' .
                 '--div--;LLL:EXT:seminars/Resources/Private/Language/locallang_db:tx_seminars_seminars.divLabelSpeakers, speakers, partners, tutors, leaders, ' .
                 '--div--;LLL:EXT:seminars/Resources/Private/Language/locallang_db:tx_seminars_seminars.divLabelOrganizers, organizers, organizing_partners, event_takes_place_reminder_sent, cancelation_deadline_reminder_sent, ' .
                 '--div--;LLL:EXT:seminars/Resources/Private/Language/locallang_db:tx_seminars_seminars.divLabelAttendees, needs_registration, attendees_min, attendees_max, queue_size, offline_attendees, organizers_notified_about_minimum_reached, mute_notification_emails, skip_collision_check, date_of_last_registration_digest, registrations, ' .

--- a/Configuration/TypoScript/setup.txt
+++ b/Configuration/TypoScript/setup.txt
@@ -90,6 +90,9 @@ plugin.tx_seminars {
     # whether date ranges should be shortened when possible
     abbreviateDateRanges = 1
 
+    # time zone used for the iCal attachments in case an event does not have a specific time zone set
+    defaultTimeZone = Europe/Berlin
+
     # ISO 4217 alpha 3 code of the currency to be used, must be valid
     currency = EUR
 

--- a/Documentation/DE/Referenz/SetupCommonForFront-endPlug-inAndBack-endModuleInPlugintxSeminars/Index.rst
+++ b/Documentation/DE/Referenz/SetupCommonForFront-endPlug-inAndBack-endModuleInPlugintxSeminars/Index.rst
@@ -509,6 +509,21 @@ only be configured using your TypoScript setup, but not via flexforms.
 
 .. container:: table-row
 
+   Property
+         defaultTimeZone
+
+   Data type
+         string
+
+   Description
+         time zone used for the iCal attachments in case an event does not have a specific time zone set
+
+   Default
+         Europe/Berlin
+
+
+.. container:: table-row
+
    Eigenschaft
          abbreviateDateRanges
 

--- a/Documentation/EN/Reference/SetupCommonForFront-endPlug-inAndBack-endModuleInPlugintxSeminars/Index.rst
+++ b/Documentation/EN/Reference/SetupCommonForFront-endPlug-inAndBack-endModuleInPlugintxSeminars/Index.rst
@@ -526,6 +526,21 @@ only be configured using your TypoScript setup, but not via flexforms.
 .. container:: table-row
 
    Property
+         defaultTimeZone
+
+   Data type
+         string
+
+   Description
+         time zone used for the iCal attachments in case an event does not have a specific time zone set
+
+   Default
+         Europe/Berlin
+
+
+.. container:: table-row
+
+   Property
          currency
 
    Data type

--- a/Resources/Private/Language/de.locallang_db.xlf
+++ b/Resources/Private/Language/de.locallang_db.xlf
@@ -211,6 +211,10 @@
                 <source>End time and date:</source>
                 <target>Endzeit und -datum:</target>
             </trans-unit>
+            <trans-unit id="tx_seminars_seminars.time_zone" xml:space="preserve">
+                <source>Time zone:</source>
+                <target>Zeitzone:</target>
+            </trans-unit>
             <trans-unit id="tx_seminars_seminars.timeslots" xml:space="preserve" approved="yes">
                 <source>Time slots</source>
                 <target>Zeitblöcke</target>

--- a/Resources/Private/Language/locallang_db.xlf
+++ b/Resources/Private/Language/locallang_db.xlf
@@ -159,6 +159,9 @@
             <trans-unit id="tx_seminars_seminars.end_date" xml:space="preserve">
                 <source>End time and date:</source>
             </trans-unit>
+            <trans-unit id="tx_seminars_seminars.time_zone" xml:space="preserve">
+                <source>Time zone:</source>
+            </trans-unit>
             <trans-unit id="tx_seminars_seminars.timeslots" xml:space="preserve">
                 <source>Time slots</source>
             </trans-unit>

--- a/Tests/Unit/Model/EventTest.php
+++ b/Tests/Unit/Model/EventTest.php
@@ -209,6 +209,44 @@ class Tx_Seminars_Tests_Unit_Model_EventTest extends Tx_Phpunit_TestCase
         );
     }
 
+    /*
+     * Tests regarding the time zone.
+     */
+
+    /**
+     * @test
+     */
+    public function getTimeZoneInitiallyReturnsEmptyString()
+    {
+        $this->fixture->setData([]);
+
+        static::assertSame('', $this->fixture->getTimeZone());
+    }
+
+    /**
+     * @test
+     */
+    public function getTimeZoneReturnsTimeZone()
+    {
+        $value = 'Europe/Berlin';
+        $this->fixture->setData(['time_zone' => $value]);
+
+        static::assertSame($value, $this->fixture->getTimeZone());
+    }
+
+    /**
+     * @test
+     */
+    public function setTimeZoneSetsTimeZone()
+    {
+        $this->fixture->setData([]);
+
+        $value = 'Europe/Berlin';
+        $this->fixture->setTimeZone($value);
+
+        static::assertSame($value, $this->fixture->getTimeZone());
+    }
+
     //////////////////////////////////////////////
     // Tests regarding the accreditation number.
     //////////////////////////////////////////////

--- a/Tests/Unit/Service/RegistrationManagerTest.php
+++ b/Tests/Unit/Service/RegistrationManagerTest.php
@@ -3682,8 +3682,12 @@ class Tx_Seminars_Tests_Unit_Service_RegistrationManagerTest extends Tx_Phpunit_
     /**
      * @test
      */
-    public function notifyAttendeeHasCalendarAttachmentWithEventStartDate()
+    public function notifyAttendeeHasCalendarAttachmentWithEventStartDateWithTimeZoneFromEvent()
     {
+        $timeZone = 'America/Chicago';
+        $this->testingFramework->changeRecord('tx_seminars_seminars', $this->seminarUid, ['time_zone' => $timeZone]);
+        $this->fixture->setConfigurationValue('defaultTimeZone', 'Europe/Berlin');
+
         $this->fixture->setConfigurationValue('sendConfirmation', true);
         $pi1 = new Tx_Seminars_FrontEnd_DefaultController();
         $pi1->init();
@@ -3697,7 +3701,31 @@ class Tx_Seminars_Tests_Unit_Service_RegistrationManagerTest extends Tx_Phpunit_
         $attachment = $attachments[0];
         $content = $attachment->getBody();
         $formattedDate = strftime('%Y%m%dT%H%M%S', $this->seminar->getBeginDateAsTimestamp());
-        self::assertContains('DTSTART:' . $formattedDate, $content);
+        self::assertContains('DTSTART;TZID=/' . $timeZone . ':' . $formattedDate, $content);
+    }
+
+    /**
+     * @test
+     */
+    public function notifyAttendeeFoEventWithoutTimeZoneHasAttachmentWithEventStartDateWithTimeZoneDefaultTimeZone()
+    {
+        $timeZone = 'Europe/Berlin';
+        $this->fixture->setConfigurationValue('defaultTimeZone', $timeZone);
+
+        $this->fixture->setConfigurationValue('sendConfirmation', true);
+        $pi1 = new Tx_Seminars_FrontEnd_DefaultController();
+        $pi1->init();
+
+        $registration = $this->createRegistration();
+        $this->fixture->notifyAttendee($registration, $pi1);
+
+        $attachments = $this->filterEmailAttachmentsByTitle($this->mailer->getFirstSentEmail(), 'text/calendar');
+        self::assertNotEmpty($attachments);
+        /** @var \Swift_Mime_Attachment $attachment */
+        $attachment = $attachments[0];
+        $content = $attachment->getBody();
+        $formattedDate = strftime('%Y%m%dT%H%M%S', $this->seminar->getBeginDateAsTimestamp());
+        self::assertContains('DTSTART;TZID=/' . $timeZone . ':' . $formattedDate, $content);
     }
 
     /**
@@ -3729,8 +3757,12 @@ class Tx_Seminars_Tests_Unit_Service_RegistrationManagerTest extends Tx_Phpunit_
     /**
      * @test
      */
-    public function notifyAttendeeHasCalendarAttachmentWithEventEndDate()
+    public function notifyAttendeeHasCalendarAttachmentWithEventEndDateTimeZoneFromEvent()
     {
+        $timeZone = 'America/Chicago';
+        $this->testingFramework->changeRecord('tx_seminars_seminars', $this->seminarUid, ['time_zone' => $timeZone]);
+        $this->fixture->setConfigurationValue('defaultTimeZone', 'Europe/Berlin');
+
         $this->fixture->setConfigurationValue('sendConfirmation', true);
         $pi1 = new Tx_Seminars_FrontEnd_DefaultController();
         $pi1->init();
@@ -3744,7 +3776,31 @@ class Tx_Seminars_Tests_Unit_Service_RegistrationManagerTest extends Tx_Phpunit_
         $attachment = $attachments[0];
         $content = $attachment->getBody();
         $formattedDate = strftime('%Y%m%dT%H%M%S', $this->seminar->getEndDateAsTimestampEvenIfOpenEnded());
-        self::assertContains('DTEND:' . $formattedDate, $content);
+        self::assertContains('DTEND;TZID=/' . $timeZone . ':' . $formattedDate, $content);
+    }
+
+    /**
+     * @test
+     */
+    public function notifyAttendeeForEventWithoutTimeZoneHasCalendarAttachmentWithEndDateDefaultTimeZone()
+    {
+        $timeZone = 'Europe/Berlin';
+        $this->fixture->setConfigurationValue('defaultTimeZone', $timeZone);
+
+        $this->fixture->setConfigurationValue('sendConfirmation', true);
+        $pi1 = new Tx_Seminars_FrontEnd_DefaultController();
+        $pi1->init();
+
+        $registration = $this->createRegistration();
+        $this->fixture->notifyAttendee($registration, $pi1);
+
+        $attachments = $this->filterEmailAttachmentsByTitle($this->mailer->getFirstSentEmail(), 'text/calendar');
+        self::assertNotEmpty($attachments);
+        /** @var \Swift_Mime_Attachment $attachment */
+        $attachment = $attachments[0];
+        $content = $attachment->getBody();
+        $formattedDate = strftime('%Y%m%dT%H%M%S', $this->seminar->getEndDateAsTimestampEvenIfOpenEnded());
+        self::assertContains('DTEND;TZID=/' . $timeZone . ':' . $formattedDate, $content);
     }
 
     /**

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -242,6 +242,7 @@ CREATE TABLE tx_seminars_seminars (
     credit_points int(11) unsigned DEFAULT '0' NOT NULL,
     begin_date int(11) unsigned DEFAULT '0' NOT NULL,
     end_date int(11) unsigned DEFAULT '0' NOT NULL,
+    time_zone tinytext,
     timeslots text,
     begin_date_registration int(11) unsigned DEFAULT '0' NOT NULL,
     deadline_registration int(11) unsigned DEFAULT '0' NOT NULL,


### PR DESCRIPTION
Without the time zone information, the dates in the iCal files will be off
by the offset to UTC.

Fixes #32