### PR TITLE
[FEATURE] Add selector widget hook

### DIFF
--- a/Classes/FrontEnd/DefaultController.php
+++ b/Classes/FrontEnd/DefaultController.php
@@ -195,6 +195,13 @@ class Tx_Seminars_FrontEnd_DefaultController extends \Tx_Oelib_TemplateHelper im
     private $singleViewHooksHaveBeenRetrieved = false;
 
     /**
+     * Objects hooked to the single view
+     *
+     * @var \OliverKlee\Seminars\Service\HookService
+     */
+    protected $seminarSingleViewHooks = null;
+
+    /**
      * a link builder instance
      *
      * @var \Tx_Seminars_Service_SingleViewLinkBuilder
@@ -455,6 +462,24 @@ class Tx_Seminars_FrontEnd_DefaultController extends \Tx_Oelib_TemplateHelper im
         }
 
         return $this->singleViewHooks;
+    }
+
+    /**
+     * Gets the hooks for the single view.
+     *
+     * @return \OliverKlee\Seminars\Interfaces\Hook\SeminarSingleView[]
+     *         the hook objects, will be empty if no hooks have been set
+     */
+    protected function getSeminarSingleViewHooks()
+    {
+        if ($this->seminarSingleViewHooks === null) {
+            $this->seminarSingleViewHooks = GeneralUtility::makeInstance(
+                \OliverKlee\Seminars\Service\HookService::class,
+                \OliverKlee\Seminars\Interfaces\Hook\SeminarSingleView::class
+            );
+        }
+
+        return $this->seminarSingleViewHooks->getHooks();
     }
 
     /**
@@ -835,6 +860,10 @@ class Tx_Seminars_FrontEnd_DefaultController extends \Tx_Oelib_TemplateHelper im
 
         foreach ($this->getSingleViewHooks() as $hook) {
             $hook->modifyEventSingleView($event, $this->getTemplate());
+        }
+
+        foreach ($this->getSeminarSingleViewHooks() as $hook) {
+            $hook->modifySingleView($this, $this->getTemplate());
         }
 
         $result = $this->getSubpart('SINGLE_VIEW');

--- a/Classes/FrontEnd/DefaultController.php
+++ b/Classes/FrontEnd/DefaultController.php
@@ -202,6 +202,13 @@ class Tx_Seminars_FrontEnd_DefaultController extends \Tx_Oelib_TemplateHelper im
     protected $seminarSingleViewHooks = null;
 
     /**
+     * Objects hooked to the registration view
+     *
+     * @var \OliverKlee\Seminars\Service\HookService
+     */
+    protected $registrationViewHooks = null;
+
+    /**
      * a link builder instance
      *
      * @var \Tx_Seminars_Service_SingleViewLinkBuilder
@@ -480,6 +487,24 @@ class Tx_Seminars_FrontEnd_DefaultController extends \Tx_Oelib_TemplateHelper im
         }
 
         return $this->seminarSingleViewHooks->getHooks();
+    }
+
+    /**
+     * Gets the hooks for the registration view.
+     *
+     * @return \OliverKlee\Seminars\Interfaces\Hook\RegistrationView[]
+     *         the hook objects, will be empty if no hooks have been set
+     */
+    protected function getRegistrationViewHooks()
+    {
+        if ($this->registrationViewHooks === null) {
+            $this->registrationViewHooks = GeneralUtility::makeInstance(
+                \OliverKlee\Seminars\Service\HookService::class,
+                \OliverKlee\Seminars\Interfaces\Hook\RegistrationView::class
+            );
+        }
+
+        return $this->registrationViewHooks->getHooks();
     }
 
     /**
@@ -3060,7 +3085,7 @@ class Tx_Seminars_FrontEnd_DefaultController extends \Tx_Oelib_TemplateHelper im
 
         $result = $this->createRegistrationHeading($errorMessage);
         $result .= $registrationForm;
-        $result .= $this->getSubpart('REGISTRATION_BOTTOM');
+        $result .= $this->createRegistrationFooter();
 
         return $result;
     }
@@ -3092,6 +3117,10 @@ class Tx_Seminars_FrontEnd_DefaultController extends \Tx_Oelib_TemplateHelper im
             $this->setMarker('error_text', $errorMessage);
         }
 
+        foreach ($this->getRegistrationViewHooks() as $hook) {
+            $hook->modifyRegistrationHeading($this, $this->getTemplate());
+        }
+
         return $this->getSubpart('REGISTRATION_HEAD');
     }
 
@@ -3117,7 +3146,25 @@ class Tx_Seminars_FrontEnd_DefaultController extends \Tx_Oelib_TemplateHelper im
             $registrationEditor->setRegistration($this->registration);
         }
 
+        foreach ($this->getRegistrationViewHooks() as $hook) {
+            $hook->modifyRegistrationForm($this, $registrationEditor);
+        }
+
         return $registrationEditor->render();
+    }
+
+    /**
+     * Creates the registration page footer.
+     *
+     * @return string HTML code including the title and error message
+     */
+    protected function createRegistrationFooter()
+    {
+        foreach ($this->getRegistrationViewHooks() as $hook) {
+            $hook->modifyRegistrationFooter($this, $this->getTemplate());
+        }
+
+        return $this->getSubpart('REGISTRATION_BOTTOM');
     }
 
     /**

--- a/Classes/FrontEnd/DefaultController.php
+++ b/Classes/FrontEnd/DefaultController.php
@@ -174,6 +174,13 @@ class Tx_Seminars_FrontEnd_DefaultController extends \Tx_Oelib_TemplateHelper im
     private $listViewHooksHaveBeenRetrieved = false;
 
     /**
+     * Objects hooked to the seminar list view
+     *
+     * @var \OliverKlee\Seminars\Service\HookService
+     */
+    protected $seminarListViewHooks = null;
+
+    /**
      * hook objects for the single view
      *
      * @var \Tx_Seminars_Interface_Hook_EventSingleView[]
@@ -396,6 +403,24 @@ class Tx_Seminars_FrontEnd_DefaultController extends \Tx_Oelib_TemplateHelper im
         }
 
         return $this->listViewHooks;
+    }
+
+    /**
+     * Gets the hooks for the seminar list view.
+     *
+     * @return \OliverKlee\Seminars\Interfaces\Hook\SeminarListView[]
+     *         the hook objects, will be empty if no hooks have been set
+     */
+    protected function getSeminarListViewHooks()
+    {
+        if ($this->seminarListViewHooks === null) {
+            $this->seminarListViewHooks = GeneralUtility::makeInstance(
+                \OliverKlee\Seminars\Service\HookService::class,
+                \OliverKlee\Seminars\Interfaces\Hook\SeminarListView::class
+            );
+        }
+
+        return $this->seminarListViewHooks->getHooks();
     }
 
     /**
@@ -1992,6 +2017,10 @@ class Tx_Seminars_FrontEnd_DefaultController extends \Tx_Oelib_TemplateHelper im
             $this->setMarker('header_' . $column, $this->getFieldHeader($column));
         }
 
+        foreach ($this->getSeminarListViewHooks() as $hook) {
+            $hook->modifyListHeader($this, $this->getTemplate());
+        }
+
         return $this->getSubpart('LIST_HEADER');
     }
 
@@ -2002,6 +2031,10 @@ class Tx_Seminars_FrontEnd_DefaultController extends \Tx_Oelib_TemplateHelper im
      */
     protected function createListFooter()
     {
+        foreach ($this->getSeminarListViewHooks() as $hook) {
+            $hook->modifyListFooter($this, $this->getTemplate());
+        }
+
         return $this->getSubpart('LIST_FOOTER');
     }
 
