### PR TITLE
[FEATURE] Improved and more hooks to the project

### DIFF
--- a/Classes/FrontEnd/DefaultController.php
+++ b/Classes/FrontEnd/DefaultController.php
@@ -212,6 +212,13 @@ class Tx_Seminars_FrontEnd_DefaultController extends \Tx_Oelib_TemplateHelper im
     protected $singleViewHookProvider = null;
 
     /**
+     * Objects hooked to the registration view
+     *
+     * @var \OliverKlee\Seminars\Service\HookService
+     */
+    protected $registrationViewHooks = null;
+
+    /**
      * a link builder instance
      *
      * @var \Tx_Seminars_Service_SingleViewLinkBuilder
@@ -484,6 +491,24 @@ class Tx_Seminars_FrontEnd_DefaultController extends \Tx_Oelib_TemplateHelper im
         }
 
         return $this->singleViewHookProvider;
+    }
+
+    /**
+     * Gets the hooks for the registration view.
+     *
+     * @return \OliverKlee\Seminars\Interfaces\Hook\RegistrationView[]
+     *         the hook objects, will be empty if no hooks have been set
+     */
+    protected function getRegistrationViewHooks()
+    {
+        if ($this->registrationViewHooks === null) {
+            $this->registrationViewHooks = GeneralUtility::makeInstance(
+                \OliverKlee\Seminars\Service\HookService::class,
+                \OliverKlee\Seminars\Interfaces\Hook\RegistrationView::class
+            );
+        }
+
+        return $this->registrationViewHooks->getHooks();
     }
 
     /**
@@ -2952,6 +2977,10 @@ class Tx_Seminars_FrontEnd_DefaultController extends \Tx_Oelib_TemplateHelper im
             $this->setMarker('error_text', $errorMessage);
         }
 
+        foreach ($this->getRegistrationViewHooks() as $hook) {
+            $hook->modifyRegistrationHeading($this, $this->getTemplate());
+        }
+
         return $this->getSubpart('REGISTRATION_HEAD');
     }
 
@@ -2977,6 +3006,10 @@ class Tx_Seminars_FrontEnd_DefaultController extends \Tx_Oelib_TemplateHelper im
             $registrationEditor->setRegistration($this->registration);
         }
 
+        foreach ($this->getRegistrationViewHooks() as $hook) {
+            $hook->modifyRegistrationForm($this, $registrationEditor);
+        }
+
         return (string)$registrationEditor->render();
     }
 
@@ -2987,6 +3020,10 @@ class Tx_Seminars_FrontEnd_DefaultController extends \Tx_Oelib_TemplateHelper im
      */
     protected function createRegistrationFooter(): string
     {
+        foreach ($this->getRegistrationViewHooks() as $hook) {
+            $hook->modifyRegistrationFooter($this, $this->getTemplate());
+        }
+
         return $this->getSubpart('REGISTRATION_BOTTOM');
     }
 

--- a/Classes/Interfaces/Hook.php
+++ b/Classes/Interfaces/Hook.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace OliverKlee\Seminars\Interfaces;
+
+/**
+ * Extend this interface to use Your interface with the HookService
+ *
+ * @author Michael Kramer <m.kramer@mxp.de>
+ */
+interface Hook
+{
+    // intentionally empty
+}

--- a/Classes/Interfaces/Hook/RegistrationView.php
+++ b/Classes/Interfaces/Hook/RegistrationView.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace OliverKlee\Seminars\Interfaces\Hook;
+
+use OliverKlee\Seminars\Interfaces\Hook;
+
+/**
+ * This interface needs to be used for hooks concerning the registration view.
+ *
+ * @author Michael Kramer <m.kramer@mxp.de>
+ */
+interface RegistrationView extends Hook
+{
+    /**
+     * Modifies the heading of the registration view.
+     *
+     * @param \Tx_Seminars_FrontEnd_DefaultController $controller
+     *        the calling controller
+     * @param \Tx_Oelib_Template $template
+     *        the template that will be used to create the heading output
+     *
+     * @return void
+     */
+    public function modifyRegistrationHeading(
+        \Tx_Seminars_FrontEnd_DefaultController $controller,
+        \Tx_Oelib_Template $template
+    );
+
+    /**
+     * Modifies the registration form.
+     *
+     * @param \Tx_Seminars_FrontEnd_DefaultController $controller
+     *        the calling controller
+     * @param \Tx_Seminars_FrontEnd_RegistrationForm $registrationEditor
+     *        the registration form renderer that will be used to create the form
+     *
+     * @return void
+     */
+    public function modifyRegistrationForm(
+        \Tx_Seminars_FrontEnd_DefaultController $controller,
+        \Tx_Seminars_FrontEnd_RegistrationForm $registrationEditor
+    );
+
+    /**
+     * Modifies the footer of the registration view.
+     *
+     * @param \Tx_Seminars_FrontEnd_DefaultController $controller
+     *        the calling controller
+     * @param \Tx_Oelib_Template $template
+     *        the template that will be used to create the footer output
+     *
+     * @return void
+     */
+    public function modifyRegistrationFooter(
+        \Tx_Seminars_FrontEnd_DefaultController $controller,
+        \Tx_Oelib_Template $template
+    );
+}

