### PR TITLE
[BUGFIX] Pin the dev dependency versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Removed
 
 ### Fixed
+- Pin the dev dependency versions (#229)
 - Initialize a BE user in the BE-related tests (#227)
 
 ## 2.2.0

--- a/composer.json
+++ b/composer.json
@@ -34,14 +34,12 @@
     },
     "require-dev": {
         "typo3/cms-scheduler": "^7.6.23 || ^8.7.9",
-        "helhum/typo3-console": "^4.9",
+        "helhum/typo3-console": "^4.9.6",
 
-        "oliverklee/phpunit": "^5.3",
-        "nimut/testing-framework": "^2.0",
-        "phpunit/phpunit": "^5.6",
-        "mikey179/vfsstream": "^1.6",
-
-        "roave/security-advisories": "dev-master"
+        "oliverklee/phpunit": "~5.3.5",
+        "nimut/testing-framework": "^2.0.3",
+        "phpunit/phpunit": "~5.6.8",
+        "mikey179/vfsstream": "^1.6.7"
     },
     "conflict": {
         "sjbr/static-info-tables": "6.7.1"


### PR DESCRIPTION
Also drop the dependency on `roave/security-advisories` as this dependency
should be in the distribution, not the individual extensions.