@@ -2195,6 +2228,10 @@ class Tx_Seminars_FrontEnd_DefaultController extends \Tx_Oelib_TemplateHelper im
                 $hook->modifyListRow($event, $this->getTemplate());
             }
 
+            foreach ($this->getSeminarListViewHooks() as $hook) {
+                $hook->modifyListRow($this, $this->getTemplate());
+            }
+
             if ($whatToDisplay === 'my_events') {
                 /** @var \Tx_Seminars_Mapper_Registration $mapper */
                 $mapper = \Tx_Oelib_MapperRegistry::get(\Tx_Seminars_Mapper_Registration::class);
@@ -2203,6 +2240,10 @@ class Tx_Seminars_FrontEnd_DefaultController extends \Tx_Oelib_TemplateHelper im
 
                 foreach ($this->getListViewHooks() as $hook) {
                     $hook->modifyMyEventsListRow($registration, $this->getTemplate());
+                }
+
+                foreach ($this->getSeminarListViewHooks() as $hook) {
+                    $hook->modifyMySeminarsListRow($this, $this->getTemplate());
                 }
             }
 

--- a/Classes/FrontEnd/SelectorWidget.php
+++ b/Classes/FrontEnd/SelectorWidget.php
@@ -40,6 +40,13 @@ class Tx_Seminars_FrontEnd_SelectorWidget extends \Tx_Seminars_FrontEnd_Abstract
     private $places = null;
 
     /**
+     * Objects hooked to the selector widget builder
+     *
+     * @var \OliverKlee\Seminars\Service\HookService
+     */
+    private $selectorWidgetHooks = null;
+
+    /**
      * Returns the selector widget if it is not hidden.
      *
      * The selector widget will automatically be hidden, if no search option is
@@ -66,6 +73,10 @@ class Tx_Seminars_FrontEnd_SelectorWidget extends \Tx_Seminars_FrontEnd_Abstract
         $this->fillOrHideDateSearch();
         $this->fillOrHideAgeSearch();
         $this->fillOrHidePriceSearch();
+
+        foreach ($this->getSelectorWidgetHooks() as $hook) {
+            $hook->modifySelectorWidget($this, $this->seminarBag);
+        }
 
         return $this->getSubpart('SELECTOR_WIDGET');
     }
@@ -299,6 +310,24 @@ class Tx_Seminars_FrontEnd_SelectorWidget extends \Tx_Seminars_FrontEnd_Abstract
         $this->setMarker('dropdown_options', $optionsList);
 
         return $this->getSubpart('SINGLE_DROPDOWN');
+    }
+
+    /**
+     * Gets the hooks for the selector widget.
+     *
+     * @return \OliverKlee\Seminars\Interfaces\Hook\SelectorWidget[]
+     *         the hook objects, will be empty if no hooks have been set
+     */
+    protected function getSelectorWidgetHooks()
+    {
+        if ($this->selectorWidgetHooks === null) {
+            $this->selectorWidgetHooks = GeneralUtility::makeInstance(
+                \OliverKlee\Seminars\Service\HookService::class,
+                \OliverKlee\Seminars\Interfaces\Hook\SelectorWidget::class
+            );
+        }
+
+        return $this->selectorWidgetHooks->getHooks();
     }
 
     ///////////////////////////////////////////////////////////////