--- a/Classes/Interfaces/Hook/SeminarListView.php
+++ b/Classes/Interfaces/Hook/SeminarListView.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace OliverKlee\Seminars\Interfaces\Hook;
+
+use OliverKlee\Seminars\Interfaces\Hook;
+
+/**
+ * This interface needs to be used for hooks concerning the seminar list view.
+ * It superseeds the outdated EventListView interface.
+ *
+ * @package TYPO3
+ * @subpackage tx_seminars
+ *
+ * @author Michael Kramer <m.kramer@mxp.de>
+ */
+interface SeminarListView extends Hook
+{
+    /**
+     * Modifies a list row in the seminar list.
+     *
+     * This function will be called for all types of seminar lists.
+     *
+     * @param \Tx_Seminars_FrontEnd_DefaultController $controller
+     *        the calling controller
+     * @param \Tx_Oelib_Template $template
+     *        the template that will be used to create the list row output
+     *
+     * @return void
+     */
+    public function modifyListRow(
+        \Tx_Seminars_FrontEnd_DefaultController $controller,
+        \Tx_Oelib_Template $template
+    );
+
+    /**
+     * Modifies a list view row in the "my seminars" list.
+     *
+     * @param \Tx_Seminars_FrontEnd_DefaultController $controller
+     *        the calling controller
+     * @param \Tx_Oelib_Template $template
+     *        the template that will be used to create the list row output
+     *
+     * @return void
+     */
+    public function modifyMySeminarsListRow(
+        \Tx_Seminars_FrontEnd_DefaultController $controller,
+        \Tx_Oelib_Template $template
+    );
+
+    /**
+     * Modifies the list view header row in the seminars list.
+     *
+     * This function will be called for all types of seminar lists.
+     *
+     * @param \Tx_Seminars_FrontEnd_DefaultController $controller
+     *        the calling controller
+     * @param \Tx_Oelib_Template $template
+     *        the template from which the list header is built
+     *
+     * @return void
+     */
+    public function modifyListHeader(
+        \Tx_Seminars_FrontEnd_DefaultController $controller,
+        \Tx_Oelib_Template $template
+    );
+
+    /**
+     * Modifies the list view footer in the seminars list.
+     *
+     * This function will be called for all types of seminar lists.
+     *
+     * @param \Tx_Seminars_FrontEnd_DefaultController $controller
+     *        the calling controller
+     * @param \Tx_Oelib_Template $template
+     *        the template from which the list footer is built
+     *
+     * @return void
+     */
+    public function modifyListFooter(
+        \Tx_Seminars_FrontEnd_DefaultController $controller,
+        \Tx_Oelib_Template $template
+    );
+}

--- a/Classes/Interfaces/Hook/SeminarListView.php
+++ b/Classes/Interfaces/Hook/SeminarListView.php
@@ -80,4 +80,26 @@ interface SeminarListView extends Hook
         \Tx_Seminars_FrontEnd_DefaultController $controller,
         \Tx_Oelib_Template $template
     );
