### PR TITLE
[BUGFIX] Make the tests independent of oelib dev fixture class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Drop the incorrect TYPO3 Core license headers (#41)
 
 ### Fixed
+- Make the tests independent of oelib dev fixture class (#50)
 - Use real GIF files in the unit tests (#49)
 - Get the CSV export tests to run on CLI (#48)
 - Get the BE module tests to run on CLI (#47)

--- a/Tests/Unit/ConfigCheckTest.php
+++ b/Tests/Unit/ConfigCheckTest.php
@@ -1,33 +1,36 @@
 <?php
+namespace OliverKlee\Seminars\Tests\Unit;
+
+use OliverKlee\Seminars\Tests\Unit\Fixtures\DummyObjectToCheck;
 
 /**
  * Test case.
  *
  * @author Niels Pardon <mail@niels-pardon.de>
  */
-class Tx_Seminars_Tests_Unit_ConfigCheckTest extends Tx_Phpunit_TestCase
+class ConfigCheckTest extends \Tx_Phpunit_TestCase
 {
     /**
-     * @var Tx_Seminars_ConfigCheck
+     * @var \Tx_Seminars_ConfigCheck
      */
-    private $fixture;
+    private $subject;
 
     /**
-     * @var Tx_Oelib_Tests_Unit_Fixtures_DummyObjectToCheck
+     * @var DummyObjectToCheck
      */
     private $objectToCheck = null;
 
     protected function setUp()
     {
-        Tx_Oelib_ConfigurationProxy::getInstance('seminars')->setAsBoolean('enableConfigCheck', true);
+        \Tx_Oelib_ConfigurationProxy::getInstance('seminars')->setAsBoolean('enableConfigCheck', true);
 
-        $this->objectToCheck = new Tx_Oelib_Tests_Unit_Fixtures_DummyObjectToCheck([]);
-        $this->fixture = new Tx_Seminars_ConfigCheck($this->objectToCheck);
+        $this->objectToCheck = new DummyObjectToCheck([]);
+        $this->subject = new \Tx_Seminars_ConfigCheck($this->objectToCheck);
     }
 
-    //////////////////////////////////////
-    // Tests concerning checkCurrency().
-    //////////////////////////////////////
+    /*
+     * Tests concerning checkCurrency
+     */
 
     /**
      * @test
@@ -35,12 +38,12 @@ class Tx_Seminars_Tests_Unit_ConfigCheckTest extends Tx_Phpunit_TestCase
     public function checkCurrencyWithEmptyStringResultsInConfigCheckMessage()
     {
         $this->objectToCheck->setConfigurationValue('currency', '');
-        $this->fixture->checkCurrency();
+
+        $this->subject->checkCurrency();
 
         self::assertContains(
-            'The specified currency setting is either empty or not a valid ' .
-                'ISO 4217 alpha 3 code.',
-            $this->fixture->getRawMessage()
+            'The specified currency setting is either empty or not a valid ISO 4217 alpha 3 code.',
+            $this->subject->getRawMessage()
         );
     }
 
@@ -50,12 +53,12 @@ class Tx_Seminars_Tests_Unit_ConfigCheckTest extends Tx_Phpunit_TestCase
     public function checkCurrencyWithInvalidIsoAlpha3CodeResultsInConfigCheckMessage()
     {
         $this->objectToCheck->setConfigurationValue('currency', 'XYZ');
-        $this->fixture->checkCurrency();
+
+        $this->subject->checkCurrency();
 
         self::assertContains(
-            'The specified currency setting is either empty or not a valid ' .
-                'ISO 4217 alpha 3 code.',
-            $this->fixture->getRawMessage()
+            'The specified currency setting is either empty or not a valid ISO 4217 alpha 3 code.',
+            $this->subject->getRawMessage()
         );
     }
 
@@ -65,10 +68,9 @@ class Tx_Seminars_Tests_Unit_ConfigCheckTest extends Tx_Phpunit_TestCase
     public function checkCurrencyWithValidIsoAlpha3CodeResultsInEmptyConfigCheckMessage()
     {
         $this->objectToCheck->setConfigurationValue('currency', 'EUR');
-        $this->fixture->checkCurrency();
 
-        self::assertTrue(
-            $this->fixture->getRawMessage() == ''
-        );
+        $this->subject->checkCurrency();
+
+        self::assertSame('', $this->subject->getRawMessage());
     }
 }

--- a/Tests/Unit/Fixtures/DummyObjectToCheck.php
+++ b/Tests/Unit/Fixtures/DummyObjectToCheck.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace OliverKlee\Seminars\Tests\Unit\Fixtures;
+
+/**
+ * This a class to test the configuration check class.
+ *
+ * @author Oliver Klee <typo3-coding@oliverklee.de>
+ */
+final class DummyObjectToCheck extends \Tx_Oelib_TemplateHelper implements \Tx_Oelib_Interface_ConfigurationCheckable
+{
+    /**
+     * @param array $configuration
+     */
+    public function __construct(array $configuration)
+    {
+        $this->init($configuration);
+    }
+
+    /**
+     * Returns the prefix for the configuration to check, e.g. "plugin.tx_seminars_pi1.".
+     *
+     * @return string the namespace prefix, will end with a dot
+     */
+    public function getTypoScriptNamespace()
+    {
+        return 'plugin.tx_seminars_test.';
+    }
+}


### PR DESCRIPTION
This fixes the tests in Composer mode.