--- a/Classes/Interfaces/Hook.php
+++ b/Classes/Interfaces/Hook.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace OliverKlee\Seminars\Interfaces;
+
+/**
+ * Extend this interface to use Your interface with the HookService
+ *
+ * @author Michael Kramer <m.kramer@mxp.de>
+ */
+interface Hook
+{
+    // intentionally empty
+}

--- a/Classes/Interfaces/Hook/RegistrationView.php
+++ b/Classes/Interfaces/Hook/RegistrationView.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace OliverKlee\Seminars\Interfaces\Hook;
+
+use OliverKlee\Seminars\Interfaces\Hook;
+
+/**
+ * This interface needs to be used for hooks concerning the registration view.
+ *
+ * @author Michael Kramer <m.kramer@mxp.de>
+ */
+interface RegistrationView extends Hook
+{
+    /**
+     * Modifies the heading of the registration view.
+     *
+     * @param \Tx_Seminars_FrontEnd_DefaultController $controller
+     *        the calling controller
+     * @param \Tx_Oelib_Template $template
+     *        the template that will be used to create the heading output
+     *
+     * @return void
+     */
+    public function modifyRegistrationHeading(
+        \Tx_Seminars_FrontEnd_DefaultController $controller,
+        \Tx_Oelib_Template $template
+    );
+
+    /**
+     * Modifies the registration form.
+     *
+     * @param \Tx_Seminars_FrontEnd_DefaultController $controller
+     *        the calling controller
+     * @param \Tx_Seminars_FrontEnd_RegistrationForm $registrationEditor
+     *        the registration form renderer that will be used to create the form
+     *
+     * @return void
+     */
+    public function modifyRegistrationForm(
+        \Tx_Seminars_FrontEnd_DefaultController $controller,
+        \Tx_Seminars_FrontEnd_RegistrationForm $registrationEditor
+    );
+
+    /**
+     * Modifies the footer of the registration view.
+     *
+     * @param \Tx_Seminars_FrontEnd_DefaultController $controller
+     *        the calling controller
+     * @param \Tx_Oelib_Template $template
+     *        the template that will be used to create the footer output
+     *
+     * @return void
+     */
+    public function modifyRegistrationFooter(
+        \Tx_Seminars_FrontEnd_DefaultController $controller,
+        \Tx_Oelib_Template $template
+    );
+}