+
+    /**
+     * Modifies the list view seminar or registration bag builder
+     * (the item collection for the seminars list).
+     *
+     * This function will be called for all types of seminar lists.
+     *
+     * @param \Tx_Seminars_FrontEnd_DefaultController $controller
+     *        the calling controller
+     * @param \Tx_Seminars_BagBuilder_Abstract $builder
+     *        the bag builder (exact type depends on $whatToDisplay)
+     * @param string $whatToDisplay
+     *        the flavor of list view: either an empty string (for the default
+     *        list view), the value from "what_to_display", or "other_dates"
+     *
+     * @return void
+     */
+    public function modifyBagBuilder(
+        \Tx_Seminars_FrontEnd_DefaultController $controller,
+        \Tx_Seminars_BagBuilder_Abstract $builder,
+        $whatToDisplay
+    );
 }

--- a/Classes/Interfaces/Hook/SeminarSingleView.php
+++ b/Classes/Interfaces/Hook/SeminarSingleView.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace OliverKlee\Seminars\Interfaces\Hook;
+
+use OliverKlee\Seminars\Interfaces\Hook;
+
+/**
+ * This interface needs to be used for hooks concerning the seminar single view.
+ * It superseeds the outdated EventSingleView interface.
+ *
+ * @package TYPO3
+ * @subpackage tx_seminars
+ *
+ * @author Michael Kramer <m.kramer@mxp.de>
+ */
+interface SeminarSingleView extends Hook
+{
+    /**
+     * Modifies the seminar details view.
+     *
+     * This function will be called for all types of seminars.
+     *
+     * @param \Tx_Seminars_FrontEnd_DefaultController $controller
+     *        the calling controller
+     * @param \Tx_Oelib_Template $template
+     *        the template that will be used to create the list row output
+     *
+     * @return void
+     */
+    public function modifySingleView(
+        \Tx_Seminars_FrontEnd_DefaultController $controller,
+        \Tx_Oelib_Template $template
+    );
+}

--- a/Classes/Interfaces/Hook/TestHook.php
+++ b/Classes/Interfaces/Hook/TestHook.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace OliverKlee\Seminars\Interfaces\Hook;
+
+use OliverKlee\Seminars\Interfaces\Hook;
+
+/**
+ * Test interface to use with the HookService
+ *
+ * @author Michael Kramer <m.kramer@mxp.de>
+ */
+interface TestHook extends Hook
+{
+    /**
+     * Test Hook Method
+     *
+     * This function will be called during HookService tests.
+     *
+     * @return void
+     */
+    public function testHookMethod();
+}

