### PR TITLE
[FEATURE] Add composer command to render the documentation using docker-compose

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,6 +5,7 @@
 /.php_cs.dist export-ignore
 /.travis.yml export-ignore
 /CODE_OF_CONDUCT.md export-ignore
+/docker-compose.yml export-ignore
 /Resources/Private/Php/update.sh export-ignore
 /Tests/ export-ignore
 /phpcs.xml.dist export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -5,7 +5,7 @@
 /.php_cs.dist export-ignore
 /.travis.yml export-ignore
 /CODE_OF_CONDUCT.md export-ignore
-/docker-compose.yml export-ignore
 /Resources/Private/Php/update.sh export-ignore
 /Tests/ export-ignore
+/docker-compose.yml export-ignore
 /phpcs.xml.dist export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 /composer.lock
 /nbproject
 /var/
+/Documentation-GENERATED-temp

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,6 @@
 /.Build/*
 /.php_cs.cache
 /composer.lock
+/Documentation-GENERATED-temp
 /nbproject
 /var/
-/Documentation-GENERATED-temp

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ## x.y.z
 
 ### Added
+- Add documentation rendering using docker-compose (#432)
 - Add new seminar list view hooks (#408)
 - Add TypoScript linting (#10)
 - Add `AbstractModel::comesFromDatabase` (#364)

--- a/composer.json
+++ b/composer.json
@@ -112,10 +112,10 @@
         "post-autoload-dump": [
             "@link-extension"
         ],
-        "render-docs": [
+        "typo3:docs:render": [
             "docker-compose run --rm t3docmake"
         ],
-        "serve-docs": [
+        "typo3:docs:serve": [
             "php -S 127.0.0.1:4000 -t Documentation-GENERATED-temp/Result/project/0.0.0"
         ]
     },

--- a/composer.json
+++ b/composer.json
@@ -111,6 +111,9 @@
         ],
         "post-autoload-dump": [
             "@link-extension"
+        ],
+        "render-docs": [
+            "docker-compose run --rm t3docmake"
         ]
     },
     "extra": {

--- a/composer.json
+++ b/composer.json
@@ -114,6 +114,9 @@
         ],
         "render-docs": [
             "docker-compose run --rm t3docmake"
+        ],
+        "serve-docs": [
+            "php -S 127.0.0.1:4000 -t Documentation-GENERATED-temp/Result/project/0.0.0"
         ]
     },
     "extra": {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+version: '2'
+services:
+  t3docmake:
+    image: t3docs/render-documentation:latest
+    volumes:
+    - ./:/PROJECT:ro
+    - ./Documentation-GENERATED-temp:/RESULT
+    command: makehtml


### PR DESCRIPTION
This is the official way to [test rendering the docs using docker-compose](https://docs.typo3.org/m/typo3/docs-how-to-document/master/en-us/RenderingDocs/Index.html).

I found this being more convenient than using the image directly. It also should be more portable to Windows than creating a shell alias as the [official site suggests](https://docs.typo3.org/m/typo3/docs-how-to-document/master/en-us/RenderingDocs/Quickstart.html#commands-to-render-documentation).