--- a/Classes/Interfaces/Hook/SelectorWidget.php
+++ b/Classes/Interfaces/Hook/SelectorWidget.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace OliverKlee\Seminars\Interfaces\Hook;
+
+use OliverKlee\Seminars\Interfaces\Hook;
+
+/**
+ * This interface needs to be used for hooks concerning the selector widget.
+ *
+ * @package TYPO3
+ * @subpackage tx_seminars
+ *
+ * @author Michael Kramer <m.kramer@mxp.de>
+ */
+interface SelectorWidget extends Hook
+{
+    /**
+     * Modifies the selector widget, just before the subpart is fetched.
+     *
+     * This function will be called for all types of seminar lists.
+     *
+     * @param \Tx_Seminars_FrontEnd_SelectorWidget $selectorWidget
+     *        the calling selector widget builder
+     * @param \Tx_Seminars_Bag_Event $seminarBag
+     *        the seminars used to create the selector widget
+     *
+     * @return void
+     */
+    public function modifySelectorWidget(
+        \Tx_Seminars_FrontEnd_SelectorWidget $selectorWidget,
+        \Tx_Seminars_Bag_Event $seminarBag
+    );
+}

--- a/Classes/Interfaces/Hook/SeminarListView.php
+++ b/Classes/Interfaces/Hook/SeminarListView.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace OliverKlee\Seminars\Interfaces\Hook;
+
+use OliverKlee\Seminars\Interfaces\Hook;
+
+/**
+ * This interface needs to be used for hooks concerning the seminar list view.
+ * It superseeds the outdated EventListView interface.
+ *
+ * @package TYPO3
+ * @subpackage tx_seminars
+ *
+ * @author Michael Kramer <m.kramer@mxp.de>
+ */
+interface SeminarListView extends Hook
+{
+    /**
+     * Modifies a list row in the seminar list.
+     *
+     * This function will be called for all types of seminar lists.
+     *
+     * @param \Tx_Seminars_FrontEnd_DefaultController $controller
+     *        the calling controller
+     * @param \Tx_Oelib_Template $template
+     *        the template that will be used to create the list row output
+     *
+     * @return void
+     */
+    public function modifyListRow(
+        \Tx_Seminars_FrontEnd_DefaultController $controller,
+        \Tx_Oelib_Template $template
+    );
+
+    /**
+     * Modifies a list view row in the "my seminars" list.
+     *
+     * @param \Tx_Seminars_FrontEnd_DefaultController $controller
+     *        the calling controller
+     * @param \Tx_Oelib_Template $template
+     *        the template that will be used to create the list row output
+     *
+     * @return void
+     */
+    public function modifyMySeminarsListRow(
+        \Tx_Seminars_FrontEnd_DefaultController $controller,
+        \Tx_Oelib_Template $template
+    );
+
+    /**
+     * Modifies the list view header row in the seminars list.
+     *
+     * This function will be called for all types of seminar lists.
+     *
+     * @param \Tx_Seminars_FrontEnd_DefaultController $controller
+     *        the calling controller
+     * @param \Tx_Oelib_Template $template
+     *        the template from which the list header is built
+     *
+     * @return void
+     */
+    public function modifyListHeader(
+        \Tx_Seminars_FrontEnd_DefaultController $controller,
+        \Tx_Oelib_Template $template
+    );
+
+    /**
+     * Modifies the list view footer in the seminars list.
+     *
+     * This function will be called for all types of seminar lists.
+     *
+     * @param \Tx_Seminars_FrontEnd_DefaultController $controller
+     *        the calling controller
+     * @param \Tx_Oelib_Template $template
+     *        the template from which the list footer is built
+     *
+     * @return void
+     */
+    public function modifyListFooter(
+        \Tx_Seminars_FrontEnd_DefaultController $controller,
+        \Tx_Oelib_Template $template
+    );
+}

--- a/Classes/Interfaces/Hook/SeminarSingleView.php
+++ b/Classes/Interfaces/Hook/SeminarSingleView.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace OliverKlee\Seminars\Interfaces\Hook;
+
+use OliverKlee\Seminars\Interfaces\Hook;
+
+/**
+ * This interface needs to be used for hooks concerning the seminar single view.
+ * It superseeds the outdated EventSingleView interface.
+ *
+ * @package TYPO3
+ * @subpackage tx_seminars
+ *
+ * @author Michael Kramer <m.kramer@mxp.de>
+ */
+interface SeminarSingleView extends Hook
+{
+    /**
+     * Modifies the seminar details view.
+     *
+     * This function will be called for all types of seminars.
+     *
+     * @param \Tx_Seminars_FrontEnd_DefaultController $controller
+     *        the calling controller
+     * @param \Tx_Oelib_Template $template
+     *        the template that will be used to create the list row output
+     *
+     * @return void
+     */
+    public function modifySingleView(
+        \Tx_Seminars_FrontEnd_DefaultController $controller,
+        \Tx_Oelib_Template $template
+    );
+}

