### PR TITLE
[BUGFIX] Fix the inclusion of the JavaScript file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Remove the print functionality from the BE module (#119)
 
 ### Fixed
+- Fix the inclusion of the JavaScript file (#161)
 - Remove the deprecated _PADDING from TCEforms wizards (#160)
 - Use the current composer names of static_info_tables (#159)
 - Add a conflict with a PHP-7.0-incompatible static_info_tables version (#156)

--- a/Configuration/TypoScript/Page.txt
+++ b/Configuration/TypoScript/Page.txt
@@ -4,7 +4,10 @@ page {
     }
 
     includeJSFooter {
-        tx_seminars_pi1 = EXT:seminars/Resources/Public/JavaScript/FrontEnd/FrontEnd.js
-        async = 1
+        seminarsFrontEnd = EXT:seminars/Resources/Public/JavaScript/FrontEnd/FrontEnd.js
+        seminarsFrontEnd {
+            async = 1
+            defer = 1
+        }
     }
 }

--- a/Resources/Public/JavaScript/FrontEnd/FrontEnd.js
+++ b/Resources/Public/JavaScript/FrontEnd/FrontEnd.js
@@ -1,17 +1,4 @@
 /*
- * This file is part of the TYPO3 CMS project.
- *
- * It is free software; you can redistribute it and/or modify it under
- * the terms of the GNU General Public License, either version 2
- * of the License, or any later version.
- *
- * For the full copyright and license information, please read the
- * LICENSE.txt file that was distributed with this source code.
- *
- * The TYPO3 project - inspiring people to share!
- */
-
-/*
  * This file provides some JavaScript functions for the seminars front-end
  * editor and the registration form.
  *


### PR DESCRIPTION
Fix the async and defer attributes.

Also remove the "part of the TYPO3 CMS" header from the JavaScript file.