### PR TITLE
[CLEANUP] Clean up switch/case constructs

### DIFF
--- a/Classes/BagBuilder/Event.php
+++ b/Classes/BagBuilder/Event.php
@@ -284,7 +284,6 @@ class Tx_Seminars_BagBuilder_Event extends \Tx_Seminars_BagBuilder_Abstract
             default:
                 // To show all events, we don't need any additional parameters.
                 $where = '';
-                break;
         }
 
         if ($where != '') {

--- a/Classes/FrontEnd/DefaultController.php
+++ b/Classes/FrontEnd/DefaultController.php
@@ -321,9 +321,8 @@ class Tx_Seminars_FrontEnd_DefaultController extends \Tx_Oelib_TemplateHelper im
                 // We still use the processEventEditorActions call in the next case.
             case 'my_entered_events':
                 $this->processEventEditorActions();
-            // The fallthrough is intended
-            // because createListView() will differentiate later.
-            // no break
+                // The fallthrough is intended
+                // because createListView() will differentiate later.
             case 'topic_list':
                 // The fallthrough is intended
                 // because createListView() will differentiate later.

--- a/Classes/OldModel/Event.php
+++ b/Classes/OldModel/Event.php
@@ -144,7 +144,6 @@ class Tx_Seminars_OldModel_Event extends \Tx_Seminars_OldModel_AbstractTimeSpan
                 break;
             default:
                 // no action if no case is matched
-                break;
         }
 
         return $result;
@@ -742,7 +741,6 @@ class Tx_Seminars_OldModel_Event extends \Tx_Seminars_OldModel_AbstractTimeSpan
                 // The fallthrough is intended.
             default:
                 $mmTable = 'tx_seminars_seminars_speakers_mm';
-                break;
         }
 
         return GeneralUtility::makeInstance(
@@ -961,7 +959,6 @@ class Tx_Seminars_OldModel_Event extends \Tx_Seminars_OldModel_AbstractTimeSpan
                 // The fallthrough is intended.
             default:
                 $hasSpeakers = $this->hasSpeakers();
-                break;
         }
 
         return $hasSpeakers;
@@ -2538,7 +2535,6 @@ class Tx_Seminars_OldModel_Event extends \Tx_Seminars_OldModel_AbstractTimeSpan
                     break;
                 default:
                     $value = $this->getRecordPropertyString($currentKey);
-                    break;
             }
 
             // Check whether there is a value to display. If not, we don't use
@@ -2702,7 +2698,6 @@ class Tx_Seminars_OldModel_Event extends \Tx_Seminars_OldModel_AbstractTimeSpan
                     $registrationsVipListPID,
                     $defaultEventVipsFeGroupID
                 );
-                break;
         }
 
         return $result;
@@ -3787,7 +3782,6 @@ class Tx_Seminars_OldModel_Event extends \Tx_Seminars_OldModel_AbstractTimeSpan
                 break;
             default:
                 $result = '';
-                break;
         }
 
         $carriageReturnRemoved = (strpos($result, CR) === false)

--- a/Classes/OldModel/Registration.php
+++ b/Classes/OldModel/Registration.php
@@ -417,7 +417,6 @@ class Tx_Seminars_OldModel_Registration extends \Tx_Seminars_OldModel_Abstract
                 break;
             default:
                 $result = $this->getRecordPropertyString($trimmedKey);
-                break;
         }
 
         $carriageReturnRemoved = str_replace(CR, LF, (string)$result);


### PR DESCRIPTION
- properly indent fall-through comments
- remove the `break` from the default case