--- a/Classes/Interfaces/Hook/TestHook.php
+++ b/Classes/Interfaces/Hook/TestHook.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace OliverKlee\Seminars\Interfaces\Hook;
+
+use OliverKlee\Seminars\Interfaces\Hook;
+
+/**
+ * Test interface to use with the HookService
+ *
+ * @author Michael Kramer <m.kramer@mxp.de>
+ */
+interface TestHook extends Hook
+{
+    /**
+     * Test Hook Method
+     *
+     * This function will be called during HookService tests.
+     *
+     * @return void
+     */
+    public function testHookMethod();
+}

--- a/Classes/Service/HookService.php
+++ b/Classes/Service/HookService.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace OliverKlee\Seminars\Service;
+
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use OliverKlee\Seminars\Interfaces\Hook;
+
+/**
+ * This class provides functions for unified hooks.
+ *
+ * It refactors the wide-spread use of this type of hooks in seminars.
+ *
+ * @author Oliver Klee <typo3-coding@oliverklee.de>
+ * @author Michael Kramer <m.kramer@mxp.de>
+ */
+class HookService
+{
+    /**
+     * Interface name to this hook
+     *
+     * @var string
+     */
+    protected $interfaceName = '';
+
+    /**
+     * Index in $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['seminars'] of hooked-in classes
+     *
+     * @var string
+     */
+    protected $index = '';
+
+    /**
+     * Hook objects built
+     *
+     * @var array
+     */
+    protected $hookObjects = [];
+
+    /**
+     * Whether the hooks have been retrieved
+     *
+     * @var boolean
+     */
+    protected $hooksHaveBeenRetrieved = false;
+
+    /**
+     * The constructor.
+     *
+     * @throws \UnexpectedValueException
+     *         if $interfaceName does not extend Hook interface
+     *
+     * @param $interfaceName interface the hook needs implemented
+     * @param $index optional index to $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['seminars']
+     *               if not using the interface name (for backwards compatibility)
+     *               (the interface name is recommended)
+     */
+    public function __construct($interfaceName, $index = '')
+    {
+        if (!interface_exists($interfaceName)) {
+            throw new \UnexpectedValueException(
+                'The interface ' . $interfaceName . ' does not exist.',
+                1565089078
+            );
+        }
+
+        if (!in_array(Hook::class, class_implements($interfaceName), true)) {
+            throw new \UnexpectedValueException(
+                'The interface ' . $interfaceName . ' does not extend '
+                    . Hook::class . ' interface.',
+                1565088963
+            );
+        }
+
+        $this->interfaceName = $interfaceName;
+        $this->index = $interfaceName;
+        if ($index != '') {
+            $this->index = $index;
+        }
+    }
+
+    /**
+     * Gets the hook objects for the interface.
+     *
+     * @throws \UnexpectedValueException
+     *         if there are registered hook classes that do not implement the
+     *         $this->interfaceName interface
+     *
+     * @return array
+     *         the hook objects, will be empty if no hooks have been set
+     */
+    public function getHooks()
+    {
+        if (!$this->hooksHaveBeenRetrieved) {
+            $hookClasses = $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['seminars'][$this->index];
+            if (is_array($hookClasses)) {
+                foreach ($hookClasses as $hookClass) {
+                    $hookInstance = GeneralUtility::makeInstance($hookClass);
+                    if (!($hookInstance instanceof $this->interfaceName)) {
+                        throw new \UnexpectedValueException(
+                            'The class ' . get_class($hookInstance) . ' is registered for the ' . $this->index .
+                                ' hook list, but does not implement the ' . $this->interfaceName . ' interface.',
+                            1448901897
+                        );
+                    }
+                    $this->hookObjects[] = $hookInstance;
+                }
+            }
+
+            $this->hooksHaveBeenRetrieved = true;
+        }
+
+        return $this->hookObjects;
+    }
+}
+
+if (defined('TYPO3_MODE')
+    && $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/seminars/Classes/Service/Hook.php']
+) {
+    include_once($GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/seminars/Classes/Service/Hook.php']);
+}

--- a/Tests/LegacyUnit/Fixtures/Service/TestHookImplementor.php
+++ b/Tests/LegacyUnit/Fixtures/Service/TestHookImplementor.php
@@ -1,0 +1,19 @@
+<?php
+
+use OliverKlee\Seminars\Interfaces\Hook\TestHook;
+
+/**
+ * This class just makes some public stuff for testing purposes.
+ *
+ * @author Michael Kramer <m.kramer@mxp.de>
+ */
+class Tx_Seminars_Tests_Unit_Fixtures_Service_TestHookImplementor implements TestHook
+{
+    public $wasCalled = false;
+
+    public function testHookMethod()
+    {
+        $this->wasCalled = true;
+        return;
+    }
+}

--- a/Tests/LegacyUnit/FrontEnd/DefaultControllerTest.php
+++ b/Tests/LegacyUnit/FrontEnd/DefaultControllerTest.php
@@ -7573,6 +7573,45 @@ class Tx_Seminars_Tests_Unit_FrontEnd_DefaultControllerTest extends TestCase
         );
     }
 
