### PR TITLE
[BUGFIX] Internally store boolean properties as integers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Drop support for TYPO3 7.6 (#248, #272, #280)
 
 ### Fixed
+- Internally store boolean properties as integers (#386)
 - Convert the old model DB accesses to the ConnectionPool (#372, #373, #379, #382, #383)
 - Fix TypoScript lint warnings (#371)
 - Fix the locallang path in the event publication (#367)

--- a/Classes/OldModel/AbstractModel.php
+++ b/Classes/OldModel/AbstractModel.php
@@ -340,7 +340,7 @@ abstract class AbstractModel extends \Tx_Oelib_TemplateHelper
     {
         $this->assertNonEmptyKey($key);
 
-        $this->recordData[$key] = (bool)$value;
+        $this->recordData[$key] = (int)(bool)$value;
     }
 
     /**


### PR DESCRIPTION
This avoids problems when persisting models with the ConnectionPool.