### PR TITLE
[BUGFIX] Add property allowed in TCA

### DIFF
--- a/Configuration/TCA/tx_seminars_seminars.php
+++ b/Configuration/TCA/tx_seminars_seminars.php
@@ -129,6 +129,7 @@ $tca = [
                 'type' => \OliverKlee\Seminars\BackEnd\TceForms::getSelectType(),
                 'renderType' => 'selectMultipleSideBySide',
                 'internal_type' => 'db',
+                'allowed' => 'tx_seminars_seminars',
                 'foreign_table' => 'tx_seminars_seminars',
                 'foreign_table_where' => 'AND tx_seminars_seminars.uid <> ###THIS_UID### AND object_type = 1 ORDER BY title',
                 'size' => 10,


### PR DESCRIPTION
Add property "allowed" to TCA configuration of
"dependencies" as getSelectType can also return "group"
where "allowed" is a must have property since
TYPO3 8.7