--- a/Classes/Service/HookService.php
+++ b/Classes/Service/HookService.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace OliverKlee\Seminars\Service;
+
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use OliverKlee\Seminars\Interfaces\Hook;
+
+/**
+ * This class provides functions for unified hooks.
+ *
+ * It refactors the wide-spread use of this type of hooks in seminars.
+ *
+ * @author Oliver Klee <typo3-coding@oliverklee.de>
+ * @author Michael Kramer <m.kramer@mxp.de>
+ */
+class HookService
+{
+    /**
+     * Interface name to this hook
+     *
+     * @var string
+     */
+    protected $interfaceName = '';
+
+    /**
+     * Index in $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['seminars'] of hooked-in classes
+     *
+     * @var string
+     */
+    protected $index = '';
+
+    /**
+     * Hook objects built
+     *
+     * @var array
+     */
+    protected $hookObjects = [];
+
+    /**
+     * Whether the hooks have been retrieved
+     *
+     * @var boolean
+     */
+    protected $hooksHaveBeenRetrieved = false;
+
+    /**
+     * The constructor.
+     *
+     * @throws \UnexpectedValueException
+     *         if $interfaceName does not extend Hook interface
+     *
+     * @param $interfaceName interface the hook needs implemented
+     * @param $index optional index to $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['seminars']
+     *               if not using the interface name (for backwards compatibility)
+     *               (the interface name is recommended)
+     */
+    public function __construct($interfaceName, $index = '')
+    {
+        if (!interface_exists($interfaceName)) {
+            throw new \UnexpectedValueException(
+                'The interface ' . $interfaceName . ' does not exist.',
+                1565089078
+            );
+        }
+
+        if (!in_array(Hook::class, class_implements($interfaceName), true)) {
+            throw new \UnexpectedValueException(
+                'The interface ' . $interfaceName . ' does not extend '
+                    . Hook::class . ' interface.',
+                1565088963
+            );
+        }
+
+        $this->interfaceName = $interfaceName;
+        $this->index = $interfaceName;
+        if ($index != '') {
+            $this->index = $index;
+        }
+    }
+
+    /**
+     * Gets the hook objects for the interface.
+     *
+     * @throws \UnexpectedValueException
+     *         if there are registered hook classes that do not implement the
+     *         $this->interfaceName interface
+     *
+     * @return array
+     *         the hook objects, will be empty if no hooks have been set
+     */
+    public function getHooks()
+    {
+        if (!$this->hooksHaveBeenRetrieved) {
+            $hookClasses = $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['seminars'][$this->index];
+            if (is_array($hookClasses)) {
+                foreach ($hookClasses as $hookClass) {
+                    $hookInstance = GeneralUtility::makeInstance($hookClass);
+                    if (!($hookInstance instanceof $this->interfaceName)) {
+                        throw new \UnexpectedValueException(
+                            'The class ' . get_class($hookInstance) . ' is registered for the ' . $this->index .
+                                ' hook list, but does not implement the ' . $this->interfaceName . ' interface.',
+                            1448901897
+                        );
+                    }
+                    $this->hookObjects[] = $hookInstance;
+                }
+            }
+
+            $this->hooksHaveBeenRetrieved = true;
+        }
+
+        return $this->hookObjects;
+    }
+}
+
+if (defined('TYPO3_MODE')
+    && $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/seminars/Classes/Service/Hook.php']
+) {
+    include_once($GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/seminars/Classes/Service/Hook.php']);
+}

--- a/Tests/LegacyUnit/Fixtures/Service/TestHookImplementor.php
+++ b/Tests/LegacyUnit/Fixtures/Service/TestHookImplementor.php
@@ -1,0 +1,19 @@
+<?php
+
+use OliverKlee\Seminars\Interfaces\Hook\TestHook;
+
+/**
+ * This class just makes some public stuff for testing purposes.
+ *
+ * @author Michael Kramer <m.kramer@mxp.de>
+ */
+class Tx_Seminars_Tests_Unit_Fixtures_Service_TestHookImplementor implements TestHook
+{
+    public $wasCalled = false;
+
+    public function testHookMethod()
+    {
+        $this->wasCalled = true;
+        return;
+    }
+}

--- a/Tests/LegacyUnit/FrontEnd/DefaultControllerTest.php
+++ b/Tests/LegacyUnit/FrontEnd/DefaultControllerTest.php
@@ -1257,6 +1257,28 @@ class Tx_Seminars_Tests_Unit_FrontEnd_DefaultControllerTest extends TestCase
         $this->subject->main('', []);
     }
 
+    /**
+     * @test
+     */
+    public function singleViewCallsSeminarSingleViewHookModifySingleView()
+    {
+        $this->subject->setConfigurationValue('what_to_display', 'single_view');
+
+        /** @var \Tx_Seminars_Model_Event $event */
+        $event = \Tx_Oelib_MapperRegistry::get(\Tx_Seminars_Mapper_Event::class)->find($this->seminarUid);
+        $hook = $this->createMock(\OliverKlee\Seminars\Interfaces\Hook\SeminarSingleView::class);
+        $hook->expects(self::once())->method('modifySingleView')->with($this->subject, self::anything());
+        // We don't test for the second parameter (the template instance here)
+        // because we cannot access it from the outside.
+
+        $hookClass = get_class($hook);
+        $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['seminars'][\OliverKlee\Seminars\Interfaces\Hook\SeminarSingleView::class][] = $hookClass;
+        GeneralUtility::addInstance($hookClass, $hook);
+
+        $this->subject->piVars['showUid'] = $this->seminarUid;
+        $this->subject->main('', []);
+    }
+
     ///////////////////////////////////////////////////////
     // Tests concerning attached files in the single view
     ///////////////////////////////////////////////////////

--- a/Tests/LegacyUnit/FrontEnd/DefaultControllerTest.php
+++ b/Tests/LegacyUnit/FrontEnd/DefaultControllerTest.php
@@ -3399,6 +3399,27 @@ class Tx_Seminars_Tests_Unit_FrontEnd_DefaultControllerTest extends TestCase
         );
     }
 
