### PR TITLE
[BUGFIX] Update the composer package name of static-info-tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Remove the print functionality from the BE module (#119)
 
 ### Fixed
+- Update the composer package name of static-info-tables (#149)
 - Fix crash in the CSV download (#140, #141)
 - Make event.timeslots an integer DB field (#138)
 - Update the documentation of the hooks (#134)

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "php": "^5.6.0 || ~7.0.0 || ~7.1.0 || ~7.2.0",
         "typo3/cms-core": "^7.6.23 || ^8.7.9",
         "typo3/cms-frontend": "^7.6.23 || ^8.7.9",
-        "sjbr/static-info-tables": "^6.4.0",
+        "typo3-ter/static-info-tables": "^6.4.0",
         "oliverklee/oelib": "^2.0.0 || ^3.0.0",
         "dmk/mkforms": "^3.0.14"
     },


### PR DESCRIPTION
The old package sjbr/static-info-tables has been abandoned.
typo3-ter/static-info-tables should be used instead.