### PR TITLE
allow unregistration_notice in thankyouemail

### DIFF
--- a/Classes/ConfigCheck.php~
+++ b/Classes/ConfigCheck.php~
@@ -884,7 +884,6 @@ class Tx_Seminars_ConfigCheck extends \Tx_Oelib_ConfigCheck
                 'footer',
                 'first_name',
                 'last_name',
-                'unregistration_notice',
             ]
         );
     }

--- a/Documentation/DE/Referenz/SetupCommonForFront-endPlug-inAndBack-endModuleInPlugintxSeminars/Index.rst
+++ b/Documentation/DE/Referenz/SetupCommonForFront-endPlug-inAndBack-endModuleInPlugintxSeminars/Index.rst
@@ -117,7 +117,7 @@ only be configured using your TypoScript setup, but not via flexforms.
          tal\_price,attendees\_names,lodgings,accommodation,foods,food,checkbox
          es, kids, accreditation\_number, credit\_points, date, time, place,
          room, paymentmethod, billing\_address,interests,url,
-         footer,planned\_disclaimer
+         footer,planned\_disclaimer,unregistration\_notice
 
    Standardwert
          credit\_points,billing\_address,kids,planned\_disclaimer

--- a/Documentation/EN/Reference/SetupCommonForFront-endPlug-inAndBack-endModuleInPlugintxSeminars/Index.rst
+++ b/Documentation/EN/Reference/SetupCommonForFront-endPlug-inAndBack-endModuleInPlugintxSeminars/Index.rst
@@ -117,7 +117,7 @@ only be configured using your TypoScript setup, but not via flexforms.
          tal\_price,attendees\_names,lodgings,accommodation,foods,food,checkbox
          es, kids, accreditation\_number, credit\_points, date, time, place,
          room,paymentmethod, billing\_address,interests,url,
-         footer,planned\_disclaimer
+         footer,planned\_disclaimer,unregistration\_notice
 
    Default
          credit\_points,billing\_address,kids,planned\_disclaimer


### PR DESCRIPTION
At the moment the configuration checker outputs the following warning:
> Configuration check warning:
> The TS setup variable plugin.tx_seminars.hideFieldsInThankYouMail contains the value unregistration_notice, but only the following values are allowed: 

I've solve this problem and add the neccessary lines to the documentation.