### PR TITLE
[FEATURE] Add TCE validation hook to event model

### DIFF
--- a/Classes/Hooks/HookProvider.php
+++ b/Classes/Hooks/HookProvider.php
@@ -86,21 +86,10 @@ class HookProvider
      * @param mixed $params parameters to $method()
      *
      * @return void
-     *
-     * @throws \InvalidArgumentException
-     * @throws \UnexpectedValueException
      */
     public function executeHook(string $method, ...$params)
     {
-        if ($method === '') {
-            throw new \InvalidArgumentException('The parameter $method must not be empty.', 1573479911);
-        }
-        if (!\in_array($method, \get_class_methods($this->interfaceName), true)) {
-            throw new \UnexpectedValueException(
-                'The interface ' . $this->interfaceName . ' does not contain method ' . $method . '.',
-                1573480302
-            );
-        }
+        $this->validateHookMethod($method);
 
         foreach ($this->getHooks() as $hook) {
             $hook->$method(...$params);
@@ -146,5 +135,28 @@ class HookProvider
         }
 
         $this->hooksHaveBeenRetrieved = true;
+    }
+
+    /**
+     * Validates the requested hooked-in methods.
+     *
+     * @param string $method the method to execute
+     *
+     * @return void
+     *
+     * @throws \InvalidArgumentException
+     * @throws \UnexpectedValueException
+     */
+    protected function validateHookMethod(string $method)
+    {
+        if ($method === '') {
+            throw new \InvalidArgumentException('The parameter $method must not be empty.', 1573479911);
+        }
+        if (!\in_array($method, \get_class_methods($this->interfaceName), true)) {
+            throw new \UnexpectedValueException(
+                'The interface ' . $this->interfaceName . ' does not contain method ' . $method . '.',
+                1573480302
+            );
+        }
     }
 }

--- a/Classes/Hooks/HookProvider.php
+++ b/Classes/Hooks/HookProvider.php
@@ -19,9 +19,16 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  * point is reached and re-used for all other points.
  *
  * Implementing hook points
- * Instantiate this class with the interface you need implemented. First call to `executeHook()` will
+ * Instantiate this class with the interface you need implemented. First call to `executeHook[...]()` will
  * instantiate the registered classes. Every further call will reuse the same instances. On each
  * call provide the method required at the point in your program.
+ *
+ * The most recommended way to design a hook method is passing objects to manipulate. Use `executeHook()`
+ * for these methods. By passing an object to the hooked-in methods the object content can be manipulated
+ * and by this change the behaviour of `seminars`.
+ *
+ * In some cases, when a return value is required, You may use `executeHookReturningMergedArray()` for returning complex
+ * results while all hooked-in methods process the same parameters.
  *
  * There is an optional index to `$GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['seminars']`, provided
  * for easier conversion of existing hooks to this class.
@@ -94,6 +101,26 @@ class HookProvider
         foreach ($this->getHooks() as $hook) {
             $hook->$method(...$params);
         }
+    }
+
+    /**
+     * Executes the hooked-in methods, that return result arrays.
+     *
+     * @param string $method the method to execute
+     * @param mixed $params parameters to $method()
+     *
+     * @return array the merged result arrays
+     */
+    public function executeHookReturningMergedArray(string $method, ...$params): array
+    {
+        $this->validateHookMethod($method);
+
+        $result = [];
+        foreach ($this->getHooks() as $hook) {
+            $result = array_merge($result, $hook->$method(...$params));
+        }
+
+        return $result;
     }
 
     /**

--- a/Classes/Hooks/Interfaces/EventModel.php
+++ b/Classes/Hooks/Interfaces/EventModel.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OliverKlee\Seminars\Hooks\Interfaces;
+
+/**
+ * Use this interface for hooks concerning the event model.
+ *
+ * @author Michael Kramer <m.kramer@mxp.de>
+ */
+interface EventModel extends Hook
+{
+    /**
+     * Validate TCE values.
+     *
+     * The TCE form values need to be validated before storing them into the DB.
+     * Check the values with additional constraints and provide the validation
+     * result as seen in `\Tx_Seminars_OldModel_Event::validateTceValues()` and
+     * `\Tx_Seminars_OldModel_Event::getUpdateArray()`.
+     *
+     * The return value is an associative array using the fieldname as the key
+     * string and an array for the validation result:
+     * `['price_regular_early' => ['status' => false, 'newValue' => '0.00']]`
+     *
+     * @param \Tx_Seminars_OldModel_Event $event the event model
+     * @param string[] &$fieldArray
+     *        associative array containing the values entered in the TCE form
+     *
+     * @return array[] associative array of associative arrays containing the validation results
+     */
+    public function validateTceValues(\Tx_Seminars_OldModel_Event $event, array &$fieldArray): array;
+}

