### PR TITLE
[TASK] Skip the DB cleanup in the new functional tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Added
 
 ### Changed
+- Skip the DB cleanup in the new functional tests (#204)
 - Require oelib >= 2.3.0 (#203)
 - Allow testing the old models with fewer DB accesses (#202)
 - Rename SUT from "fixture" to "subject" (#196) 

--- a/Tests/Functional/Mapper/RegistrationTest.php
+++ b/Tests/Functional/Mapper/RegistrationTest.php
@@ -41,12 +41,6 @@ class RegistrationTest extends FunctionalTestCase
         $this->subject = new \Tx_Seminars_Mapper_Registration();
     }
 
-    protected function tearDown()
-    {
-        $this->testingFramework->cleanUp();
-        parent::tearDown();
-    }
-
     /**
      * @test
      */

--- a/Tests/Functional/OldModel/SpeakerTest.php
+++ b/Tests/Functional/OldModel/SpeakerTest.php
@@ -27,14 +27,6 @@ class SpeakerTest extends FunctionalTestCase
      */
     private $subject = null;
 
-    protected function tearDown()
-    {
-        if ($this->testingFramework !== null) {
-            $this->testingFramework->cleanUp();
-        }
-        parent::tearDown();
-    }
-
     ///////////////////////
     // Utility functions.
     ///////////////////////


### PR DESCRIPTION
The testing framework will flush the DB tables anyway, so there is no
need to do that ourselves.

This should improve test performance a bit.