### PR TITLE
[FEATURE] Add new seminar single view hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ## x.y.z
 
 ### Added
+- Add new seminar single view hook (#338)
 - Add hook base (#313, #336)
 - Support TYPO3 9LTS (#322)
 - Add code sniffing and fixing (#319)
@@ -25,6 +26,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Update the testing libraries (#251, #252, #254)
 
 ### Deprecated
+- `EventSingleView` interface and 'singleView' hook index (#338)
 
 ### Removed
 - Drop unneeded Travis CI configuration settings (#258, #259, #260, #261)

--- a/Classes/FrontEnd/DefaultController.php
+++ b/Classes/FrontEnd/DefaultController.php
@@ -3,6 +3,8 @@
 declare(strict_types=1);
 
 use OliverKlee\Seminars\Bag\AbstractBag;
+use OliverKlee\Seminars\Hooks\HookProvider;
+use OliverKlee\Seminars\Hooks\Interfaces\SeminarSingleView;
 use OliverKlee\Seminars\OldModel\AbstractModel;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Utility\MathUtility;
@@ -190,6 +192,11 @@ class Tx_Seminars_FrontEnd_DefaultController extends \Tx_Oelib_TemplateHelper im
      * @var bool
      */
     private $singleViewHooksHaveBeenRetrieved = false;
+
+    /**
+     * @var HookProvider|null
+     */
+    protected $singleViewHookProvider = null;
 
     /**
      * a link builder instance
@@ -428,6 +435,20 @@ class Tx_Seminars_FrontEnd_DefaultController extends \Tx_Oelib_TemplateHelper im
         }
 
         return $this->singleViewHooks;
+    }
+
+    /**
+     * Gets the hook provider for the single view.
+     *
+     * @return HookProvider
+     */
+    protected function getSingleViewHookProvider(): HookProvider
+    {
+        if (!$this->singleViewHookProvider instanceof HookProvider) {
+            $this->singleViewHookProvider = GeneralUtility::makeInstance(HookProvider::class, SeminarSingleView::class);
+        }
+
+        return $this->singleViewHookProvider;
     }
 
     /**
@@ -810,6 +831,8 @@ class Tx_Seminars_FrontEnd_DefaultController extends \Tx_Oelib_TemplateHelper im
         foreach ($this->getSingleViewHooks() as $hook) {
             $hook->modifyEventSingleView($event, $this->getTemplate());
         }
+
+        $this->getSingleViewHookProvider()->executeHook('modifySingleView', $this);
 
         $result = $this->getSubpart('SINGLE_VIEW');
 

--- a/Classes/FrontEnd/DefaultController.php
+++ b/Classes/FrontEnd/DefaultController.php
@@ -417,7 +417,7 @@ class Tx_Seminars_FrontEnd_DefaultController extends \Tx_Oelib_TemplateHelper im
      *          if there are registered hook classes that do not implement the
      *          \Tx_Seminars_Interface_Hook_EventSingleView interface
      *
-     * @deprecated will be removed in seminars 4; use ->getSingleViewHookProvider() instead
+     * @deprecated will be removed in seminars 4; use `->getSingleViewHookProvider()` instead
      */
     protected function getSingleViewHooks(): array
     {

--- a/Classes/FrontEnd/DefaultController.php
+++ b/Classes/FrontEnd/DefaultController.php
@@ -183,6 +183,8 @@ class Tx_Seminars_FrontEnd_DefaultController extends \Tx_Oelib_TemplateHelper im
      * hook objects for the single view
      *
      * @var \Tx_Seminars_Interface_Hook_EventSingleView[]
+     *
+     * @deprecated will be removed in seminars 4; see ->getSingleViewHookProvider()
      */
     private $singleViewHooks = [];
 
@@ -190,6 +192,8 @@ class Tx_Seminars_FrontEnd_DefaultController extends \Tx_Oelib_TemplateHelper im
      * whether the hooks in $this->singleViewHooks have been retrieved
      *
      * @var bool
+     *
+     * @deprecated will be removed in seminars 4; see ->getSingleViewHookProvider()
      */
     private $singleViewHooksHaveBeenRetrieved = false;
 
@@ -412,6 +416,9 @@ class Tx_Seminars_FrontEnd_DefaultController extends \Tx_Oelib_TemplateHelper im
      * @throws \UnexpectedValueException
      *          if there are registered hook classes that do not implement the
      *          \Tx_Seminars_Interface_Hook_EventSingleView interface
+     *
+     * @deprecated will be removed in seminars 4; use ->getSingleViewHookProvider() instead
+
      */
     protected function getSingleViewHooks(): array
     {
@@ -419,6 +426,7 @@ class Tx_Seminars_FrontEnd_DefaultController extends \Tx_Oelib_TemplateHelper im
             $hookClasses = $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['seminars']['singleView'];
             if (is_array($hookClasses)) {
                 foreach ($hookClasses as $hookClass) {
+                    GeneralUtility::deprecationLog($hookClass ' - since seminars 3.0, interface \\Tx_Seminars_Interface_Hook_EventSingleView will be removed in seminars 4.0');
                     $hookInstance = GeneralUtility::getUserObj($hookClass);
                     if (!($hookInstance instanceof \Tx_Seminars_Interface_Hook_EventSingleView)) {
                         throw new \UnexpectedValueException(

--- a/Classes/FrontEnd/DefaultController.php
+++ b/Classes/FrontEnd/DefaultController.php
@@ -426,7 +426,7 @@ class Tx_Seminars_FrontEnd_DefaultController extends \Tx_Oelib_TemplateHelper im
             $hookClasses = $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['seminars']['singleView'];
             if (is_array($hookClasses)) {
                 foreach ($hookClasses as $hookClass) {
-                    GeneralUtility::deprecationLog($hookClass ' - since seminars 3.0, interface \\Tx_Seminars_Interface_Hook_EventSingleView will be removed in seminars 4.0');
+                    GeneralUtility::deprecationLog($hookClass . ' - since seminars 3.0, interface \\Tx_Seminars_Interface_Hook_EventSingleView will be removed in seminars 4.0');
                     $hookInstance = GeneralUtility::getUserObj($hookClass);
                     if (!($hookInstance instanceof \Tx_Seminars_Interface_Hook_EventSingleView)) {
                         throw new \UnexpectedValueException(

--- a/Classes/FrontEnd/DefaultController.php
+++ b/Classes/FrontEnd/DefaultController.php
@@ -418,7 +418,6 @@ class Tx_Seminars_FrontEnd_DefaultController extends \Tx_Oelib_TemplateHelper im
      *          \Tx_Seminars_Interface_Hook_EventSingleView interface
      *
      * @deprecated will be removed in seminars 4; use ->getSingleViewHookProvider() instead
-
      */
     protected function getSingleViewHooks(): array
     {
@@ -426,7 +425,10 @@ class Tx_Seminars_FrontEnd_DefaultController extends \Tx_Oelib_TemplateHelper im
             $hookClasses = $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['seminars']['singleView'];
             if (is_array($hookClasses)) {
                 foreach ($hookClasses as $hookClass) {
-                    GeneralUtility::deprecationLog($hookClass . ' - since seminars 3.0, interface \\Tx_Seminars_Interface_Hook_EventSingleView will be removed in seminars 4.0');
+                    GeneralUtility::deprecationLog(
+                        $hookClass . ' - since seminars 3.0, interface \\Tx_Seminars_Interface_Hook_EventSingleView'
+                            . ' will be removed in seminars 4.0'
+                    );
                     $hookInstance = GeneralUtility::getUserObj($hookClass);
                     if (!($hookInstance instanceof \Tx_Seminars_Interface_Hook_EventSingleView)) {
                         throw new \UnexpectedValueException(
@@ -452,7 +454,7 @@ class Tx_Seminars_FrontEnd_DefaultController extends \Tx_Oelib_TemplateHelper im
      */
     protected function getSingleViewHookProvider(): HookProvider
     {
-        if (!$this->singleViewHookProvider instanceof HookProvider) {
+        if ($this->singleViewHookProvider === null) {
             $this->singleViewHookProvider = GeneralUtility::makeInstance(HookProvider::class, SeminarSingleView::class);
         }
 

--- a/Classes/Hooks/Interfaces/SeminarSingleView.php
+++ b/Classes/Hooks/Interfaces/SeminarSingleView.php
@@ -9,7 +9,7 @@ use OliverKlee\Seminars\Hooks\Interfaces\Hook;
 /**
  * Use this interface for hooks concerning the seminar single view.
  *
- * It supersedes the deprecated EventSingleView interface.
+ * It supersedes the deprecated `EventSingleView` interface.
  *
  * @author Michael Kramer <m.kramer@mxp.de>
  */
@@ -18,7 +18,7 @@ interface SeminarSingleView extends Hook
     /**
      * Modifies the seminar details view.
      *
-     * This function will be called for all types of seminars.
+     * This function will be called for all types of seminars (single events, topics, and dates).
      *
      * @param \Tx_Seminars_FrontEnd_DefaultController $controller the calling controller
      *

--- a/Classes/Hooks/Interfaces/SeminarSingleView.php
+++ b/Classes/Hooks/Interfaces/SeminarSingleView.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OliverKlee\Seminars\Hooks\Interfaces;
+
+use OliverKlee\Seminars\Hooks\Interfaces\Hook;
+
+/**
+ * Use this interface for hooks concerning the seminar single view.
+ *
+ * It superseeds the deprecated EventSingleView interface.
+ *
+ * @author Michael Kramer <m.kramer@mxp.de>
+ */
+interface SeminarSingleView extends Hook
+{
+    /**
+     * Modifies the seminar details view.
+     *
+     * This function will be called for all types of seminars.
+     *
+     * @param \Tx_Seminars_FrontEnd_DefaultController $controller the calling controller
+     *
+     * @return void
+     */
+    public function modifySingleView(\Tx_Seminars_FrontEnd_DefaultController $controller);
+}

--- a/Classes/Hooks/Interfaces/SeminarSingleView.php
+++ b/Classes/Hooks/Interfaces/SeminarSingleView.php
@@ -9,7 +9,7 @@ use OliverKlee\Seminars\Hooks\Interfaces\Hook;
 /**
  * Use this interface for hooks concerning the seminar single view.
  *
- * It superseeds the deprecated EventSingleView interface.
+ * It supersedes the deprecated EventSingleView interface.
  *
  * @author Michael Kramer <m.kramer@mxp.de>
  */

--- a/Classes/Interface/Hook/EventSingleView.php
+++ b/Classes/Interface/Hook/EventSingleView.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 /**
  * This interface needs to be used for hooks concerning the event single view.
  *
+ * @deprecated will be removed in seminars 4; use hooks from `Hooks\Interfaces\Hook\SeminarSingleView` instead
+ *
  * @author Oliver Klee <typo3-coding@oliverklee.de>
  */
 interface Tx_Seminars_Interface_Hook_EventSingleView
@@ -18,6 +20,8 @@ interface Tx_Seminars_Interface_Hook_EventSingleView
      *        the template that will be used to create the single view output
      *
      * @return void
+     *
+     * @deprecated will be removed in seminars 4; use SeminarSingleView::modifySingleView instead
      */
     public function modifyEventSingleView(\Tx_Seminars_Model_Event $event, \Tx_Oelib_Template $template);
 
@@ -31,6 +35,8 @@ interface Tx_Seminars_Interface_Hook_EventSingleView
      *        the template that will be used to create the list row output
      *
      * @return void
+     *
+     * @deprecated will be removed in seminars 4; no replacement
      */
     public function modifyTimeSlotListRow(\Tx_Seminars_Model_TimeSlot $timeSlot, \Tx_Oelib_Template $template);
 }

--- a/Classes/Interface/Hook/EventSingleView.php
+++ b/Classes/Interface/Hook/EventSingleView.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * This interface needs to be used for hooks concerning the event single view.
  *
- * @deprecated will be removed in seminars 4; use hooks from `Hooks\Interfaces\Hook\SeminarSingleView` instead
+ * @deprecated will be removed in seminars 4; use `Hooks\Interfaces\Hook\SeminarSingleView` instead
  *
  * @author Oliver Klee <typo3-coding@oliverklee.de>
  */
@@ -21,7 +21,7 @@ interface Tx_Seminars_Interface_Hook_EventSingleView
      *
      * @return void
      *
-     * @deprecated will be removed in seminars 4; use SeminarSingleView::modifySingleView instead
+     * @deprecated will be removed in seminars 4; use `SeminarSingleView::modifySingleView` instead
      */
     public function modifyEventSingleView(\Tx_Seminars_Model_Event $event, \Tx_Oelib_Template $template);
 

--- a/Tests/LegacyUnit/FrontEnd/DefaultControllerTest.php
+++ b/Tests/LegacyUnit/FrontEnd/DefaultControllerTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use OliverKlee\PhpUnit\TestCase;
+use OliverKlee\Seminars\Hooks\Interfaces\SeminarSingleView;
 use OliverKlee\Seminars\Tests\LegacyUnit\Fixtures\OldModel\TestingEvent;
 use OliverKlee\Seminars\Tests\LegacyUnit\FrontEnd\Fixtures\TestingDefaultController;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -1255,6 +1256,26 @@ class Tx_Seminars_Tests_Unit_FrontEnd_DefaultControllerTest extends TestCase
         $hookClass = get_class($hook);
         $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['seminars']['singleView'][$hookClass] = $hookClass;
         GeneralUtility::addInstance($hookClass, $hook);
+
+        $this->subject->piVars['showUid'] = $this->seminarUid;
+        $this->subject->main('', []);
+    }
+
+    /**
+     * @test
+     */
+    public function singleViewCallsHookSeminarSingleViewModifySingleView()
+    {
+        $this->subject->setConfigurationValue('what_to_display', 'single_view');
+
+        /** @var \Tx_Seminars_Model_Event $event */
+        $event = \Tx_Oelib_MapperRegistry::get(\Tx_Seminars_Mapper_Event::class)->find($this->seminarUid);
+        $hookedInObject = $this->createMock(SeminarSingleView::class);
+        $hookedInObject->expects(self::once())->method('modifySingleView')->with($this->subject);
+
+        $hookedInClass = get_class($hookedInObject);
+        $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['seminars'][SeminarSingleView::class][] = $hookedInClass;
+        GeneralUtility::addInstance($hookedInClass, $hookedInObject);
 
         $this->subject->piVars['showUid'] = $this->seminarUid;
         $this->subject->main('', []);

--- a/Tests/LegacyUnit/FrontEnd/DefaultControllerTest.php
+++ b/Tests/LegacyUnit/FrontEnd/DefaultControllerTest.php
@@ -1268,16 +1268,14 @@ class Tx_Seminars_Tests_Unit_FrontEnd_DefaultControllerTest extends TestCase
     {
         $this->subject->setConfigurationValue('what_to_display', 'single_view');
 
-        /** @var \Tx_Seminars_Model_Event $event */
-        $event = \Tx_Oelib_MapperRegistry::get(\Tx_Seminars_Mapper_Event::class)->find($this->seminarUid);
         $hookedInObject = $this->createMock(SeminarSingleView::class);
         $hookedInObject->expects(self::once())->method('modifySingleView')->with($this->subject);
 
-        $hookedInClass = get_class($hookedInObject);
+        $hookedInClass = \get_class($hookedInObject);
         $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['seminars'][SeminarSingleView::class][] = $hookedInClass;
         GeneralUtility::addInstance($hookedInClass, $hookedInObject);
 
-        $this->subject->piVars['showUid'] = $this->seminarUid;
+        $this->subject->piVars['showUid'] = (string)$this->seminarUid;
         $this->subject->main('', []);
     }
 


### PR DESCRIPTION
As requested by @oliverklee in #241

There is these open questions:

- Is the interface feature complete? Or add methods for next day events list / other dates list, too?
- Should I deprecate the old hook? If so, like for new RegistrationEmailHookInterface?

As a side note: One of the CsvDownloaderTests failed when I had an error (threw an unexpected Exception in GeneralUtility) in the test I added:
```
There was 1 failure:

1) Tx_Seminars_Tests_Unit_Csv_CsvDownloaderTest::createAndOutputListOfRegistrationsForInexistentEventUidReturn404
Failed asserting that 'Content-disposition: attachment; filename=' contains "404".

/home/michael/MXP/ext-seminars/Tests/LegacyUnit/Csv/CsvDownloaderTest.php:823
...
```

Should I open an issue for that? Or will the test be re-implemented anyways soon?