### PR TITLE
[FEATURE] Add seminar list view hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ## x.y.z
 
 ### Added
+- Add new seminar list view hooks (#408)
 - Add TypoScript linting (#10)
 - Add `AbstractModel::comesFromDatabase` (#364)
 - Add php-cs-fixer to the CI (#351)

--- a/Classes/FrontEnd/DefaultController.php
+++ b/Classes/FrontEnd/DefaultController.php
@@ -425,7 +425,7 @@ class Tx_Seminars_FrontEnd_DefaultController extends \Tx_Oelib_TemplateHelper im
      */
     protected function getListViewHookProvider(): HookProvider
     {
-        if ($this->listViewHookProvider === null) {
+        if (!$this->listViewHookProvider instanceof HookProvider) {
             $this->listViewHookProvider = GeneralUtility::makeInstance(HookProvider::class, SeminarListView::class);
         }
 
@@ -1895,9 +1895,7 @@ class Tx_Seminars_FrontEnd_DefaultController extends \Tx_Oelib_TemplateHelper im
 
         if ($builder instanceof \Tx_Seminars_BagBuilder_Event) {
             $this->getListViewHookProvider()->executeHook('modifyEventBagBuilder', $this, $builder, $whatToDisplay);
-        }
-
-        if ($builder instanceof \Tx_Seminars_BagBuilder_Registration) {
+        } elseif ($builder instanceof \Tx_Seminars_BagBuilder_Registration) {
             $this->getListViewHookProvider()
                 ->executeHook('modifyRegistrationBagBuilder', $this, $builder, $whatToDisplay);
         }

--- a/Classes/FrontEnd/DefaultController.php
+++ b/Classes/FrontEnd/DefaultController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use OliverKlee\Seminars\Bag\AbstractBag;
 use OliverKlee\Seminars\Hooks\HookProvider;
+use OliverKlee\Seminars\Hooks\Interfaces\SeminarListView;
 use OliverKlee\Seminars\Hooks\Interfaces\SeminarSingleView;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Utility\MathUtility;
@@ -168,6 +169,8 @@ class Tx_Seminars_FrontEnd_DefaultController extends \Tx_Oelib_TemplateHelper im
      * hook objects for the list view
      *
      * @var \Tx_Seminars_Interface_Hook_EventListView[]
+     *
+     * @deprecated will be removed in seminars 4; use `->getListViewHookProvider()` instead
      */
     private $listViewHooks = [];
 
@@ -175,8 +178,15 @@ class Tx_Seminars_FrontEnd_DefaultController extends \Tx_Oelib_TemplateHelper im
      * whether the hooks in $this->listViewHooks have been retrieved
      *
      * @var bool
+     *
+     * @deprecated will be removed in seminars 4; use `->getListViewHookProvider()` instead
      */
     private $listViewHooksHaveBeenRetrieved = false;
+
+    /**
+     * @var HookProvider|null
+     */
+    protected $listViewHookProvider = null;
 
     /**
      * hook objects for the single view
@@ -381,6 +391,8 @@ class Tx_Seminars_FrontEnd_DefaultController extends \Tx_Oelib_TemplateHelper im
      * @throws \UnexpectedValueException
      *          if there are registered hook classes that do not implement the
      *          \Tx_Seminars_Interface_Hook_EventListView interface
+     *
+     * @deprecated will be removed in seminars 4; use `->getListViewHookProvider()` instead
      */
     protected function getListViewHooks(): array
     {
@@ -404,6 +416,20 @@ class Tx_Seminars_FrontEnd_DefaultController extends \Tx_Oelib_TemplateHelper im
         }
 
         return $this->listViewHooks;
+    }
+
+    /**
+     * Gets the hook provider for the list view.
+     *
+     * @return HookProvider
+     */
+    protected function getListViewHookProvider(): HookProvider
+    {
+        if ($this->listViewHookProvider === null) {
+            $this->listViewHookProvider = GeneralUtility::makeInstance(HookProvider::class, SeminarListView::class);
+        }
+
+        return $this->listViewHookProvider;
     }
 
     /**
@@ -1867,6 +1893,15 @@ class Tx_Seminars_FrontEnd_DefaultController extends \Tx_Oelib_TemplateHelper im
         $resultsAtATime = MathUtility::forceIntegerInRange($this->internal['results_at_a_time'], 1, 1000);
         $builder->setLimit(($pointer * $resultsAtATime) . ',' . $resultsAtATime);
 
+        if ($builder instanceof \Tx_Seminars_BagBuilder_Event) {
+            $this->getListViewHookProvider()->executeHook('modifyEventBagBuilder', $this, $builder, $whatToDisplay);
+        }
+
+        if ($builder instanceof \Tx_Seminars_BagBuilder_Registration) {
+            $this->getListViewHookProvider()
+                ->executeHook('modifyRegistrationBagBuilder', $this, $builder, $whatToDisplay);
+        }
+
         $seminarOrRegistrationBag = $builder->build();
 
         $this->internal['res_count'] = $seminarOrRegistrationBag->countWithoutLimit();
@@ -1962,6 +1997,8 @@ class Tx_Seminars_FrontEnd_DefaultController extends \Tx_Oelib_TemplateHelper im
             $this->setMarker('header_' . $column, $this->getFieldHeader($column));
         }
 
+        $this->getListViewHookProvider()->executeHook('modifyListHeader', $this);
+
         return $this->getSubpart('LIST_HEADER');
     }
 
@@ -1972,6 +2009,8 @@ class Tx_Seminars_FrontEnd_DefaultController extends \Tx_Oelib_TemplateHelper im
      */
     protected function createListFooter(): string
     {
+        $this->getListViewHookProvider()->executeHook('modifyListFooter', $this);
+
         return $this->getSubpart('LIST_FOOTER');
     }
 
@@ -2123,6 +2162,8 @@ class Tx_Seminars_FrontEnd_DefaultController extends \Tx_Oelib_TemplateHelper im
                 $hook->modifyListRow($event, $this->getTemplate());
             }
 
+            $this->getListViewHookProvider()->executeHook('modifyListRow', $this);
+
             if ($whatToDisplay === 'my_events') {
                 /** @var \Tx_Seminars_Mapper_Registration $mapper */
                 $mapper = \Tx_Oelib_MapperRegistry::get(\Tx_Seminars_Mapper_Registration::class);
@@ -2132,6 +2173,8 @@ class Tx_Seminars_FrontEnd_DefaultController extends \Tx_Oelib_TemplateHelper im
                 foreach ($this->getListViewHooks() as $hook) {
                     $hook->modifyMyEventsListRow($registration, $this->getTemplate());
                 }
+
+                $this->getListViewHookProvider()->executeHook('modifyMyEventsListRow', $this);
             }
 
             $result = $this->getSubpart('LIST_ITEM');

--- a/Classes/Hooks/Interfaces/SeminarListView.php
+++ b/Classes/Hooks/Interfaces/SeminarListView.php
@@ -35,7 +35,7 @@ interface SeminarListView extends Hook
     public function modifyEventBagBuilder(
         \Tx_Seminars_FrontEnd_DefaultController $controller,
         \Tx_Seminars_BagBuilder_Event $builder,
-        $whatToDisplay
+        string $whatToDisplay
     );
 
     /**
@@ -58,7 +58,7 @@ interface SeminarListView extends Hook
     public function modifyRegistrationBagBuilder(
         \Tx_Seminars_FrontEnd_DefaultController $controller,
         \Tx_Seminars_BagBuilder_Registration $builder,
-        $whatToDisplay
+        string $whatToDisplay
     );
 
     /**

--- a/Classes/Hooks/Interfaces/SeminarListView.php
+++ b/Classes/Hooks/Interfaces/SeminarListView.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OliverKlee\Seminars\Hooks\Interfaces;
+
+/**
+ * Use this interface for hooks concerning the seminar list views.
+ *
+ * It supersedes the deprecated `EventListView` interface.
+ *
+ * @author Michael Kramer <m.kramer@mxp.de>
+ */
+interface SeminarListView extends Hook
+{
+    /**
+     * Modifies the list view seminar bag builder (the item collection for a seminar list).
+     *
+     * Add or alter limitations for the selection of seminars to be shown in the
+     * list.
+     *
+     * @see \OliverKlee\Seminars\BagBuilder\AbstractBagBuilder::getWhereClausePart()
+     * @see \OliverKlee\Seminars\BagBuilder\AbstractBagBuilder::setWhereClausePart()
+     *
+     * This function will be called for these types of seminar lists: "topics", "seminars",
+     * "my vip seminars", "my entered events", "events next day", "other dates".
+     *
+     * @param \Tx_Seminars_FrontEnd_DefaultController $controller the calling controller
+     * @param \Tx_Seminars_BagBuilder_Event $builder the bag builder
+     * @param string $whatToDisplay the flavor of list view: 'seminar_list', 'topic_list',
+     *        'my_vip_events', 'my_entered_events', 'events_next_day' or 'other_dates'
+     *
+     * @return void
+     */
+    public function modifyEventBagBuilder(
+        \Tx_Seminars_FrontEnd_DefaultController $controller,
+        \Tx_Seminars_BagBuilder_Event $builder,
+        $whatToDisplay
+    );
+
+    /**
+     * Modifies the list view registration bag builder (the item collection for a "my events" list).
+     *
+     * Add or alter limitations for the selection of seminars to be shown in the
+     * list.
+     *
+     * @see \OliverKlee\Seminars\BagBuilder\AbstractBagBuilder::getWhereClausePart()
+     * @see \OliverKlee\Seminars\BagBuilder\AbstractBagBuilder::setWhereClausePart()
+     *
+     * This function will be called for "my events" lists only.
+     *
+     * @param \Tx_Seminars_FrontEnd_DefaultController $controller the calling controller
+     * @param \Tx_Seminars_BagBuilder_Registration $builder the bag builder
+     * @param string $whatToDisplay the flavor of list view ('my_events' only?)
+     *
+     * @return void
+     */
+    public function modifyRegistrationBagBuilder(
+        \Tx_Seminars_FrontEnd_DefaultController $controller,
+        \Tx_Seminars_BagBuilder_Registration $builder,
+        $whatToDisplay
+    );
+
+    /**
+     * Modifies the list view header row in a seminar list.
+     *
+     * This function will be called for all types of seminar lists ("topics",
+     * "seminars", "my seminars", "my vip seminars", "my entered events",
+     * "events next day", "other dates").
+     *
+     * @param \Tx_Seminars_FrontEnd_DefaultController $controller the calling controller
+     *
+     * @return void
+     */
+    public function modifyListHeader(\Tx_Seminars_FrontEnd_DefaultController $controller);
+
+    /**
+     * Modifies a list row in a seminar list.
+     *
+     * This function will be called for all types of seminar lists ("topics",
+     * "seminars", "my seminars", "my vip seminars", "my entered events",
+     * "events next day", "other dates").
+     *
+     * @param \Tx_Seminars_FrontEnd_DefaultController $controller the calling controller
+     *
+     * @return void
+     */
+    public function modifyListRow(\Tx_Seminars_FrontEnd_DefaultController $controller);
+
+    /**
+     * Modifies a list view row in a "my seminars" list.
+     *
+     * This function will be called for "my seminars" , "my vip seminars",
+     * "my entered events" lists only.
+     *
+     * @param \Tx_Seminars_FrontEnd_DefaultController $controller the calling controller
+     *
+     * @return void
+     */
+    public function modifyMyEventsListRow(\Tx_Seminars_FrontEnd_DefaultController $controller);
+
+    /**
+     * Modifies the list view footer in a seminars list.
+     *
+     * This function will be called for all types of seminar lists ("topics",
+     * "seminars", "my seminars", "my vip seminars", "my entered events",
+     * "events next day", "other dates").
+     *
+     * @param \Tx_Seminars_FrontEnd_DefaultController $controller the calling controller
+     *
+     * @return void
+     */
+    public function modifyListFooter(\Tx_Seminars_FrontEnd_DefaultController $controller);
+}

--- a/Classes/Interface/Hook/EventListView.php
+++ b/Classes/Interface/Hook/EventListView.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 /**
  * This interface needs to be used for hooks concerning the event list view.
  *
+ * @deprecated will be removed in seminars 4; use `Hooks\Interfaces\Hook\SeminarListView` instead
+ *
  * @author Oliver Klee <typo3-coding@oliverklee.de>
  */
 interface Tx_Seminars_Interface_Hook_EventListView
@@ -20,6 +22,8 @@ interface Tx_Seminars_Interface_Hook_EventListView
      *        the template that will be used to create the list row output
      *
      * @return void
+     *
+     * @deprecated will be removed in seminars 4; use `SeminarListView::modifyListRow` instead
      */
     public function modifyListRow(\Tx_Seminars_Model_Event $event, \Tx_Oelib_Template $template);
 
@@ -32,6 +36,8 @@ interface Tx_Seminars_Interface_Hook_EventListView
      *        the template that will be used to create the list row output
      *
      * @return void
+     *
+     * @deprecated will be removed in seminars 4; use `SeminarListView::modifyMyEventsListRow` instead
      */
     public function modifyMyEventsListRow(
         \Tx_Seminars_Model_Registration $registration,

--- a/Tests/LegacyUnit/FrontEnd/DefaultControllerTest.php
+++ b/Tests/LegacyUnit/FrontEnd/DefaultControllerTest.php
@@ -9517,21 +9517,21 @@ class Tx_Seminars_Tests_Unit_FrontEnd_DefaultControllerTest extends TestCase
     /**
      * @test
      */
-    public function listViewCallsSeminarListViewHookMethodsForOtherDates()
+    public function singleViewCallsSeminarListViewHookMethodsForOtherDates()
     {
-        $topic = $this->testingFramework->createRecord(
+        $topicUId = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
             [
                 'pid' => $this->systemFolderPid,
                 'object_type' => \Tx_Seminars_Model_Event::TYPE_TOPIC,
             ]
         );
-        $date = $this->testingFramework->createRecord(
+        $dateUid = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
             [
                 'pid' => $this->systemFolderPid,
                 'object_type' => \Tx_Seminars_Model_Event::TYPE_DATE,
-                'topic' => $topic,
+                'topic' => $topicUId,
                 'begin_date' => $GLOBALS['SIM_EXEC_TIME'] + 1000,
                 'end_date' => $GLOBALS['SIM_EXEC_TIME'] + 2000,
             ]
@@ -9541,13 +9541,13 @@ class Tx_Seminars_Tests_Unit_FrontEnd_DefaultControllerTest extends TestCase
             [
                 'pid' => $this->systemFolderPid,
                 'object_type' => \Tx_Seminars_Model_Event::TYPE_DATE,
-                'topic' => $topic,
+                'topic' => $topicUId,
                 'begin_date' => $GLOBALS['SIM_EXEC_TIME'] + 11000, // > 1 day after first date
                 'end_date' => $GLOBALS['SIM_EXEC_TIME'] + 12000,
             ]
         );
         $this->subject->setConfigurationValue('what_to_display', 'single_view');
-        $this->subject->piVars['showUid'] = (string)$date;
+        $this->subject->piVars['showUid'] = (string)$dateUid;
 
         $hook = $this->createMock(SeminarListView::class);
         $hook->expects(self::exactly(2))->method('modifyListHeader')->with($this->subject);

--- a/Tests/LegacyUnit/FrontEnd/DefaultControllerTest.php
+++ b/Tests/LegacyUnit/FrontEnd/DefaultControllerTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use OliverKlee\PhpUnit\TestCase;
+use OliverKlee\Seminars\Hooks\Interfaces\SeminarListView;
 use OliverKlee\Seminars\Hooks\Interfaces\SeminarSingleView;
 use OliverKlee\Seminars\Tests\LegacyUnit\Fixtures\OldModel\TestingEvent;
 use OliverKlee\Seminars\Tests\LegacyUnit\FrontEnd\Fixtures\TestingDefaultController;
@@ -9447,6 +9448,161 @@ class Tx_Seminars_Tests_Unit_FrontEnd_DefaultControllerTest extends TestCase
         $hookClass = \get_class($hook);
 
         $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['seminars']['listView'][$hookClass] = $hookClass;
+        GeneralUtility::addInstance($hookClass, $hook);
+
+        $this->subject->main('', []);
+    }
+
+    /**
+     * @test
+     */
+    public function listViewCallsSeminarListViewHookMethodsForTopicList()
+    {
+        $topic = $this->testingFramework->createRecord(
+            'tx_seminars_seminars',
+            [
+                'pid' => $this->systemFolderPid,
+                'object_type' => \Tx_Seminars_Model_Event::TYPE_TOPIC,
+            ]
+        );
+        $this->testingFramework->createRecord(
+            'tx_seminars_seminars',
+            [
+                'pid' => $this->systemFolderPid,
+                'object_type' => \Tx_Seminars_Model_Event::TYPE_DATE,
+                'topic' => $topic,
+                'begin_date' => $GLOBALS['SIM_EXEC_TIME'] + 1000,
+                'end_date' => $GLOBALS['SIM_EXEC_TIME'] + 2000,
+            ]
+        );
+        $this->subject->setConfigurationValue('what_to_display', 'topic_list');
+
+        $hook = $this->createMock(SeminarListView::class);
+        $hook->expects(self::once())->method('modifyListHeader')->with($this->subject);
+        $hook->expects(self::once())->method('modifyListRow')->with($this->subject);
+        $hook->expects(self::never())->method('modifyMyEventsListRow');
+        $hook->expects(self::once())->method('modifyListFooter')->with($this->subject);
+        $hook->expects(self::once())->method('modifyEventBagBuilder')->with($this->subject, self::anything(), 'topic_list');
+        // We don't test for the second parameter (the bag builder instance here)
+        // because we cannot access it from the outside.
+        $hook->expects(self::never())->method('modifyRegistrationBagBuilder');
+
+        $hookClass = \get_class($hook);
+        $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['seminars'][SeminarListView::class][] = $hookClass;
+        GeneralUtility::addInstance($hookClass, $hook);
+
+        $this->subject->main('', []);
+    }
+
+    /**
+     * @test
+     */
+    public function listViewCallsSeminarListViewHookMethodsForSeminarList()
+    {
+        $this->subject->setConfigurationValue('what_to_display', 'seminar_list');
+
+        $hook = $this->createMock(SeminarListView::class);
+        $hook->expects(self::once())->method('modifyListHeader')->with($this->subject);
+        $hook->expects(self::once())->method('modifyListRow')->with($this->subject);
+        $hook->expects(self::never())->method('modifyMyEventsListRow');
+        $hook->expects(self::once())->method('modifyListFooter')->with($this->subject);
+        $hook->expects(self::once())->method('modifyEventBagBuilder')->with($this->subject, self::anything(), 'seminar_list');
+        // We don't test for the second parameter (the bag builder instance here)
+        // because we cannot access it from the outside.
+        $hook->expects(self::never())->method('modifyRegistrationBagBuilder');
+
+        $hookClass = \get_class($hook);
+        $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['seminars'][SeminarListView::class][] = $hookClass;
+        GeneralUtility::addInstance($hookClass, $hook);
+
+        $this->subject->main('', []);
+    }
+
+    /**
+     * @ test "events next day", "other dates" ?
+     */
+
+    /**
+     * @test
+     */
+    public function listViewCallsSeminarListViewHookMethodsForMyEventsList()
+    {
+        $this->subject->setConfigurationValue('what_to_display', 'my_events');
+
+        $this->createLogInAndRegisterFeUser();
+
+        $hook = $this->createMock(SeminarListView::class);
+        $hook->expects(self::once())->method('modifyListHeader')->with($this->subject);
+        $hook->expects(self::once())->method('modifyListRow')->with($this->subject);
+        $hook->expects(self::once())->method('modifyMyEventsListRow')->with($this->subject);
+        $hook->expects(self::once())->method('modifyListFooter')->with($this->subject);
+        $hook->expects(self::never())->method('modifyEventBagBuilder');
+        $hook->expects(self::once())->method('modifyRegistrationBagBuilder')->with($this->subject, self::anything(), 'my_events');
+        // We don't test for the second parameter (the bag builder instance here)
+        // because we cannot access it from the outside.
+
+        $hookClass = \get_class($hook);
+        $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['seminars'][SeminarListView::class][] = $hookClass;
+        GeneralUtility::addInstance($hookClass, $hook);
+
+        $this->subject->main('', []);
+    }
+
+    /**
+     * @test
+     */
+    public function listViewCallsSeminarListViewHookMethodsForMyVipEventsList()
+    {
+        $this->subject->setConfigurationValue('what_to_display', 'my_vip_events');
+
+        $this->createLogInAndAddFeUserAsVip();
+
+        $hook = $this->createMock(SeminarListView::class);
+        $hook->expects(self::once())->method('modifyListHeader')->with($this->subject);
+        $hook->expects(self::once())->method('modifyListRow')->with($this->subject);
+        $hook->expects(self::never())->method('modifyMyEventsListRow');
+        $hook->expects(self::once())->method('modifyListFooter')->with($this->subject);
+        $hook->expects(self::once())->method('modifyEventBagBuilder')->with($this->subject, self::anything(), 'my_vip_events');
+        // We don't test for the second parameter (the bag builder instance here)
+        // because we cannot access it from the outside.
+        $hook->expects(self::never())->method('modifyRegistrationBagBuilder');
+
+        $hookClass = \get_class($hook);
+        $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['seminars'][SeminarListView::class][] = $hookClass;
+        GeneralUtility::addInstance($hookClass, $hook);
+
+        $this->subject->main('', []);
+    }
+
+    /**
+     * @test
+     */
+    public function listViewCallsSeminarListViewHookMethodsForMyEnteredEventsList()
+    {
+        $editorGroupUid = $this->testingFramework->createFrontEndUserGroup();
+        $this->subject->setConfigurationValue('what_to_display', 'my_entered_events');
+        $this->subject->setConfigurationValue('eventEditorFeGroupID', $editorGroupUid);
+        $feUserUid = $this->testingFramework->createAndLoginFrontEndUser($editorGroupUid);
+        $this->testingFramework->createRecord(
+            'tx_seminars_seminars',
+            [
+                'pid' => $this->systemFolderPid,
+                'owner_feuser' => $feUserUid,
+            ]
+        );
+
+        $hook = $this->createMock(SeminarListView::class);
+        $hook->expects(self::once())->method('modifyListHeader')->with($this->subject);
+        $hook->expects(self::once())->method('modifyListRow')->with($this->subject);
+        $hook->expects(self::never())->method('modifyMyEventsListRow');
+        $hook->expects(self::once())->method('modifyListFooter')->with($this->subject);
+        $hook->expects(self::once())->method('modifyEventBagBuilder')->with($this->subject, self::anything(), 'my_entered_events');
+        // We don't test for the second parameter (the bag builder instance here)
+        // because we cannot access it from the outside.
+        $hook->expects(self::never())->method('modifyRegistrationBagBuilder');
+
+        $hookClass = \get_class($hook);
+        $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['seminars'][SeminarListView::class][] = $hookClass;
         GeneralUtility::addInstance($hookClass, $hook);
 
         $this->subject->main('', []);


### PR DESCRIPTION
As requested by @oliverklee in #241

- Deprecates Tx_Seminars_Interface_Hook_EventListView
- Adds hooks to bag builders, table header, list rows and table footer
- Tests for all hooks

I will add the changelog entry when this is almost finished (to prevent conflicts when rebasing).