### PR TITLE
[TASK] Allow testing the old models with fewer DB accesses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Added
 
 ### Changed
+- Allow testing the old models with fewer DB accesses (#202)
 - Rename SUT from "fixture" to "subject" (#196) 
 - Convert the first tests to nimut/testing-framework (#194, #195, #201)
 - Move to old tests to the "Legacy" namespace (#193)

--- a/Classes/OldModel/Registration.php
+++ b/Classes/OldModel/Registration.php
@@ -93,7 +93,7 @@ class Tx_Seminars_OldModel_Registration extends \Tx_Seminars_OldModel_Abstract
 
         $data = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($dbResult);
         if ($data !== false) {
-            $this->getDataFromDbResult($data);
+            $this->setData($data);
         }
     }
 

--- a/Tests/LegacyUnit/Fixtures/OldModel/TestingEvent.php
+++ b/Tests/LegacyUnit/Fixtures/OldModel/TestingEvent.php
@@ -30,7 +30,7 @@ final class Tx_Seminars_Tests_Unit_Fixtures_OldModel_TestingEvent extends \Tx_Se
     public function setEventData(array $eventData)
     {
         $this->recordData = $eventData;
-        $this->isInDb = true;
+        $this->isPersisted = true;
     }
 
     /**

--- a/Tests/LegacyUnit/OldModel/AbstractTest.php
+++ b/Tests/LegacyUnit/OldModel/AbstractTest.php
@@ -105,16 +105,24 @@ class Tx_Seminars_Tests_Unit_OldModel_AbstractTest extends \Tx_Phpunit_TestCase
         );
     }
 
-    public function testCreateFromDbResultFailsForNull()
+    /**
+     * @test
+     */
+    public function createFromDirectDataResultsInOkay()
     {
-        $test = new \Tx_Seminars_Tests_Unit_Fixtures_OldModel_Testing(
-            0,
-            null
-        );
+        $subject = new Tx_Seminars_Tests_Unit_Fixtures_OldModel_Testing(0, false, false, ['title' => 'Foo']);
 
-        self::assertFalse(
-            $test->isOk()
-        );
+        self::assertTrue($subject->isOk());
+    }
+
+    /**
+     * @test
+     */
+    public function createFromDbResultFailsForFalse()
+    {
+        $test = new \Tx_Seminars_Tests_Unit_Fixtures_OldModel_Testing(0, false);
+
+        self::assertFalse($test->isOk());
     }
 
     /**
@@ -148,7 +156,7 @@ class Tx_Seminars_Tests_Unit_OldModel_AbstractTest extends \Tx_Phpunit_TestCase
 
         $test = new \Tx_Seminars_Tests_Unit_Fixtures_OldModel_Testing(
             $this->subjectUid,
-            null,
+            false,
             true
         );
 
@@ -199,6 +207,16 @@ class Tx_Seminars_Tests_Unit_OldModel_AbstractTest extends \Tx_Phpunit_TestCase
             'Test',
             $this->subject->getTitle()
         );
+    }
+
+    /**
+     * @test
+     */
+    public function dataCanBeSetDirectlyInConstructor()
+    {
+        $subject = new Tx_Seminars_Tests_Unit_Fixtures_OldModel_Testing(0, false, false, ['title' => 'Foo']);
+
+        self::assertSame('Foo', $subject->getTitle());
     }
 
     //////////////////////////////////

--- a/Tests/LegacyUnit/OldModel/CategoryTest.php
+++ b/Tests/LegacyUnit/OldModel/CategoryTest.php
@@ -8,29 +8,13 @@
 class Tx_Seminars_Tests_Unit_OldModel_CategoryTest extends \Tx_Phpunit_TestCase
 {
     /**
-     * @var \Tx_Seminars_OldModel_Category
-     */
-    private $subject;
-
-    /**
      * @var \Tx_Oelib_TestingFramework
      */
     private $testingFramework;
 
-    /**
-     * UID of the fixture's data in the DB
-     *
-     * @var int
-     */
-    private $subjectUid = 0;
-
     protected function setUp()
     {
         $this->testingFramework = new \Tx_Oelib_TestingFramework('tx_seminars');
-        $this->subjectUid = $this->testingFramework->createRecord(
-            'tx_seminars_categories',
-            ['title' => 'Test category']
-        );
     }
 
     protected function tearDown()
@@ -38,92 +22,43 @@ class Tx_Seminars_Tests_Unit_OldModel_CategoryTest extends \Tx_Phpunit_TestCase
         $this->testingFramework->cleanUp();
     }
 
-    public function testCreateFromUid()
+    /**
+     * @test
+     */
+    public function getTitleReturnsTitle()
     {
-        $this->subject = new \Tx_Seminars_OldModel_Category($this->subjectUid);
+        $title = 'Test category';
+        $subject = new \Tx_Seminars_OldModel_Category(0, false, false, ['title' => $title]);
 
-        self::assertTrue(
-            $this->subject->isOk()
-        );
+        self::assertSame($title, $subject->getTitle());
     }
 
-    public function testCreateFromUidFailsForInvalidUid()
+    /**
+     * @test
+     */
+    public function getIconReturnsIcon()
     {
-        $this->subject = new \Tx_Seminars_OldModel_Category($this->subjectUid + 99);
+        $icon = 'foo.gif';
+        $subject = new \Tx_Seminars_OldModel_Category(0, false, false, ['icon' => $icon]);
 
-        self::assertFalse(
-            $this->subject->isOk()
-        );
+        self::assertSame($icon, $subject->getIcon());
     }
 
-    public function testCreateFromUidFailsForZeroUid()
+    /**
+     * @test
+     */
+    public function createFromUidMapsAllFields()
     {
-        $this->subject = new \Tx_Seminars_OldModel_Category(0);
-
-        self::assertFalse(
-            $this->subject->isOk()
-        );
-    }
-
-    public function testCreateFromDbResult()
-    {
-        $dbResult = \Tx_Oelib_Db::select(
-            '*',
+        $title = 'Test category';
+        $icon = 'foo.gif';
+        $subjectUid = $this->testingFramework->createRecord(
             'tx_seminars_categories',
-            'uid = ' . $this->subjectUid
+            ['title' => $title, 'icon' => $icon]
         );
+        $subject = new \Tx_Seminars_OldModel_Category($subjectUid);
 
-        $this->subject = new \Tx_Seminars_OldModel_Category(0, $dbResult);
-
-        self::assertTrue(
-            $this->subject->isOk()
-        );
-    }
-
-    public function testCreateFromDbResultFailsForNull()
-    {
-        $this->subject = new \Tx_Seminars_OldModel_Category(0, null);
-
-        self::assertFalse(
-            $this->subject->isOk()
-        );
-    }
-
-    public function testGetTitle()
-    {
-        $this->subject = new \Tx_Seminars_OldModel_Category($this->subjectUid);
-
-        self::assertEquals(
-            'Test category',
-            $this->subject->getTitle()
-        );
-    }
-
-    public function testGetIconReturnsIcon()
-    {
-        $this->subject = new \Tx_Seminars_OldModel_Category(
-            $this->testingFramework->createRecord(
-                'tx_seminars_categories',
-                [
-                    'title' => 'Test category',
-                    'icon' => 'foo.gif',
-                ]
-            )
-        );
-
-        self::assertEquals(
-            'foo.gif',
-            $this->subject->getIcon()
-        );
-    }
-
-    public function testGetIconReturnsEmptyStringIfCategoryHasNoIcon()
-    {
-        $this->subject = new \Tx_Seminars_OldModel_Category($this->subjectUid);
-
-        self::assertEquals(
-            '',
-            $this->subject->getIcon()
-        );
+        self::assertTrue($subject->isOk());
+        self::assertSame($title, $subject->getTitle());
+        self::assertSame($icon, $subject->getIcon());
     }
 }


### PR DESCRIPTION
Also refactor the AbstractOldModel a bit.

Also convert the Category and SpeakerTests accordingly.