+    /**
+     * @test
+     */
+    public function listViewCallsSeminarListViewHookModifyListHeaderRowFooter()
+    {
+        $this->subject->setConfigurationValue('what_to_display', 'seminar_list');
+
+        $hook = $this->createMock(\OliverKlee\Seminars\Interfaces\Hook\SeminarListView::class);
+        $hook->expects(self::once())->method('modifyListHeader')->with($this->subject, self::anything());
+        $hook->expects(self::once())->method('modifyListRow')->with($this->subject, self::anything());
+        $hook->expects(self::once())->method('modifyListFooter')->with($this->subject, self::anything());
+        // We don't test for the second parameter (the template instance here)
+        // because we cannot access it from the outside.
+
+        $hookClass = get_class($hook);
+        $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['seminars'][\OliverKlee\Seminars\Interfaces\Hook\SeminarListView::class][] = $hookClass;
+        GeneralUtility::addInstance($hookClass, $hook);
+
+        $this->subject->main('', []);
+    }
+
     /////////////////////////////////////////////////////////
     // Tests concerning the result counter in the list view
     /////////////////////////////////////////////////////////
@@ -6096,6 +6117,26 @@ class Tx_Seminars_Tests_Unit_FrontEnd_DefaultControllerTest extends TestCase
             '01.01.2008',
             $this->subject->main('', [])
         );
+    }
+
+    /**
+     * @test
+     */
+    public function testMyEventsCallsSeminarListViewHookModifyMySeminarsListRow()
+    {
+        $this->createLogInAndRegisterFeUser();
+        $this->subject->setConfigurationValue('what_to_display', 'my_events');
+
+        $hook = $this->createMock(\OliverKlee\Seminars\Interfaces\Hook\SeminarListView::class);
+        $hook->expects(self::once())->method('modifyMySeminarsListRow')->with($this->subject, self::anything());
+        // We don't test for the second parameter (the template instance here)
+        // because we cannot access it from the outside.
+
+        $hookClass = get_class($hook);
+        $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['seminars'][\OliverKlee\Seminars\Interfaces\Hook\SeminarListView::class][] = $hookClass;
+        GeneralUtility::addInstance($hookClass, $hook);
+
+        $this->subject->main('', []);
     }
 
     /////////////////////////////////////////////////////////////////////////////////

--- a/Tests/LegacyUnit/FrontEnd/DefaultControllerTest.php
+++ b/Tests/LegacyUnit/FrontEnd/DefaultControllerTest.php
@@ -3402,11 +3402,14 @@ class Tx_Seminars_Tests_Unit_FrontEnd_DefaultControllerTest extends TestCase
     /**
      * @test
      */