+    /**
+     * @test
+     */
+    public function registrationFormCallsRegistrationViewHookModifyRegistrationHeadingFormFooter()
+    {
+        $registrationFormMock = $this->createMock(\Tx_Seminars_FrontEnd_RegistrationForm::class);
+        GeneralUtility::addInstance(\Tx_Seminars_FrontEnd_RegistrationForm::class, $registrationFormMock);
+
+        $this->testingFramework->createAndLoginFrontEndUser();
+        $this->subject->setConfigurationValue('what_to_display', 'seminar_registration');
+
+        $eventUid = $this->testingFramework->createRecord(
+            'tx_seminars_seminars',
+            [
+                'object_type' => \Tx_Seminars_Model_Event::TYPE_COMPLETE,
+                'title' => 'foo & bar',
+                'begin_date' => $GLOBALS['SIM_EXEC_TIME'] + 1000,
+                'end_date' => $GLOBALS['SIM_EXEC_TIME'] + 2000,
+                'needs_registration' => 1,
+                'attendees_max' => 10,
+            ]
+        );
+
+        $this->subject->piVars['seminar'] = $eventUid;
+
+        $hook = $this->createMock(\OliverKlee\Seminars\Interfaces\Hook\RegistrationView::class);
+        $hook->expects(self::once())->method('modifyRegistrationHeading')->with($this->subject, self::anything());
+        $hook->expects(self::once())->method('modifyRegistrationForm')->with($this->subject, self::anything());
+        $hook->expects(self::once())->method('modifyRegistrationFooter')->with($this->subject, self::anything());
+        // We don't test for the second parameter (the template instance here)
+        // because we cannot access it from the outside.
+
+        $hookClass = get_class($hook);
+        $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['seminars'][\OliverKlee\Seminars\Interfaces\Hook\RegistrationView::class][] = $hookClass;
+        GeneralUtility::addInstance($hookClass, $hook);
+
+        $this->subject->main('', []);
+    }
+
     /*
      * Tests concerning getVacanciesClasses
      */

--- a/Tests/LegacyUnit/FrontEnd/DefaultControllerTest.php
+++ b/Tests/LegacyUnit/FrontEnd/DefaultControllerTest.php
@@ -1297,6 +1297,28 @@ class Tx_Seminars_Tests_Unit_FrontEnd_DefaultControllerTest extends TestCase
         $this->subject->main('', []);
     }
 
+    /**
+     * @test
+     */
+    public function singleViewCallsSeminarSingleViewHookModifySingleView()
+    {
+        $this->subject->setConfigurationValue('what_to_display', 'single_view');
+
+        /** @var \Tx_Seminars_Model_Event $event */
+        $event = \Tx_Oelib_MapperRegistry::get(\Tx_Seminars_Mapper_Event::class)->find($this->seminarUid);
+        $hook = $this->createMock(\OliverKlee\Seminars\Interfaces\Hook\SeminarSingleView::class);
+        $hook->expects(self::once())->method('modifySingleView')->with($this->subject, self::anything());
+        // We don't test for the second parameter (the template instance here)
+        // because we cannot access it from the outside.
+
+        $hookClass = get_class($hook);
+        $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['seminars'][\OliverKlee\Seminars\Interfaces\Hook\SeminarSingleView::class][] = $hookClass;
+        GeneralUtility::addInstance($hookClass, $hook);
+
+        $this->subject->piVars['showUid'] = $this->seminarUid;
+        $this->subject->main('', []);
+    }
+
     ///////////////////////////////////////////////////////
     // Tests concerning attached files in the single view
     ///////////////////////////////////////////////////////