--- a/Documentation/DE/Referenz/Hooks/Index.rst
+++ b/Documentation/DE/Referenz/Hooks/Index.rst
@@ -31,6 +31,7 @@ Es gibt Hooks in diese Teile von seminars:
 * :ref:`emailsalutation_de`
 * :ref:`backendemail_de`
 * :ref:`backendregistrationlistview_de`
+* :ref:`eventmodeltcevalidation_de`
 
 Bitte nehmen Sie Kontakt zu uns auf, wenn Sie weitere Hooks benötigen.
 
@@ -660,6 +661,58 @@ Implementieren Sie die benötigten Methoden gemäß dem Interface:
             \Tx_Oelib_Template $template,
             int $registrationsToShow
         ) {
+            // Hier Ihr Code
+        }
+    }
+
+.. _eventmodeltcevalidation_de:
+
+Hooks zur Event-Model TCE-Validierung
+"""""""""""""""""""""""""""""""""""""
+
+Es gibt einen Hook in das Event Model, um bei der TCE-Validierung (vor dem Speichern eines
+Seminars) zusätzliche Bedingungen abzuprüfen und eigene dynamische Anpassungen der Daten
+vorzunehmen (z.B. Registrierung-Deadline = Beginn-Datum - 14 Tage).
+
+Das Verfahren der TCE-Validierung ist von Typo3 vorgegeben. `seminars` erhält dabei die Formular-Daten
+aus dem FlexForm des Content-Elements und gibt nötige Änderungen der eingetragenen Werte an Typo3 zurück.
+
+Ihre Klasse, die :php:`\OliverKlee\Seminars\Hooks\Interfaces\EventModel` implementiert,
+machen Sie seminars in :file:`ext_localconf.php` Ihrer Extension bekannt:
+
+.. code-block:: php
+
+    $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['seminars'][\OliverKlee\Seminars\Hooks\Interfaces\EventModel:class][]
+        = \Tx_Seminarspaypal_Hooks_EventModel::class;
+
+Implementieren Sie die benötigten Methoden gemäß dem Interface:
+
+.. code-block:: php
+
+    use \OliverKlee\Seminars\Hooks\Interfaces\EventModel;
+
+    class Tx_Seminarspaypal_Hooks_EventModel implements EventModel
+    {
+        /**
+         * Validate TCE values.
+         *
+         * The TCE form values need to be validated before storing them into the DB.
+         * Check the values with additional constraints and provide the validation
+         * result as seen in `\Tx_Seminars_OldModel_Event::validateTceValues()` and
+         * `\Tx_Seminars_OldModel_Event::getUpdateArray()`.
+         *
+         * The return value is an associative array using the fieldname as the key
+         * string and an array for the validation result:
+         * `['price_regular_early' => ['status' => false, 'newValue' => '0.00']]`
+         *
+         * @param \Tx_Seminars_OldModel_Event $event the event model
+         * @param string[] &$fieldArray
+         *        associative array containing the values entered in the TCE form
+         *
+         * @return array[] associative array of associative arrays containing the validation results
+         */
+        public function validateTceValues(\Tx_Seminars_OldModel_Event $event, array &$fieldArray): array
+        {
             // Hier Ihr Code
         }
     }

--- a/Documentation/EN/Reference/Hooks/Index.rst
+++ b/Documentation/EN/Reference/Hooks/Index.rst
@@ -31,6 +31,7 @@ are hooks for these parts of seminars:
 * :ref:`emailsalutation_en`
 * :ref:`backendemail_en`
 * :ref:`backendregistrationlistview_en`
+* :ref:`eventmodeltcevalidation_en`
 
 Please contact us if you need additional hooks.
 
