### PR TITLE
[FEATURE] Add new registrationEmailHook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,21 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ## x.y.z
 
 ### Added
+- New hook interface and RegistrationEmailHookInterface (#150)
+- New hook to post process attendee email in registration manager (#150)
+- New hook to post process attendee email text in registration manager (#150)
+- New hook to post process organizer email in registration manager (#150)
+- New hook to post process additional email in registration manager (#150)
 - Automatic prices for subsequent registrations (#144)
 - Calculate collisions using the time slots (#139)
 
 ### Changed
 
 ### Deprecated
+- XClass hook Tx_Seminars_Service_RegistrationManager::modifyNotificationEmail has been replaced by RegistrationEmailHookInterface::postProcessOrganizerEmail (#150)
+- Hook Tx_Seminars_Interface_Hook_Registration::modifyOrganizerNotificationEmail has been replaced by RegistrationEmailHookInterface::postProcessOrganizerEmail (#150)
+- Hook Tx_Seminars_Interface_Hook_Registration::modifyAttendeeEmailText has been replaced by RegistrationEmailHookInterface::postProcessAttendeeEmailText (#150)
+- Hook modifyThankYouEmail has been replaced by RegistrationEmailHookInterface::postProcessAttendeeEmail (#150)
 
 ### Removed
 - Remove the "use page browser" switch in the EM (#135, #126)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Calculate collisions using the time slots (#139)
 
 ### Changed
-- Add mail object to hook modifyOrganizerNotificationEmail (#150)
+- Add mail object to hook modifyOrganizerNotificationEmail (#149)
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Calculate collisions using the time slots (#139)
 
 ### Changed
-- Add mail object to hook modifyOrganizerNotificationEmail (#149)
+- Add mail object to hook modifyOrganizerNotificationEmail (#150)
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Calculate collisions using the time slots (#139)
 
 ### Changed
+- Add mail object to hook modifyOrganizerNotificationEmail (#149)
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,6 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Calculate collisions using the time slots (#139)
 
 ### Changed
-- Add mail object to hook modifyOrganizerNotificationEmail (#149)
 
 ### Deprecated
 

--- a/Classes/Hooks/RegistrationEmailHookInterface.php
+++ b/Classes/Hooks/RegistrationEmailHookInterface.php
@@ -1,0 +1,51 @@
+<?php
+namespace OliverKlee\Seminars\Hooks;
+
+/*
+ * This file is part of the seminars project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+/**
+ * Interface RegistrationEmailHookInterface
+ */
+interface RegistrationEmailHookInterface
+{
+    /**
+     * @param \Tx_Oelib_Mail $mail
+     * @param \Tx_Seminars_Model_Registration $registration
+     *
+     * @return void
+     */
+    public function postProcessAttendeeEmail(\Tx_Oelib_Mail $mail, \Tx_Seminars_Model_Registration $registration);
+
+    /**
+     * @param \Tx_Oelib_Mail $mail
+     * @param \Tx_Seminars_OldModel_Registration $registration
+     *
+     * @return void
+     */
+    public function postProcessOrganizerEmail(\Tx_Oelib_Mail $mail, \Tx_Seminars_OldModel_Registration $registration);
+
+    /**
+     * @param \Tx_Oelib_Mail $mail
+     * @param \Tx_Seminars_OldModel_Registration $registration
+     * @param string $emailReason see Tx_Seminars_Service_RegistrationManager::getReasonForNotification()
+     *                            for information about possible values
+     *
+     * @return void
+     */
+    public function postProcessAdditionalEmail(
+        \Tx_Oelib_Mail $mail,
+        \Tx_Seminars_OldModel_Registration $registration,
+        $emailReason = ''
+    );
+}

--- a/Classes/Hooks/RegistrationEmailHookInterface.php
+++ b/Classes/Hooks/RegistrationEmailHookInterface.php
@@ -15,7 +15,9 @@ namespace OliverKlee\Seminars\Hooks;
  */
 
 /**
- * Interface RegistrationEmailHookInterface
+ * Hook interface to customize emails after they has been processed.
+ *
+ * @author Pascal Rinker <projects@jweiland.net>
  */
 interface RegistrationEmailHookInterface
 {
@@ -26,6 +28,14 @@ interface RegistrationEmailHookInterface
      * @return void
      */
     public function postProcessAttendeeEmail(\Tx_Oelib_Mail $mail, \Tx_Seminars_Model_Registration $registration);
+
+    /**
+     * @param \Tx_Seminars_OldModel_Registration $registration
+     * @param \Tx_Oelib_Template $emailTemplate
+     *
+     * @return void
+     */
+    public function postProcessAttendeeEmailText(\Tx_Seminars_OldModel_Registration $registration, \Tx_Oelib_Template $emailTemplate);
 
     /**
      * @param \Tx_Oelib_Mail $mail

--- a/Classes/Interface/Hook/Registration.php
+++ b/Classes/Interface/Hook/Registration.php
@@ -12,10 +12,15 @@ interface Tx_Seminars_Interface_Hook_Registration
      *
      * @param \Tx_Seminars_OldModel_Registration $registration
      * @param \Tx_Oelib_Template $emailTemplate
+     * @param \Tx_Oelib_Mail $eMailNotification
      *
      * @return void
      */
-    public function modifyOrganizerNotificationEmail(\Tx_Seminars_OldModel_Registration $registration, \Tx_Oelib_Template $emailTemplate);
+    public function modifyOrganizerNotificationEmail(
+        \Tx_Seminars_OldModel_Registration $registration,
+        \Tx_Oelib_Template $emailTemplate,
+        \Tx_Oelib_Mail $eMailNotification
+    );
 
     /**
      * Modifies the registration or unregistration e-mail to an attendee.
@@ -25,5 +30,8 @@ interface Tx_Seminars_Interface_Hook_Registration
      *
      * @return void
      */
-    public function modifyAttendeeEmailText(\Tx_Seminars_OldModel_Registration $registration, \Tx_Oelib_Template $emailTemplate);
+    public function modifyAttendeeEmailText(
+        \Tx_Seminars_OldModel_Registration $registration,
+        \Tx_Oelib_Template $emailTemplate
+    );
 }

--- a/Classes/Interface/Hook/Registration.php
+++ b/Classes/Interface/Hook/Registration.php
@@ -12,15 +12,10 @@ interface Tx_Seminars_Interface_Hook_Registration
      *
      * @param \Tx_Seminars_OldModel_Registration $registration
      * @param \Tx_Oelib_Template $emailTemplate
-     * @param \Tx_Oelib_Mail $eMailNotification
      *
      * @return void
      */
-    public function modifyOrganizerNotificationEmail(
-        \Tx_Seminars_OldModel_Registration $registration,
-        \Tx_Oelib_Template $emailTemplate,
-        \Tx_Oelib_Mail $eMailNotification
-    );
+    public function modifyOrganizerNotificationEmail(\Tx_Seminars_OldModel_Registration $registration, \Tx_Oelib_Template $emailTemplate);
 
     /**
      * Modifies the registration or unregistration e-mail to an attendee.
@@ -30,8 +25,5 @@ interface Tx_Seminars_Interface_Hook_Registration
      *
      * @return void
      */
-    public function modifyAttendeeEmailText(
-        \Tx_Seminars_OldModel_Registration $registration,
-        \Tx_Oelib_Template $emailTemplate
-    );
+    public function modifyAttendeeEmailText(\Tx_Seminars_OldModel_Registration $registration, \Tx_Oelib_Template $emailTemplate);
 }

--- a/Classes/Interface/Hook/Registration.php
+++ b/Classes/Interface/Hook/Registration.php
@@ -4,6 +4,7 @@
  * This interface needs to be used for hooks concerning the registration process.
  *
  * @author Oliver Klee <typo3-coding@oliverklee.de>
+ * @deprecated use hooks from RegistrationEmailHookInterface instead
  */
 interface Tx_Seminars_Interface_Hook_Registration
 {
@@ -14,6 +15,7 @@ interface Tx_Seminars_Interface_Hook_Registration
      * @param \Tx_Oelib_Template $emailTemplate
      *
      * @return void
+     * @deprecated use RegistrationEmailHookInterface::postProcessOrganizerEmail instead
      */
     public function modifyOrganizerNotificationEmail(\Tx_Seminars_OldModel_Registration $registration, \Tx_Oelib_Template $emailTemplate);
 
@@ -24,6 +26,7 @@ interface Tx_Seminars_Interface_Hook_Registration
      * @param \Tx_Oelib_Template $emailTemplate
      *
      * @return void
+     * @deprecated use RegistrationEmailHookInterface::postProcessAttendeeEmail instead
      */
     public function modifyAttendeeEmailText(\Tx_Seminars_OldModel_Registration $registration, \Tx_Oelib_Template $emailTemplate);
 }

--- a/Classes/Service/RegistrationManager.php
+++ b/Classes/Service/RegistrationManager.php
@@ -1018,7 +1018,7 @@ class Tx_Seminars_Service_RegistrationManager extends \Tx_Oelib_TemplateHelper
             $this->hideSubparts('attendancedata', 'field_wrapper');
         }
 
-        $this->callModifyOrganizerNotificationEmailHooks($registration, $this->getTemplate());
+        $this->callModifyOrganizerNotificationEmailHooks($registration, $this->getTemplate(), $eMailNotification);
 
         $eMailNotification->setMessage($this->getSubpart('MAIL_NOTIFICATION'));
         $this->modifyNotificationEmail($eMailNotification, $registration);
@@ -1033,17 +1033,19 @@ class Tx_Seminars_Service_RegistrationManager extends \Tx_Oelib_TemplateHelper
      *
      * @param \Tx_Seminars_OldModel_Registration $registration
      * @param \Tx_Oelib_Template $emailTemplate
+     * @param \Tx_Oelib_Mail $eMailNotification
      *
      * @return void
      */
     protected function callModifyOrganizerNotificationEmailHooks(
         \Tx_Seminars_OldModel_Registration $registration,
-        \Tx_Oelib_Template $emailTemplate
+        \Tx_Oelib_Template $emailTemplate,
+        \Tx_Oelib_Mail $eMailNotification
     ) {
         foreach ($this->getHooks() as $hook) {
             if ($hook instanceof \Tx_Seminars_Interface_Hook_Registration) {
                 /** @var \Tx_Seminars_Interface_Hook_Registration $hook */
-                $hook->modifyOrganizerNotificationEmail($registration, $emailTemplate);
+                $hook->modifyOrganizerNotificationEmail($registration, $emailTemplate, $eMailNotification);
             }
         }
     }

--- a/Classes/Service/RegistrationManager.php
+++ b/Classes/Service/RegistrationManager.php
@@ -1018,7 +1018,7 @@ class Tx_Seminars_Service_RegistrationManager extends \Tx_Oelib_TemplateHelper
             $this->hideSubparts('attendancedata', 'field_wrapper');
         }
 
-        $this->callModifyOrganizerNotificationEmailHooks($registration, $this->getTemplate(), $eMailNotification);
+        $this->callModifyOrganizerNotificationEmailHooks($registration, $this->getTemplate());
 
         $eMailNotification->setMessage($this->getSubpart('MAIL_NOTIFICATION'));
         $this->modifyNotificationEmail($eMailNotification, $registration);
@@ -1033,19 +1033,17 @@ class Tx_Seminars_Service_RegistrationManager extends \Tx_Oelib_TemplateHelper
      *
      * @param \Tx_Seminars_OldModel_Registration $registration
      * @param \Tx_Oelib_Template $emailTemplate
-     * @param \Tx_Oelib_Mail $eMailNotification
      *
      * @return void
      */
     protected function callModifyOrganizerNotificationEmailHooks(
         \Tx_Seminars_OldModel_Registration $registration,
-        \Tx_Oelib_Template $emailTemplate,
-        \Tx_Oelib_Mail $eMailNotification
+        \Tx_Oelib_Template $emailTemplate
     ) {
         foreach ($this->getHooks() as $hook) {
             if ($hook instanceof \Tx_Seminars_Interface_Hook_Registration) {
                 /** @var \Tx_Seminars_Interface_Hook_Registration $hook */
-                $hook->modifyOrganizerNotificationEmail($registration, $emailTemplate, $eMailNotification);
+                $hook->modifyOrganizerNotificationEmail($registration, $emailTemplate);
             }
         }
     }

--- a/Classes/Service/RegistrationManager.php
+++ b/Classes/Service/RegistrationManager.php
@@ -1,8 +1,8 @@
 <?php
 
+use OliverKlee\Seminars\Hooks\RegistrationEmailHookInterface;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Frontend\Plugin\AbstractPlugin;
-use OliverKlee\Seminars\Hooks\RegistrationEmailHookInterface;
 
 /**
  * This utility class checks and creates registrations for seminars.
@@ -889,7 +889,7 @@ class Tx_Seminars_Service_RegistrationManager extends \Tx_Oelib_TemplateHelper
             if ($hook instanceof RegistrationEmailHookInterface) {
                 $hook->postProcessAttendeeEmail($mail, $registration);
             } elseif (method_exists($hook, 'modifyThankYouEmail')) {
-                // todo: Maybe declare this hook as deprecated
+                // @todo deprecated - use hook above instead
                 $hook->modifyThankYouEmail($mail, $registration);
             }
         }
@@ -1053,6 +1053,7 @@ class Tx_Seminars_Service_RegistrationManager extends \Tx_Oelib_TemplateHelper
      * @param \Tx_Oelib_Template $emailTemplate
      *
      * @return void
+     * @deprecated hook has been replaced by RegistrationEmailHookInterface::postProcessOrganizerEmail
      */
     protected function callModifyOrganizerNotificationEmailHooks(
         \Tx_Seminars_OldModel_Registration $registration,
@@ -1093,7 +1094,7 @@ class Tx_Seminars_Service_RegistrationManager extends \Tx_Oelib_TemplateHelper
      * @param \Tx_Seminars_OldModel_Registration $registration
      *
      * @return void
-     * @todo Maybe declare this method as deprecated?
+     * @deprecated use RegistrationEmailHookInterface::postProcessOrganizerEmail instead
      */
     protected function modifyNotificationEmail(
         \Tx_Oelib_Mail $emailNotification,
@@ -1102,19 +1103,19 @@ class Tx_Seminars_Service_RegistrationManager extends \Tx_Oelib_TemplateHelper
     }
 
     /**
-     * Calls the modifyAttendeeEmailText hooks.
-     *
      * @param \Tx_Seminars_OldModel_Registration $registration
      * @param \Tx_Oelib_Template $emailTemplate
      *
      * @return void
      */
-    protected function callModifyAttendeeEmailTextHooks(
+    protected function callPostProcessAttendeeEmailTextHooks(
         \Tx_Seminars_OldModel_Registration $registration,
         \Tx_Oelib_Template $emailTemplate
     ) {
         foreach ($this->getHooks() as $hook) {
-            if ($hook instanceof \Tx_Seminars_Interface_Hook_Registration) {
+            if ($hook instanceof RegistrationEmailHookInterface) {
+                $hook->postProcessAttendeeEmailText($registration, $emailTemplate);
+            } elseif ($hook instanceof \Tx_Seminars_Interface_Hook_Registration) {
                 /** @var \Tx_Seminars_Interface_Hook_Registration $hook */
                 $hook->modifyAttendeeEmailText($registration, $emailTemplate);
             }
@@ -1428,7 +1429,7 @@ class Tx_Seminars_Service_RegistrationManager extends \Tx_Oelib_TemplateHelper
         $footers = $event->getOrganizersFooter();
         $this->setMarker('footer', !empty($footers) ? LF . '-- ' . LF . $footers[0] : '');
 
-        $this->callModifyAttendeeEmailTextHooks($registration, $this->getTemplate());
+        $this->callPostProcessAttendeeEmailTextHooks($registration, $this->getTemplate());
 
         return $this->getSubpart($useHtml ? 'MAIL_THANKYOU_HTML' : 'MAIL_THANKYOU');
     }

--- a/Classes/Service/RegistrationManager.php
+++ b/Classes/Service/RegistrationManager.php
@@ -889,7 +889,7 @@ class Tx_Seminars_Service_RegistrationManager extends \Tx_Oelib_TemplateHelper
             if ($hook instanceof RegistrationEmailHookInterface) {
                 $hook->postProcessAttendeeEmail($mail, $registration);
             } elseif (method_exists($hook, 'modifyThankYouEmail')) {
-                // @todo deprecated - use hook above instead
+                GeneralUtility::logDeprecatedFunction();
                 $hook->modifyThankYouEmail($mail, $registration);
             }
         }
@@ -1061,6 +1061,7 @@ class Tx_Seminars_Service_RegistrationManager extends \Tx_Oelib_TemplateHelper
     ) {
         foreach ($this->getHooks() as $hook) {
             if ($hook instanceof \Tx_Seminars_Interface_Hook_Registration) {
+                GeneralUtility::logDeprecatedFunction();
                 /** @var \Tx_Seminars_Interface_Hook_Registration $hook */
                 $hook->modifyOrganizerNotificationEmail($registration, $emailTemplate);
             }
@@ -1116,6 +1117,7 @@ class Tx_Seminars_Service_RegistrationManager extends \Tx_Oelib_TemplateHelper
             if ($hook instanceof RegistrationEmailHookInterface) {
                 $hook->postProcessAttendeeEmailText($registration, $emailTemplate);
             } elseif ($hook instanceof \Tx_Seminars_Interface_Hook_Registration) {
+                GeneralUtility::logDeprecatedFunction();
                 /** @var \Tx_Seminars_Interface_Hook_Registration $hook */
                 $hook->modifyAttendeeEmailText($registration, $emailTemplate);
             }

--- a/Documentation/DE/Referenz/Hooks/Index.rst
+++ b/Documentation/DE/Referenz/Hooks/Index.rst
@@ -126,18 +126,74 @@ It's used like this:
        ) {…}
 
 
-Hooks for the organizer notification e-mails
-""""""""""""""""""""""""""""""""""""""""""""
+Hooks to post process notification emails
+""""""""""""""""""""""""""""""""""""""""""
 
 To use this hook, please create a class that implements the interface
-tx\_seminars\_Interface\_Hook\_Registration. The method in your class
-then should expect two parameters:
+\\OliverKlee\\Seminars\\Hooks\\RegistrationEmailHookInterface. Then you need to add the following methods:
+
+**Hook to post process the attendee email**
 
 ::
 
-   public function modifyOrganizerNotificationEmail(
-         Tx_Seminars_OldModel_Registration $registration, Tx_Oelib_Template $emailTemplate
-   ) {
+    /**
+     * @param \Tx_Oelib_Mail $mail
+     * @param \Tx_Seminars_Model_Registration $registration
+     *
+     * @return void
+     */
+    public function postProcessAttendeeEmail(\Tx_Oelib_Mail $mail, \Tx_Seminars_Model_Registration $registration)
+    {
+    }
+
+**Hook to post process the attendee email text**
+
+::
+
+    /**
+     * @param \Tx_Seminars_OldModel_Registration $registration
+     * @param \Tx_Oelib_Template $emailTemplate
+     *
+     * @return void
+     */
+    public function postProcessAttendeeEmailText(\Tx_Seminars_OldModel_Registration $registration, \Tx_Oelib_Template $emailTemplate)
+    {
+    }
+
+**Hook to post process the organizer email**
+
+::
+
+    /**
+     * @param \Tx_Oelib_Mail $mail
+     * @param \Tx_Seminars_OldModel_Registration $registration
+     *
+     * @return void
+     */
+    public function postProcessOrganizerEmail(\Tx_Oelib_Mail $mail, \Tx_Seminars_OldModel_Registration $registration)
+    {
+    }
+
+**Hook to post process additional emails**
+
+::
+
+    /**
+     * @param \Tx_Oelib_Mail $mail
+     * @param \Tx_Seminars_OldModel_Registration $registration
+     * @param string $emailReason see Tx_Seminars_Service_RegistrationManager::getReasonForNotification()
+     *                            for information about possible values
+     *
+     * @return void
+     */
+    public function postProcessAdditionalEmail(
+        \Tx_Oelib_Mail $mail,
+        \Tx_Seminars_OldModel_Registration $registration,
+        $emailReason = ''
+    )
+    {
+    }
+
 
 Your class then needs to be included and registered like in this
 example:
@@ -145,55 +201,7 @@ example:
 ::
 
    // register my hook objects
-   $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['seminars']['registration'][] = \tx_invoices_email::class;
-
-
-Hooks for the thank-you e-mails sent after a registration
-"""""""""""""""""""""""""""""""""""""""""""""""""""""""""
-
-There are two hooks: one for modifying the e-mail (e.g., adding
-recipients or attachments), and one for modifying the e-mail texts
-before the corresponding subparts are rendered
-
-**Hook for the e-mail**
-
-To use this hook, you need to create a class with a method named
-modifyThankYouEmail. The method in your class should expect two
-parameters:
-
-::
-
-           public function modifyThankYouEmail(
-                 Tx_Oelib_Mail $email, Tx_Seminars_Model_Registration $registration
-         ) {
-
-Your class then needs to be included and registered like in this
-example:
-
-::
-
-   // register my hook objects
-   $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['seminars']['registration'][] = \tx_invoices_email::class;
-
-**Hook for the e-mail text**
-
-To use this hook, please create a class that implements the interface
-tx\_seminars\_Interface\_Hook\_Registration. The method in your class
-then should expect two parameters:
-
-::
-
-    public function modifyAttendeeEmailText(
-                 Tx_Seminars_OldModel_Registration $registration, Tx_Oelib_Template $emailTemplate
-       ) {
-
-Your class then needs to be included and registered like in this
-example:
-
-::
-
-   // register my hook objects
-   $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['seminars']['registration'][] = \tx_invoices_email::class;
+   $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['seminars']['registration'][] = \\MyVendor\\MyExt\\Hooks\\RegistrationEmailHook::class;
 
 
 Hooks for the e-mails sent from the back-end module

--- a/Documentation/EN/Reference/Hooks/Index.rst
+++ b/Documentation/EN/Reference/Hooks/Index.rst
@@ -127,18 +127,74 @@ It's used like this:
        ) {…}
 
 
-Hooks for the organizer notification e-mails
-""""""""""""""""""""""""""""""""""""""""""""
+Hooks to post process notification emails
+""""""""""""""""""""""""""""""""""""""""""
 
 To use this hook, please create a class that implements the interface
-tx\_seminars\_Interface\_Hook\_Registration. The method in your class
-then should expect two parameters:
+\\OliverKlee\\Seminars\\Hooks\\RegistrationEmailHookInterface. Then you need to add the following methods:
+
+**Hook to post process the attendee email**
 
 ::
 
-   public function modifyOrganizerNotificationEmail(
-         Tx_Seminars_OldModel_Registration $registration, Tx_Oelib_Template $emailTemplate
-   ) {
+    /**
+     * @param \Tx_Oelib_Mail $mail
+     * @param \Tx_Seminars_Model_Registration $registration
+     *
+     * @return void
+     */
+    public function postProcessAttendeeEmail(\Tx_Oelib_Mail $mail, \Tx_Seminars_Model_Registration $registration)
+    {
+    }
+
+**Hook to post process the attendee email text**
+
+::
+
+    /**
+     * @param \Tx_Seminars_OldModel_Registration $registration
+     * @param \Tx_Oelib_Template $emailTemplate
+     *
+     * @return void
+     */
+    public function postProcessAttendeeEmailText(\Tx_Seminars_OldModel_Registration $registration, \Tx_Oelib_Template $emailTemplate)
+    {
+    }
+
+**Hook to post process the organizer email**
+
+::
+
+    /**
+     * @param \Tx_Oelib_Mail $mail
+     * @param \Tx_Seminars_OldModel_Registration $registration
+     *
+     * @return void
+     */
+    public function postProcessOrganizerEmail(\Tx_Oelib_Mail $mail, \Tx_Seminars_OldModel_Registration $registration)
+    {
+    }
+
+**Hook to post process additional emails**
+
+::
+
+    /**
+     * @param \Tx_Oelib_Mail $mail
+     * @param \Tx_Seminars_OldModel_Registration $registration
+     * @param string $emailReason see Tx_Seminars_Service_RegistrationManager::getReasonForNotification()
+     *                            for information about possible values
+     *
+     * @return void
+     */
+    public function postProcessAdditionalEmail(
+        \Tx_Oelib_Mail $mail,
+        \Tx_Seminars_OldModel_Registration $registration,
+        $emailReason = ''
+    )
+    {
+    }
+
 
 Your class then needs to be included and registered like in this
 example:
@@ -146,55 +202,7 @@ example:
 ::
 
    // register my hook objects
-   $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['seminars']['registration'][] = \tx_invoices_email::class;
-
-
-Hooks for the thank-you e-mails sent after a registration
-"""""""""""""""""""""""""""""""""""""""""""""""""""""""""
-
-There are two hooks: one for modifying the e-mail (e.g., adding
-recipients or attachments), and one for modifying the e-mail texts
-before the corresponding subparts are rendered
-
-**Hook for the e-mail**
-
-To use this hook, you need to create a class with a method named
-modifyThankYouEmail. The method in your class should expect two
-parameters:
-
-::
-
-           public function modifyThankYouEmail(
-                 Tx_Oelib_Mail $email, Tx_Seminars_Model_Registration $registration
-         ) {
-
-Your class then needs to be included and registered like in this
-example:
-
-::
-
-   // register my hook objects
-   $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['seminars']['registration'][] = \tx_invoices_email::class;
-
-**Hook for the e-mail text**
-
-To use this hook, please create a class that implements the interface
-tx\_seminars\_Interface\_Hook\_Registration. The method in your class
-then should expect two parameters:
-
-::
-
-    public function modifyAttendeeEmailText(
-                 Tx_Seminars_OldModel_Registration $registration, Tx_Oelib_Template $emailTemplate
-       ) {
-
-Your class then needs to be included and registered like in this
-example:
-
-::
-
-   // register my hook objects
-   $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['seminars']['registration'][] = \tx_invoices_email::class;
+   $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['seminars']['registration'][] = \\MyVendor\\MyExt\\Hooks\\RegistrationEmailHook::class;
 
 
 Hooks for the salutation in all e-mails to the attendees

--- a/Tests/Unit/Service/RegistrationManagerTest.php
+++ b/Tests/Unit/Service/RegistrationManagerTest.php
@@ -5069,7 +5069,11 @@ class Tx_Seminars_Tests_Unit_Service_RegistrationManagerTest extends \Tx_Phpunit
 
         $hook = $this->getMock(\Tx_Seminars_Interface_Hook_Registration::class);
         $hookClassName = get_class($hook);
-        $hook->expects(self::once())->method('modifyOrganizerNotificationEmail')->with($registration, self::anything());
+        $hook->expects(self::once())->method('modifyOrganizerNotificationEmail')->with(
+            $registration,
+            self::anything(),
+            self::anything()
+        );
 
         $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['seminars']['registration'][$hookClassName] = $hookClassName;
         GeneralUtility::addInstance($hookClassName, $hook);

--- a/Tests/Unit/Service/RegistrationManagerTest.php
+++ b/Tests/Unit/Service/RegistrationManagerTest.php
@@ -2345,6 +2345,64 @@ class Tx_Seminars_Tests_Unit_Service_RegistrationManagerTest extends \Tx_Phpunit
     /**
      * @test
      */
+    public function notifyAttendeeForSendConfirmationTrueAndPlainTextEmailCallsPostProcessAttendeeEmailTextHookOnce()
+    {
+        \Tx_Oelib_ConfigurationProxy::getInstance('seminars')
+            ->setAsInteger('eMailFormatForAttendees', \Tx_Seminars_Service_RegistrationManager::SEND_TEXT_MAIL);
+
+        $registration = $this->createRegistration();
+
+        $hookClassName = uniqid('RegistrationEmailHookInterface');
+        $hook = $this->getMock(
+            RegistrationEmailHookInterface::class,
+            ['postProcessAttendeeEmail', 'postProcessOrganizerEmail', 'postProcessAdditionalEmail', 'postProcessAttendeeEmailText'],
+            [],
+            $hookClassName
+        );
+        $hook->expects(self::once())->method('postProcessAttendeeEmailText');
+
+        $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['seminars']['registration'][$hookClassName] = $hookClassName;
+        GeneralUtility::addInstance($hookClassName, $hook);
+
+        $this->fixture->setConfigurationValue('sendConfirmation', true);
+        $pi1 = new \Tx_Seminars_FrontEnd_DefaultController();
+        $pi1->init();
+
+        $this->fixture->notifyAttendee($registration, $pi1);
+    }
+
+    /**
+     * @test
+     */
+    public function notifyAttendeeForSendConfirmationTrueAndHtmlEmailCallsPostProcessAttendeeEmailTextHookTwice()
+    {
+        \Tx_Oelib_ConfigurationProxy::getInstance('seminars')
+            ->setAsInteger('eMailFormatForAttendees', \Tx_Seminars_Service_RegistrationManager::SEND_HTML_MAIL);
+
+        $registration = $this->createRegistration();
+
+        $hookClassName = uniqid('RegistrationEmailHookInterface');
+        $hook = $this->getMock(
+            RegistrationEmailHookInterface::class,
+            ['postProcessAttendeeEmail', 'postProcessOrganizerEmail', 'postProcessAdditionalEmail', 'postProcessAttendeeEmailText'],
+            [],
+            $hookClassName
+        );
+        $hook->expects(self::exactly(2))->method('postProcessAttendeeEmailText');
+
+        $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['seminars']['registration'][$hookClassName] = $hookClassName;
+        GeneralUtility::addInstance($hookClassName, $hook);
+
+        $this->fixture->setConfigurationValue('sendConfirmation', true);
+        $pi1 = new \Tx_Seminars_FrontEnd_DefaultController();
+        $pi1->init();
+
+        $this->fixture->notifyAttendee($registration, $pi1);
+    }
+
+    /**
+     * @test
+     */
     public function notifyAttendeeMailSubjectContainsConfirmationSubject()
     {
         $this->fixture->setConfigurationValue('sendConfirmation', true);
@@ -4881,7 +4939,7 @@ class Tx_Seminars_Tests_Unit_Service_RegistrationManagerTest extends \Tx_Phpunit
         $hookClassName = uniqid('RegistrationEmailHookInterface');
         $hook = $this->getMock(
             RegistrationEmailHookInterface::class,
-            ['postProcessAttendeeEmail', 'postProcessOrganizerEmail', 'postProcessAdditionalEmail'],
+            ['postProcessAttendeeEmail', 'postProcessOrganizerEmail', 'postProcessAdditionalEmail', 'postProcessAttendeeEmailText'],
             [],
             $hookClassName
         );
@@ -4906,7 +4964,7 @@ class Tx_Seminars_Tests_Unit_Service_RegistrationManagerTest extends \Tx_Phpunit
         $hookClassName = uniqid('RegistrationEmailHookInterface');
         $hook = $this->getMock(
             RegistrationEmailHookInterface::class,
-            ['postProcessAttendeeEmail', 'postProcessOrganizerEmail', 'postProcessAdditionalEmail'],
+            ['postProcessAttendeeEmail', 'postProcessOrganizerEmail', 'postProcessAdditionalEmail', 'postProcessAttendeeEmailText'],
             [],
             $hookClassName
         );
@@ -5169,7 +5227,7 @@ class Tx_Seminars_Tests_Unit_Service_RegistrationManagerTest extends \Tx_Phpunit
         $hookClassName = uniqid('RegistrationEmailHookInterface');
         $hook = $this->getMock(
             RegistrationEmailHookInterface::class,
-            ['postProcessAttendeeEmail', 'postProcessOrganizerEmail', 'postProcessAdditionalEmail'],
+            ['postProcessAttendeeEmail', 'postProcessOrganizerEmail', 'postProcessAdditionalEmail', 'postProcessAttendeeEmailText'],
             [],
             $hookClassName
         );
@@ -5197,7 +5255,7 @@ class Tx_Seminars_Tests_Unit_Service_RegistrationManagerTest extends \Tx_Phpunit
         $hookClassName = uniqid('RegistrationEmailHookInterface');
         $hook = $this->getMock(
             RegistrationEmailHookInterface::class,
-            ['postProcessAttendeeEmail', 'postProcessOrganizerEmail', 'postProcessAdditionalEmail'],
+            ['postProcessAttendeeEmail', 'postProcessOrganizerEmail', 'postProcessAdditionalEmail', 'postProcessAttendeeEmailText'],
             [],
             $hookClassName
         );
@@ -5722,7 +5780,7 @@ class Tx_Seminars_Tests_Unit_Service_RegistrationManagerTest extends \Tx_Phpunit
         $hookClassName = uniqid('RegistrationEmailHookInterface');
         $hook = $this->getMock(
             RegistrationEmailHookInterface::class,
-            ['postProcessAttendeeEmail', 'postProcessOrganizerEmail', 'postProcessAdditionalEmail'],
+            ['postProcessAttendeeEmail', 'postProcessOrganizerEmail', 'postProcessAdditionalEmail', 'postProcessAttendeeEmailText'],
             [],
             $hookClassName
         );

--- a/Tests/Unit/Service/RegistrationManagerTest.php
+++ b/Tests/Unit/Service/RegistrationManagerTest.php
@@ -5069,11 +5069,7 @@ class Tx_Seminars_Tests_Unit_Service_RegistrationManagerTest extends \Tx_Phpunit
 
         $hook = $this->getMock(\Tx_Seminars_Interface_Hook_Registration::class);
         $hookClassName = get_class($hook);
-        $hook->expects(self::once())->method('modifyOrganizerNotificationEmail')->with(
-            $registration,
-            self::anything(),
-            self::anything()
-        );
+        $hook->expects(self::once())->method('modifyOrganizerNotificationEmail')->with($registration, self::anything());
 
         $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['seminars']['registration'][$hookClassName] = $hookClassName;
         GeneralUtility::addInstance($hookClassName, $hook);


### PR DESCRIPTION
This change adds the Mail object to the hook so the Mail object can be modified without using XClasses.

Because of that interface it would be breaking. I could also add another hook containing the mail object and let this hook untouched if you don´t want a breaking change.