--- a/Tests/LegacyUnit/FrontEnd/DefaultControllerTest.php
+++ b/Tests/LegacyUnit/FrontEnd/DefaultControllerTest.php
@@ -3439,6 +3439,27 @@ class Tx_Seminars_Tests_Unit_FrontEnd_DefaultControllerTest extends TestCase
         );
     }
 
+    /**
+     * @test
+     */
+    public function listViewCallsSeminarListViewHookModifyListHeaderRowFooter()
+    {
+        $this->subject->setConfigurationValue('what_to_display', 'seminar_list');
+
+        $hook = $this->createMock(\OliverKlee\Seminars\Interfaces\Hook\SeminarListView::class);
+        $hook->expects(self::once())->method('modifyListHeader')->with($this->subject, self::anything());
+        $hook->expects(self::once())->method('modifyListRow')->with($this->subject, self::anything());
+        $hook->expects(self::once())->method('modifyListFooter')->with($this->subject, self::anything());
+        // We don't test for the second parameter (the template instance here)
+        // because we cannot access it from the outside.
+
+        $hookClass = get_class($hook);
+        $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['seminars'][\OliverKlee\Seminars\Interfaces\Hook\SeminarListView::class][] = $hookClass;
+        GeneralUtility::addInstance($hookClass, $hook);
+
+        $this->subject->main('', []);
+    }
+
     /////////////////////////////////////////////////////////
     // Tests concerning the result counter in the list view
     /////////////////////////////////////////////////////////
@@ -6131,6 +6152,26 @@ class Tx_Seminars_Tests_Unit_FrontEnd_DefaultControllerTest extends TestCase
             '01.01.2008',
             $this->subject->main('', [])
         );
+    }
+
+    /**
+     * @test
+     */
+    public function testMyEventsCallsSeminarListViewHookModifyMySeminarsListRow()
+    {
+        $this->createLogInAndRegisterFeUser();
+        $this->subject->setConfigurationValue('what_to_display', 'my_events');
+
+        $hook = $this->createMock(\OliverKlee\Seminars\Interfaces\Hook\SeminarListView::class);
+        $hook->expects(self::once())->method('modifyMySeminarsListRow')->with($this->subject, self::anything());
+        // We don't test for the second parameter (the template instance here)
+        // because we cannot access it from the outside.
+
+        $hookClass = get_class($hook);
+        $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['seminars'][\OliverKlee\Seminars\Interfaces\Hook\SeminarListView::class][] = $hookClass;
+        GeneralUtility::addInstance($hookClass, $hook);
+
+        $this->subject->main('', []);
     }
 
     /////////////////////////////////////////////////////////////////////////////////

--- a/Tests/LegacyUnit/FrontEnd/SelectorWidgetTest.php
+++ b/Tests/LegacyUnit/FrontEnd/SelectorWidgetTest.php
@@ -2,6 +2,7 @@
 
 use OliverKlee\PhpUnit\TestCase;
 use SJBR\StaticInfoTables\PiBaseApi;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
  * Test case.
@@ -211,6 +212,28 @@ class Tx_Seminars_Tests_Unit_FrontEnd_SelectorWidgetTest extends TestCase
             '###',
             $this->subject->render()
         );
+    }
+
+    /**
+     * @test
+     */
+    public function renderForEnabledSearchWidgetCallsSelectorWidgetHookModifySelectorWidget()
+    {
+        $this->subject->setConfigurationValue(
+            'displaySearchFormFields',
+            'city'
+        );
+
+        $hook = $this->createMock(\OliverKlee\Seminars\Interfaces\Hook\SelectorWidget::class);
+        $hook->expects(self::once())->method('modifySelectorWidget')->with($this->subject, self::anything());
+        // We don't test for the second parameter (the seminar bag here)
+        // because we cannot access it from the outside.
+
+        $hookClass = get_class($hook);
+        $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['seminars'][\OliverKlee\Seminars\Interfaces\Hook\SelectorWidget::class][] = $hookClass;
+        GeneralUtility::addInstance($hookClass, $hook);
+
+        $this->subject->render();
     }
 
     /////////////////////////////////////////////