@@ -660,6 +661,58 @@ Implement the methods required by the interface:
             \Tx_Oelib_Template $template,
             int $registrationsToShow
         ) {
+            // Your code here
+        }
+    }
+
+.. _eventmodeltcevalidation_en:
+
+Hooks for the event model TCE validation
+""""""""""""""""""""""""""""""""""""""""
+
+There is a hook into the event model to additionaly manipulate `seminars` FlexForm data during
+TCE validation (just before storing the data). You may apply additional constraints and dynamically
+adjust values (e.g. registration deadline = begin date - 14 days).
+
+TCE validation is a Typo3 defined process. `seminars` gets the form values from the content element's
+FlexForm and returns required changes of the values back to Typo3.
+
+Register your class that implements :php:`\OliverKlee\Seminars\Hooks\Interfaces\EventModel`
+like this in :file:`ext_localconf.php` of your extension:
+
+.. code-block:: php
+
+    $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['seminars'][\OliverKlee\Seminars\Hooks\Interfaces\EventModel:class][]
+        = \Tx_Seminarspaypal_Hooks_EventModel::class;
+
+Implement the methods required by the interface:
+
+.. code-block:: php
+
+    use \OliverKlee\Seminars\Hooks\Interfaces\EventModel;
+
+    class Tx_Seminarspaypal_Hooks_EventModel implements EventModel
+    {
+        /**
+         * Validate TCE values.
+         *
+         * The TCE form values need to be validated before storing them into the DB.
+         * Check the values with additional constraints and provide the validation
+         * result as seen in `\Tx_Seminars_OldModel_Event::validateTceValues()` and
+         * `\Tx_Seminars_OldModel_Event::getUpdateArray()`.
+         *
+         * The return value is an associative array using the fieldname as the key
+         * string and an array for the validation result:
+         * `['price_regular_early' => ['status' => false, 'newValue' => '0.00']]`
+         *
+         * @param \Tx_Seminars_OldModel_Event $event the event model
+         * @param string[] &$fieldArray
+         *        associative array containing the values entered in the TCE form
+         *
+         * @return array[] associative array of associative arrays containing the validation results
+         */
+        public function validateTceValues(\Tx_Seminars_OldModel_Event $event, array &$fieldArray): array
+        {
             // Your code here
         }
     }

--- a/Tests/LegacyUnit/OldModel/EventTest.php
+++ b/Tests/LegacyUnit/OldModel/EventTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use OliverKlee\PhpUnit\TestCase;
+use OliverKlee\Seminars\Hooks\Interfaces\EventModel;
 use OliverKlee\Seminars\Tests\LegacyUnit\Fixtures\OldModel\TestingEvent;
 use OliverKlee\Seminars\Tests\Unit\Traits\LanguageHelper;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -10472,5 +10473,26 @@ final class Tx_Seminars_Tests_Unit_OldModel_EventTest extends TestCase
     public function getAvailablePricesForNoPricesSetReturnsRegularPriceOnly()
     {
         self::assertSame(['regular'], array_keys($this->subject->getAvailablePrices()));
+    }
+
+    /*
+     * Tests concerning the TCE validation
+     */
+
+    /**
+     * @test
+     */
+    public function tceValidationCallsEventModelHook()
+    {
+        $formData = ['anyField' => 'anyValue'];
+
+        $hook = $this->createMock(EventModel::class);
+        $hook->expects(self::once())->method('validateTceValues')->with($this->subject, $formData);
+
+        $hookClass = \get_class($hook);
+        $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['seminars'][EventModel::class][] = $hookClass;
+        GeneralUtility::addInstance($hookClass, $hook);
+
+        $this->subject->getUpdateArray($formData);
     }
 }

--- a/Tests/Unit/Hooks/Fixtures/TestingHookImplementorReturnsArray.php
+++ b/Tests/Unit/Hooks/Fixtures/TestingHookImplementorReturnsArray.php
@@ -20,7 +20,7 @@ final class TestingHookImplementorReturnsArray implements TestingHookInterfaceRe
      */
     public function testHookMethodReturnsArray(): array
     {
-        return ['me' => 'ok','overwritten' => 'initial',];
+        return ['me' => 'ok', 'overwritten' => 'initial'];
     }
 
     /**
@@ -31,8 +31,8 @@ final class TestingHookImplementorReturnsArray implements TestingHookInterfaceRe
     public function testHookMethodReturnsNestedArray(): array
     {
         return [
-            'me' => ['status' => true ],
-            'me1' => ['status' => false, 'newValue' => 'new1', ]
+            'me' => ['status' => true],
+            'me1' => ['status' => false, 'newValue' => 'new1'],
         ];
     }
 }

--- a/Tests/Unit/Hooks/Fixtures/TestingHookImplementorReturnsArray.php
+++ b/Tests/Unit/Hooks/Fixtures/TestingHookImplementorReturnsArray.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OliverKlee\Seminars\Tests\Unit\Hooks\Fixtures;
+
+/**
+ * Valid test interface implementation to use with the HookProviderTest.
+ *
+ * Will be accepted, because it implements TestingHookInterfaceReturnsArray.
+ *
+ * @author Michael Kramer <m.kramer@mxp.de>
+ */
+final class TestingHookImplementorReturnsArray implements TestingHookInterfaceReturnsArray
+{
+    /**
+     * Gets called during HookProvider tests.
+     *
+     * @return array
+     */
+    public function testHookMethodReturnsArray(): array
+    {
+        return ['me' => 'ok','overwritten' => 'initial',];
+    }
+
+    /**
+     * Gets called during HookProvider tests.
+     *
+     * @return array[]
+     */
+    public function testHookMethodReturnsNestedArray(): array
+    {
+        return [
+            'me' => ['status' => true ],
+            'me1' => ['status' => false, 'newValue' => 'new1', ]
+        ];
+    }
+}

--- a/Tests/Unit/Hooks/Fixtures/TestingHookImplementorReturnsArray2.php
+++ b/Tests/Unit/Hooks/Fixtures/TestingHookImplementorReturnsArray2.php
@@ -20,7 +20,7 @@ final class TestingHookImplementorReturnsArray2 implements TestingHookInterfaceR
      */
     public function testHookMethodReturnsArray(): array
     {
-        return ['me2' => 'ok','overwritten' => 'replaced',];
+        return ['me2' => 'ok', 'overwritten' => 'replaced'];
     }
 
     /**
@@ -31,8 +31,8 @@ final class TestingHookImplementorReturnsArray2 implements TestingHookInterfaceR
     public function testHookMethodReturnsNestedArray(): array
     {
         return [
-            'me1' => ['status' => true ],
-            'me2' => ['status' => false, 'newValue' => 'new2', ]
+            'me1' => ['status' => true],
+            'me2' => ['status' => false, 'newValue' => 'new2'],
         ];
     }
 }

--- a/Tests/Unit/Hooks/Fixtures/TestingHookImplementorReturnsArray2.php
+++ b/Tests/Unit/Hooks/Fixtures/TestingHookImplementorReturnsArray2.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OliverKlee\Seminars\Tests\Unit\Hooks\Fixtures;
+
+/**
+ * Second valid test interface implementation to use with the HookProviderTest.
+ *
+ * Will be accepted as a second hooked-in class.
+ *
+ * @author Michael Kramer <m.kramer@mxp.de>
+ */
+final class TestingHookImplementorReturnsArray2 implements TestingHookInterfaceReturnsArray
+{
+    /**
+     * Gets called during HookProvider tests.
+     *
+     * @return array
+     */
+    public function testHookMethodReturnsArray(): array
+    {
+        return ['me2' => 'ok','overwritten' => 'replaced',];
+    }
+
+    /**
+     * Gets called during HookProvider tests.
+     *
+     * @return array[]
+     */
+    public function testHookMethodReturnsNestedArray(): array
+    {
+        return [
+            'me1' => ['status' => true ],
+            'me2' => ['status' => false, 'newValue' => 'new2', ]
+        ];
+    }
+}

--- a/Tests/Unit/Hooks/Fixtures/TestingHookInterfaceReturnsArray.php
+++ b/Tests/Unit/Hooks/Fixtures/TestingHookInterfaceReturnsArray.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OliverKlee\Seminars\Tests\Unit\Hooks\Fixtures;
+
+use OliverKlee\Seminars\Hooks\Interfaces\Hook;
+
+/**
+ * Valid test interface returning an array to use with the HookProviderTest.
+ *
+ * Will be accepted, because it extends Hook.
+ *
+ * @author Michael Kramer <m.kramer@mxp.de>
+ */
+interface TestingHookInterfaceReturnsArray extends Hook
+{
+    /**
+     * Gets called during HookProvider tests.
+     *
+     * @return array
+     */
+    public function testHookMethodReturnsArray(): array;
+
+    /**
+     * Gets called during HookProvider tests.
+     *
+     * @return array[]
+     */
+    public function testHookMethodReturnsNestedArray(): array;
+}

--- a/Tests/Unit/Hooks/HookProviderTest.php
+++ b/Tests/Unit/Hooks/HookProviderTest.php
@@ -421,7 +421,7 @@ final class HookProviderTest extends UnitTestCase
         $hookObject = new HookProvider(TestingHookInterfaceReturnsArray::class);
 
         self::assertSame(
-            ['me' => 'ok','overwritten' => 'initial',],
+            ['me' => 'ok', 'overwritten' => 'initial'],
             $hookObject->executeHookReturningMergedArray('testHookMethodReturnsArray')
         );
     }
@@ -438,7 +438,7 @@ final class HookProviderTest extends UnitTestCase
         $hookObject = new HookProvider(TestingHookInterfaceReturnsArray::class);
 
         self::assertSame(
-            ['me' => 'ok','overwritten' => 'replaced','me2' => 'ok',],
+            ['me' => 'ok', 'overwritten' => 'replaced', 'me2' => 'ok'],
             $hookObject->executeHookReturningMergedArray('testHookMethodReturnsArray')
         );
     }

--- a/Tests/Unit/Hooks/HookProviderTest.php
+++ b/Tests/Unit/Hooks/HookProviderTest.php
@@ -10,8 +10,11 @@ use OliverKlee\Seminars\Hooks\Interfaces\Hook;
 use OliverKlee\Seminars\Tests\Unit\Hooks\Fixtures\TestingHookImplementor;
 use OliverKlee\Seminars\Tests\Unit\Hooks\Fixtures\TestingHookImplementor2;
 use OliverKlee\Seminars\Tests\Unit\Hooks\Fixtures\TestingHookImplementorNotImplementsInterface;
+use OliverKlee\Seminars\Tests\Unit\Hooks\Fixtures\TestingHookImplementorReturnsArray;
+use OliverKlee\Seminars\Tests\Unit\Hooks\Fixtures\TestingHookImplementorReturnsArray2;
 use OliverKlee\Seminars\Tests\Unit\Hooks\Fixtures\TestingHookInterface;
 use OliverKlee\Seminars\Tests\Unit\Hooks\Fixtures\TestingHookInterfaceNotExtendsHook;
+use OliverKlee\Seminars\Tests\Unit\Hooks\Fixtures\TestingHookInterfaceReturnsArray;
 
 /**
  * Test case.
@@ -221,6 +224,18 @@ final class HookProviderTest extends UnitTestCase
 
     /**
      * @test
+     */
+    public function hookObjectForTestHookWithIndexCanBeCreated()
+    {
+        self::assertInstanceOf(HookProvider::class, $this->createHookObject('anyIndex'));
+    }
+
+    /*
+     * Tests concerning Hook::executeHook().
+     */
+
+    /**
+     * @test
      * @doesNotPerformAssertions
      */
     public function hookObjectForTestHookWithNoHookImplementorRegisteredSucceedsForValidMethod()
@@ -305,14 +320,6 @@ final class HookProviderTest extends UnitTestCase
     /**
      * @test
      */
-    public function hookObjectForTestHookWithIndexCanBeCreated()
-    {
-        self::assertInstanceOf(HookProvider::class, $this->createHookObject('anyIndex'));
-    }
-
-    /**
-     * @test
-     */
     public function hookObjectForTestHookWithIndexWithOneHookImplementorRegisteredSucceedsWithMethodCalledOnce()
     {
         $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['seminars']['anyIndex'][1574270061] =
@@ -353,5 +360,103 @@ final class HookProviderTest extends UnitTestCase
 
         self::assertSame(0, TestingHookImplementor::$wasCalled);
         self::assertSame(1, TestingHookImplementor2::$wasCalled);
+    }
+
+    /*
+     * Tests concerning Hook::executeHookReturningMergedArray().
+     */
+
+    /**
+     * @test
+     */
+    public function hookObjectForTestingHookReturningArrayCanBeCreated()
+    {
+        self::assertInstanceOf(HookProvider::class, new HookProvider(TestingHookInterfaceReturnsArray::class));
+    }
+
+    /**
+     * @test
+     */
+    public function hookObjectForTestingHookReturningArrayWithNoHookImplementorRegisteredReturnsEmptyArray()
+    {
+        $hookObject = new HookProvider(TestingHookInterfaceReturnsArray::class);
+
+        self::assertSame([], $hookObject->executeHookReturningMergedArray('testHookMethodReturnsArray'));
+        self::assertSame([], $hookObject->executeHookReturningMergedArray('testHookMethodReturnsNestedArray'));
+    }
+
+    /**
+     * @test
+     */
+    public function hookObjectForTestingHookReturningArrayWithNoHookImplementorRegisteredFailsForEmptyMethod()
+    {
+        $hookObject = new HookProvider(TestingHookInterfaceReturnsArray::class);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionCode(1573479911);
+
+        $hookObject->executeHookReturningMergedArray('');
+    }
+
+    /**
+     * @test
+     */
+    public function hookObjectForTestingHookReturningArrayWithNoHookImplementorRegisteredFailsForUnknownMethod()
+    {
+        $hookObject = new HookProvider(TestingHookInterfaceReturnsArray::class);
+
+        $this->expectException(\UnexpectedValueException::class);
+        $this->expectExceptionCode(1573480302);
+
+        $hookObject->executeHookReturningMergedArray('methodNotImplemented');
+    }
+
+    /**
+     * @test
+     */
+    public function hookObjectForTestingHookReturningArrayWithOneHookImplementorRegisteredReturnsFilledArray()
+    {
+        $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['seminars'][TestingHookInterfaceReturnsArray::class][1577363366] =
+            TestingHookImplementorReturnsArray::class;
+        $hookObject = new HookProvider(TestingHookInterfaceReturnsArray::class);
+
+        self::assertSame(
+            ['me' => 'ok','overwritten' => 'initial',],
+            $hookObject->executeHookReturningMergedArray('testHookMethodReturnsArray')
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function hookObjectForTestingHookReturningArrayWithTwoHookImplementorsRegisteredReturnsMergedArray()
+    {
+        $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['seminars'][TestingHookInterfaceReturnsArray::class][1577363366] =
+            TestingHookImplementorReturnsArray::class;
+        $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['seminars'][TestingHookInterfaceReturnsArray::class][1577363367] =
+            TestingHookImplementorReturnsArray2::class;
+        $hookObject = new HookProvider(TestingHookInterfaceReturnsArray::class);
+
+        self::assertSame(
+            ['me' => 'ok','overwritten' => 'replaced','me2' => 'ok',],
+            $hookObject->executeHookReturningMergedArray('testHookMethodReturnsArray')
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function hookObjectForTestingHookReturningArrayWithTwoHookImplementorsRegisteredReturnsNestedMergedArray()
+    {
+        $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['seminars'][TestingHookInterfaceReturnsArray::class][1577363366] =
+            TestingHookImplementorReturnsArray::class;
+        $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['seminars'][TestingHookInterfaceReturnsArray::class][1577363367] =
+            TestingHookImplementorReturnsArray2::class;
+        $hookObject = new HookProvider(TestingHookInterfaceReturnsArray::class);
+
+        self::assertSame(
+            ['me' => ['status' => true], 'me1' => ['status' => true], 'me2' => ['status' => false, 'newValue' => 'new2']],
+            $hookObject->executeHookReturningMergedArray('testHookMethodReturnsNestedArray')
+        );
     }
 }


### PR DESCRIPTION
This hook requires the return of complex data. I chose a merged array for that, as it is the most flexible solution I could think of. All hooks registered get the same parameters, and the resulting arrays are merged and return to the caller.

I will add the CHANGELOG line when it is ready to merge.