### PR TITLE
[TASK] Pass user object in modifySalutation hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Added
 
 ### Changed
+- Pass user object in modifySalutation hook (#215)
 - Rename and namespace the DataHandler hook class (#206)
 - Skip the DB cleanup in the new functional tests (#204)
 - Require oelib >= 2.3.0 (#203)
@@ -15,7 +16,6 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Rename SUT from "fixture" to "subject" (#196) 
 - Convert the first tests to nimut/testing-framework (#194, #195, #201)
 - Move to old tests to the "Legacy" namespace (#193)
-- Pass user object in modifySalutation hook (#215)
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Rename SUT from "fixture" to "subject" (#196) 
 - Convert the first tests to nimut/testing-framework (#194, #195, #201)
 - Move to old tests to the "Legacy" namespace (#193)
+- Pass user object in modifySalutation hook (#215)
 
 ### Deprecated
 

--- a/Classes/EmailSalutation.php
+++ b/Classes/EmailSalutation.php
@@ -52,7 +52,7 @@ class Tx_Seminars_EmailSalutation
 
         foreach ($this->getHooks() as $hook) {
             if (method_exists($hook, 'modifySalutation')) {
-                $hook->modifySalutation($salutationParts);
+                $hook->modifySalutation($salutationParts, $user);
             }
         }
 

--- a/Documentation/EN/Reference/Hooks/Index.rst
+++ b/Documentation/EN/Reference/Hooks/Index.rst
@@ -215,11 +215,13 @@ the following hook:
   before the salutation is returned by getSalutation
 
 To use this hook, you need to create a class with a method named
-modifySalutation. The method in your class should only expect one
-parameter which is a reference to an array with the following
+modifySalutation. The method in your class should expect two
+parameters. The first one is a reference to an array with the following
 structure:
 
 array('dear' => String, 'title' => String, 'name' => String)
+
+The second parameter is an user object \Tx_Seminars_Model_FrontEndUser.
 
 Your class then needs to be included and registered like in this
 example:
@@ -227,7 +229,7 @@ example:
 ::
 
    // register my hook objects
-   $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['seminars']['modifyEmailSalutation'][] = \tx_rsysseminarsext_modemailsalutation::class;
+   $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['seminars']['modifyEmailSalutation'][] = \\MyVendor\\MyExt\\Hooks\\ModifySalutationHook::class;
 
 
 Hooks for the e-mails sent from the back-end module

--- a/Tests/LegacyUnit/Service/EMailSalutationTest.php
+++ b/Tests/LegacyUnit/Service/EMailSalutationTest.php
@@ -356,12 +356,16 @@ class Tx_Seminars_Tests_Unit_Service_EMailSalutationTest extends \Tx_Phpunit_Tes
             $hookClassName,
             ['modifySalutation']
         );
-        $salutationHookMock->expects(self::atLeastOnce())->method('modifySalutation');
+        $frontendUser = $this->createFrontEndUser();
+        $salutationHookMock->expects(self::atLeastOnce())->method('modifySalutation')->with(
+            self::isType('array'),
+            self::identicalTo($frontendUser)
+        );
 
         $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['seminars']['modifyEmailSalutation'][$hookClassName] = $hookClassName;
         GeneralUtility::addInstance($hookClassName, $salutationHookMock);
 
-        $this->subject->getSalutation($this->createFrontEndUser());
+        $this->subject->getSalutation($frontendUser);
     }
 
     /**
@@ -374,7 +378,11 @@ class Tx_Seminars_Tests_Unit_Service_EMailSalutationTest extends \Tx_Phpunit_Tes
             $hookClassName1,
             ['modifySalutation']
         );
-        $salutationHookMock1->expects(self::atLeastOnce())->method('modifySalutation');
+        $frontendUser = $this->createFrontEndUser();
+        $salutationHookMock1->expects(self::atLeastOnce())->method('modifySalutation')->with(
+            self::isType('array'),
+            self::identicalTo($frontendUser)
+        );
         $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['seminars']['modifyEmailSalutation'][$hookClassName1] = $hookClassName1;
         GeneralUtility::addInstance($hookClassName1, $salutationHookMock1);
 
@@ -383,11 +391,14 @@ class Tx_Seminars_Tests_Unit_Service_EMailSalutationTest extends \Tx_Phpunit_Tes
             $hookClassName2,
             ['modifySalutation']
         );
-        $salutationHookMock2->expects(self::atLeastOnce())->method('modifySalutation');
+        $salutationHookMock2->expects(self::atLeastOnce())->method('modifySalutation')->with(
+            self::isType('array'),
+            self::identicalTo($frontendUser)
+        );
         $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['seminars']['modifyEmailSalutation'][$hookClassName2] = $hookClassName2;
         GeneralUtility::addInstance($hookClassName2, $salutationHookMock2);
 
-        $this->subject->getSalutation($this->createFrontEndUser());
+        $this->subject->getSalutation($frontendUser);
     }
 
     /*


### PR DESCRIPTION
Currently it isn´t possible to get the user object inside the
modifySalution hook. The change shouldn´t be breaking.