--- a/Tests/LegacyUnit/Service/HookServiceTest.php
+++ b/Tests/LegacyUnit/Service/HookServiceTest.php
@@ -1,0 +1,170 @@
+<?php
+
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use OliverKlee\Seminars\Service\HookService;
+use OliverKlee\Seminars\Interfaces\Hook;
+use OliverKlee\Seminars\Interfaces\Hook\TestHook;
+use Tx_Seminars_Tests_Unit_Fixtures_Service_TestHookImplementor as TestHookImplementor;
+
+/**
+ * Test case.
+ *
+ * @author Michael Kramer <m.kramer@mxp.de>
+ */
+class Tx_Seminars_Tests_Unit_Service_HookServiceTest extends \Tx_Phpunit_TestCase
+{
+    /**
+     * @var array backed-up extension configuration of the TYPO3 configuration
+     *            variables
+     */
+    protected $extConfBackup = [];
+
+    protected function setUp()
+    {
+        $this->extConfBackup = $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['seminars'];
+    }
+
+    protected function tearDown()
+    {
+        $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['seminars'] = $this->extConfBackup;
+    }
+
+    /*
+     * Utility functions
+     */
+
+    /**
+     * Creates a TestHook implementor object.
+     *
+     * @return \Tx_Seminars_Tests_Unit_Fixtures_Service_TestingHookService
+     */
+    protected function createTestHookImplementor()
+    {
+        return GeneralUtility::makeInstance(
+            TestHookImplementor::class
+        );
+    }
+
+    /**
+     * Creates a TestHook accepting Hook object.
+     *
+     * @return \OliverKlee\Seminars\Service\HookService
+     */
+    protected function createHookObject()
+    {
+        return GeneralUtility::makeInstance(
+            HookService::class,
+            TestHook::class
+        );
+    }
+
+    /*
+     * Tests concerning the Hook implementors
+     */
+
+    /**
+     * @test
+     */
+    public function testHookImplementorCanBeCreated()
+    {
+        self::assertInstanceOf(
+            TestHookImplementor::class,
+            $this->createTestHookImplementor()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function testHookImplementorImplementsHookHierachie()
+    {
+        $implementor = $this->createTestHookImplementor();
+
+        self::assertInstanceOf(
+            Hook::class,
+            $implementor
+        );
+
+        self::assertInstanceOf(
+            TestHook::class,
+            $implementor
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function testHookImplementorImplementsRequiredTestApi()
+    {
+        $implementor = $this->createTestHookImplementor();
+
+        self::assertClassHasAttribute('wasCalled', TestHookImplementor::class);
+        self::assertObjectHasAttribute('wasCalled', $implementor);
+        self::assertFalse($implementor->wasCalled);
+    }
+
+    /**
+     * @test
+     */
+    public function testHookImplementorTestHookMethodCanBeCalledAndReportsBeingCalled()
+    {
+        $implementor = $this->createTestHookImplementor();
+
+        $implementor->testHookMethod();
+
+        self::assertTrue($implementor->wasCalled);
+    }
+
+    /*
+     * Tests concerning the Hook object
+     */
+
+    /**
+     * @test
+     */
+    public function hookObjectForTestHookCanBeCreated()
+    {
+        self::assertInstanceOf(
+            HookService::class,
+            $this->createHookObject()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function hookObjectForTestHookWithNoHookImplemetorRegisteredResultsInEmptyHookList()
+    {
+        unset($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['seminars'][TestHook::class]);
+        $hookObject = $this->createHookObject();
+
+        self::assertEmpty($hookObject->getHooks());
+    }
+
+    /**
+     * @test
+     */
+    public function hookObjectForTestHookWithOneHookImplemetorRegisteredResultsInOneHookInHookList()
+    {
+        $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['seminars'][TestHook::class][1565007112] =
+            TestHookImplementor::class;
+        $hookObject = $this->createHookObject();
+
+        self::assertCount(1, $hookObject->getHooks());
+        self::assertContainsOnlyInstancesOf(TestHook::class, $hookObject->getHooks());
+    }
+
+    /**
+     * @test
+     */
+    public function hookObjectForTestHookWithTwoHookImplemetorsRegisteredResultsInTwoHooksInHookList()
+    {
+        $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['seminars'][TestHook::class][1565007112] =
+        $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['seminars'][TestHook::class][1565007113] =
+            TestHookImplementor::class;
+        $hookObject = $this->createHookObject();
+
+        self::assertCount(2, $hookObject->getHooks());
+        self::assertContainsOnlyInstancesOf(TestHook::class, $hookObject->getHooks());
+    }
+}


### PR DESCRIPTION
After: #238

Allows hooking into selector widget generation. Where to respect the incoming PiVars (actually filtering the list results as requested)? I didn't need that, as I was filtering in JavaScript without posting the form back to Typo3.