### PR TITLE
[TASK] Skip the tests for the old BE module in TYPO3 >= 8.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Add support for PHP 7.1 and 7.2 (#70)
 
 ### Changed
+- Skip the tests for the old BE module in TYPO3 >= 8.7 (#75)
 - Also allow oelib 3.x (#72)
 - Update to PHPUnit 5.3 (#66)
 

--- a/Tests/Unit/BackEnd/AbstractEventMailFormTest.php
+++ b/Tests/Unit/BackEnd/AbstractEventMailFormTest.php
@@ -3,6 +3,7 @@
 use OliverKlee\Seminars\Tests\Unit\Support\Traits\BackEndTestsTrait;
 use TYPO3\CMS\Backend\Utility\BackendUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Core\Utility\VersionNumberUtility;
 
 /**
  * Test case.
@@ -59,6 +60,10 @@ class Tx_Seminars_Tests_Unit_BackEnd_AbstractEventMailFormTest extends Tx_Phpuni
         $this->mailer = $mailerFactory->getMailer();
 
         $this->testingFramework = new Tx_Oelib_TestingFramework('tx_seminars');
+
+        if (VersionNumberUtility::convertVersionNumberToInteger(TYPO3_version) >= 8000000) {
+            self::markTestSkipped('This test is for the old BE module only.');
+        }
 
         $this->dummySysFolderUid = $this->testingFramework->createSystemFolder();
         Tx_Oelib_PageFinder::getInstance()->setPageUid($this->dummySysFolderUid);

--- a/Tests/Unit/BackEnd/CancelEventMailFormTest.php
+++ b/Tests/Unit/BackEnd/CancelEventMailFormTest.php
@@ -2,6 +2,7 @@
 
 use OliverKlee\Seminars\Tests\Unit\Support\Traits\BackEndTestsTrait;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Core\Utility\VersionNumberUtility;
 
 /**
  * Test case.
@@ -60,6 +61,10 @@ class Tx_Seminars_Tests_Unit_BackEnd_CancelEventMailFormTest extends Tx_Phpunit_
 
         $this->testingFramework = new Tx_Oelib_TestingFramework('tx_seminars');
         Tx_Oelib_MapperRegistry::getInstance()->activateTestingMode($this->testingFramework);
+
+        if (VersionNumberUtility::convertVersionNumberToInteger(TYPO3_version) >= 8000000) {
+            self::markTestSkipped('This test is for the old BE module only.');
+        }
 
         $this->dummySysFolderUid = $this->testingFramework->createSystemFolder();
         Tx_Oelib_PageFinder::getInstance()->setPageUid($this->dummySysFolderUid);

--- a/Tests/Unit/BackEnd/ConfirmEventMailFormTest.php
+++ b/Tests/Unit/BackEnd/ConfirmEventMailFormTest.php
@@ -2,6 +2,7 @@
 
 use OliverKlee\Seminars\Tests\Unit\Support\Traits\BackEndTestsTrait;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Core\Utility\VersionNumberUtility;
 
 /**
  * Test case.
@@ -59,6 +60,10 @@ class Tx_Seminars_Tests_Unit_BackEnd_ConfirmEventMailFormTest extends Tx_Phpunit
 
         $this->testingFramework = new Tx_Oelib_TestingFramework('tx_seminars');
         Tx_Oelib_MapperRegistry::getInstance()->activateTestingMode($this->testingFramework);
+
+        if (VersionNumberUtility::convertVersionNumberToInteger(TYPO3_version) >= 8000000) {
+            self::markTestSkipped('This test is for the old BE module only.');
+        }
 
         $this->dummySysFolderUid = $this->testingFramework->createSystemFolder();
         Tx_Oelib_PageFinder::getInstance()->setPageUid($this->dummySysFolderUid);

--- a/Tests/Unit/BackEnd/EventsListTest.php
+++ b/Tests/Unit/BackEnd/EventsListTest.php
@@ -2,6 +2,7 @@
 
 use OliverKlee\Seminars\Tests\Unit\Support\Traits\BackEndTestsTrait;
 use TYPO3\CMS\Backend\Template\DocumentTemplate;
+use TYPO3\CMS\Core\Utility\VersionNumberUtility;
 
 /**
  * Test case.
@@ -38,6 +39,10 @@ class Tx_Seminars_Tests_Unit_BackEnd_EventsListTest extends Tx_Phpunit_TestCase
         $this->unifyTestingEnvironment();
 
         $this->testingFramework = new Tx_Oelib_TestingFramework('tx_seminars');
+
+        if (VersionNumberUtility::convertVersionNumberToInteger(TYPO3_version) >= 8000000) {
+            self::markTestSkipped('This test is for the old BE module only.');
+        }
 
         $this->dummySysFolderPid = $this->testingFramework->createSystemFolder();
 

--- a/Tests/Unit/BackEnd/GeneralEventMailFormTest.php
+++ b/Tests/Unit/BackEnd/GeneralEventMailFormTest.php
@@ -2,6 +2,7 @@
 
 use OliverKlee\Seminars\Tests\Unit\Support\Traits\BackEndTestsTrait;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Core\Utility\VersionNumberUtility;
 
 /**
  * Test case.
@@ -58,6 +59,10 @@ class Tx_Seminars_Tests_Unit_BackEnd_GeneralEventMailFormTest extends Tx_Phpunit
         $this->mailer = $mailerFactory->getMailer();
 
         $this->testingFramework = new Tx_Oelib_TestingFramework('tx_seminars');
+
+        if (VersionNumberUtility::convertVersionNumberToInteger(TYPO3_version) >= 8000000) {
+            self::markTestSkipped('This test is for the old BE module only.');
+        }
 
         $this->dummySysFolderUid = $this->testingFramework->createSystemFolder();
         Tx_Oelib_PageFinder::getInstance()->setPageUid($this->dummySysFolderUid);

--- a/Tests/Unit/BackEnd/ModuleTest.php
+++ b/Tests/Unit/BackEnd/ModuleTest.php
@@ -1,5 +1,7 @@
 <?php
 
+use TYPO3\CMS\Core\Utility\VersionNumberUtility;
+
 /**
  * Test case.
  *
@@ -14,6 +16,10 @@ class Tx_Seminars_Tests_Unit_BackEnd_ModuleTest extends Tx_Phpunit_TestCase
 
     protected function setUp()
     {
+        if (VersionNumberUtility::convertVersionNumberToInteger(TYPO3_version) >= 8000000) {
+            self::markTestSkipped('This test is for the old BE module only.');
+        }
+
         \Tx_Oelib_ConfigurationProxy::getInstance('seminars')->setAsBoolean('enableConfigCheck', false);
 
         $this->fixture = new Tx_Seminars_BackEnd_Module();

--- a/Tests/Unit/BackEnd/OrganizersListTest.php
+++ b/Tests/Unit/BackEnd/OrganizersListTest.php
@@ -2,6 +2,7 @@
 
 use OliverKlee\Seminars\Tests\Unit\Support\Traits\BackEndTestsTrait;
 use TYPO3\CMS\Backend\Template\DocumentTemplate;
+use TYPO3\CMS\Core\Utility\VersionNumberUtility;
 
 /**
  * Test case.
@@ -36,6 +37,10 @@ class Tx_Seminars_Tests_Unit_BackEnd_OrganizersListTest extends Tx_Phpunit_TestC
         $this->unifyTestingEnvironment();
 
         $this->testingFramework = new Tx_Oelib_TestingFramework('tx_seminars');
+
+        if (VersionNumberUtility::convertVersionNumberToInteger(TYPO3_version) >= 8000000) {
+            self::markTestSkipped('This test is for the old BE module only.');
+        }
 
         $this->dummySysFolderPid = $this->testingFramework->createSystemFolder();
 

--- a/Tests/Unit/BackEnd/RegistrationsListTest.php
+++ b/Tests/Unit/BackEnd/RegistrationsListTest.php
@@ -2,6 +2,7 @@
 
 use OliverKlee\Seminars\Tests\Unit\Support\Traits\BackEndTestsTrait;
 use TYPO3\CMS\Backend\Template\DocumentTemplate;
+use TYPO3\CMS\Core\Utility\VersionNumberUtility;
 
 /**
  * Test case.
@@ -36,6 +37,10 @@ class Tx_Seminars_Tests_Unit_BackEnd_RegistrationsListTest extends Tx_Phpunit_Te
         $this->unifyTestingEnvironment();
 
         $this->testingFramework = new Tx_Oelib_TestingFramework('tx_seminars');
+
+        if (VersionNumberUtility::convertVersionNumberToInteger(TYPO3_version) >= 8000000) {
+            self::markTestSkipped('This test is for the old BE module only.');
+        }
 
         $this->backEndModule = new Tx_Seminars_BackEnd_Module();
         $this->backEndModule->id = $this->dummySysFolderPid;

--- a/Tests/Unit/BackEnd/SpeakersListTest.php
+++ b/Tests/Unit/BackEnd/SpeakersListTest.php
@@ -2,6 +2,7 @@
 
 use OliverKlee\Seminars\Tests\Unit\Support\Traits\BackEndTestsTrait;
 use TYPO3\CMS\Backend\Template\DocumentTemplate;
+use TYPO3\CMS\Core\Utility\VersionNumberUtility;
 
 /**
  * Test case.
@@ -36,6 +37,10 @@ class Tx_Seminars_Tests_Unit_BackEnd_SpeakersListTest extends Tx_Phpunit_TestCas
         $this->unifyTestingEnvironment();
 
         $this->testingFramework = new Tx_Oelib_TestingFramework('tx_seminars');
+
+        if (VersionNumberUtility::convertVersionNumberToInteger(TYPO3_version) >= 8000000) {
+            self::markTestSkipped('This test is for the old BE module only.');
+        }
 
         $this->dummySysFolderPid = $this->testingFramework->createSystemFolder();
 


### PR DESCRIPTION
The tests will be reactivated with the new BE module.