-    public function listViewCallsSeminarListViewHookModifyListHeaderRowFooter()
+    public function listViewCallsSeminarListViewHookModifyBagBuilderListHeaderRowFooter()
     {
         $this->subject->setConfigurationValue('what_to_display', 'seminar_list');
 
         $hook = $this->createMock(\OliverKlee\Seminars\Interfaces\Hook\SeminarListView::class);
+        $hook->expects(self::once())->method('modifyBagBuilder')->with($this->subject, self::anything(), 'seminar_list');
+        // We don't test for the second parameter (the bag builder instance here)
+        // because we cannot access it from the outside.
         $hook->expects(self::once())->method('modifyListHeader')->with($this->subject, self::anything());
         $hook->expects(self::once())->method('modifyListRow')->with($this->subject, self::anything());
         $hook->expects(self::once())->method('modifyListFooter')->with($this->subject, self::anything());

--- a/Tests/LegacyUnit/Service/HookServiceTest.php
+++ b/Tests/LegacyUnit/Service/HookServiceTest.php
@@ -1,0 +1,170 @@
+<?php
+
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use OliverKlee\Seminars\Service\HookService;
+use OliverKlee\Seminars\Interfaces\Hook;
+use OliverKlee\Seminars\Interfaces\Hook\TestHook;
+use Tx_Seminars_Tests_Unit_Fixtures_Service_TestHookImplementor as TestHookImplementor;
+
+/**
+ * Test case.
+ *
+ * @author Michael Kramer <m.kramer@mxp.de>
+ */
+class Tx_Seminars_Tests_Unit_Service_HookServiceTest extends \Tx_Phpunit_TestCase
+{
+    /**
+     * @var array backed-up extension configuration of the TYPO3 configuration
+     *            variables
+     */
+    protected $extConfBackup = [];
+
+    protected function setUp()
+    {
+        $this->extConfBackup = $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['seminars'];
+    }
+
+    protected function tearDown()
+    {
+        $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['seminars'] = $this->extConfBackup;
+    }
+
+    /*
+     * Utility functions
+     */
+
+    /**
+     * Creates a TestHook implementor object.
+     *
+     * @return \Tx_Seminars_Tests_Unit_Fixtures_Service_TestingHookService
+     */
+    protected function createTestHookImplementor()
+    {
+        return GeneralUtility::makeInstance(
+            TestHookImplementor::class
+        );
+    }
+
+    /**
+     * Creates a TestHook accepting Hook object.
+     *
+     * @return \OliverKlee\Seminars\Service\HookService
+     */
+    protected function createHookObject()
+    {
+        return GeneralUtility::makeInstance(
+            HookService::class,
+            TestHook::class
+        );
+    }
+
+    /*
+     * Tests concerning the Hook implementors
+     */
+
+    /**
+     * @test
+     */
+    public function testHookImplementorCanBeCreated()
+    {
+        self::assertInstanceOf(
+            TestHookImplementor::class,
+            $this->createTestHookImplementor()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function testHookImplementorImplementsHookHierachie()
+    {
+        $implementor = $this->createTestHookImplementor();
+
+        self::assertInstanceOf(
+            Hook::class,
+            $implementor
+        );
+
+        self::assertInstanceOf(
+            TestHook::class,
+            $implementor
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function testHookImplementorImplementsRequiredTestApi()
+    {
+        $implementor = $this->createTestHookImplementor();
+
+        self::assertClassHasAttribute('wasCalled', TestHookImplementor::class);
+        self::assertObjectHasAttribute('wasCalled', $implementor);
+        self::assertFalse($implementor->wasCalled);
+    }
+
+    /**
+     * @test
+     */
+    public function testHookImplementorTestHookMethodCanBeCalledAndReportsBeingCalled()
+    {
+        $implementor = $this->createTestHookImplementor();
+
+        $implementor->testHookMethod();
+
+        self::assertTrue($implementor->wasCalled);
+    }
+
+    /*
+     * Tests concerning the Hook object
+     */
+
+    /**
+     * @test
+     */
+    public function hookObjectForTestHookCanBeCreated()
+    {
+        self::assertInstanceOf(
+            HookService::class,
+            $this->createHookObject()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function hookObjectForTestHookWithNoHookImplemetorRegisteredResultsInEmptyHookList()
+    {
+        unset($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['seminars'][TestHook::class]);
+        $hookObject = $this->createHookObject();
+
+        self::assertEmpty($hookObject->getHooks());
+    }
+
+    /**
+     * @test
+     */
+    public function hookObjectForTestHookWithOneHookImplemetorRegisteredResultsInOneHookInHookList()
+    {
+        $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['seminars'][TestHook::class][1565007112] =
+            TestHookImplementor::class;
+        $hookObject = $this->createHookObject();
+
+        self::assertCount(1, $hookObject->getHooks());
+        self::assertContainsOnlyInstancesOf(TestHook::class, $hookObject->getHooks());
+    }
+
+    /**
+     * @test
+     */
+    public function hookObjectForTestHookWithTwoHookImplemetorsRegisteredResultsInTwoHooksInHookList()
+    {
+        $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['seminars'][TestHook::class][1565007112] =
+        $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['seminars'][TestHook::class][1565007113] =
+            TestHookImplementor::class;
+        $hookObject = $this->createHookObject();
+
+        self::assertCount(2, $hookObject->getHooks());
+        self::assertContainsOnlyInstancesOf(TestHook::class, $hookObject->getHooks());
+    }
+}


### PR DESCRIPTION
I wanted to use the existing hooks (some time ago) and found them to be cluttered and incomplete. So I wrote a hook service class and added it to the DefaultController where I needed hooks.

It is based on the way the (most recently added?) hooks where already implemented.

Please discuss these issues with my implementation:

- Where to place the interfaces? PHP does not allow "interface" in the namespace, so using PSR-4 required some other place.
- Testing the hook service required a test hook interface. Where to place that?
- Are the hooks complete enough? Using interfaces makes it harder to add more places / methods to a hook (becoming backwards incompatible immidiately).

The tests for the hooks are still missing. I got caught by You switching to nimut and need to get the test run locally again before adding more tests...