### PR TITLE
[FEATURE] Enhance hook provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Add `AbstractModel::comesFromDatabase` (#364)
 - Add php-cs-fixer to the CI (#351)
 - Add new seminar single view hook (#338, #345)
-- Add hook base (#313, #336)
+- Add hook base (#313, #336, #444)
 - Support TYPO3 9LTS (#322, #324)
 - Add code sniffing and fixing (#319)
 - Enable modifying the BagBuilder limitations in hooks (#308)

--- a/Classes/Hooks/HookProvider.php
+++ b/Classes/Hooks/HookProvider.php
@@ -120,9 +120,7 @@ class HookProvider
             $result[] = $hook->$method(...$params);
         }
 
-        \array_merge(...$result);
-
-        return $result;
+        return \array_merge([], ...$result);
     }
 
     /**

--- a/Classes/Hooks/HookProvider.php
+++ b/Classes/Hooks/HookProvider.php
@@ -86,21 +86,10 @@ class HookProvider
      * @param mixed $params parameters to $method()
      *
      * @return void
-     *
-     * @throws \InvalidArgumentException
-     * @throws \UnexpectedValueException
      */
     public function executeHook(string $method, ...$params)
     {
-        if ($method === '') {
-            throw new \InvalidArgumentException('The parameter $method must not be empty.', 1573479911);
-        }
-        if (!\in_array($method, \get_class_methods($this->interfaceName), true)) {
-            throw new \UnexpectedValueException(
-                'The interface ' . $this->interfaceName . ' does not contain method ' . $method . '.',
-                1573480302
-            );
-        }
+        $this->validateHookMethod($method);
 
         foreach ($this->getHooks() as $hook) {
             $hook->$method(...$params);
@@ -146,5 +135,28 @@ class HookProvider
         }
 
         $this->hooksHaveBeenRetrieved = true;
+    }
+
+    /**
+     * Validates the requested hooked-in methods.
+     *
+     * @param string $method the method to execute
+     *
+     * @return void
+     *
+     * @throws \InvalidArgumentException
+     * @throws \UnexpectedValueException
+     */
+    protected function validateHookMethod(string $method)
+    {
+        if ($method === '') {
+            throw new \InvalidArgumentException('The parameter $method must not be empty.', 1573479911);
+        }
+        if (!\in_array($method, \get_class_methods($this->interfaceName), true)) {
+            throw new \UnexpectedValueException(
+                'The interface ' . $this->interfaceName . ' does not contain method ' . $method . '.',
+                1573480302
+            );
+        }
     }
 }

--- a/Classes/Hooks/HookProvider.php
+++ b/Classes/Hooks/HookProvider.php
@@ -19,9 +19,16 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  * point is reached and re-used for all other points.
  *
  * Implementing hook points
- * Instantiate this class with the interface you need implemented. First call to `executeHook()` will
+ * Instantiate this class with the interface you need implemented. First call to `executeHook[...]()` will
  * instantiate the registered classes. Every further call will reuse the same instances. On each
  * call provide the method required at the point in your program.
+ *
+ * The most recommended way to design a hook method is passing objects to manipulate. Use `executeHook()`
+ * for these methods. By passing an object to the hooked-in methods the object content can be manipulated
+ * and by this change the behaviour of `seminars`.
+ *
+ * In some cases, when a return value is required, You may use `executeHookReturningMergedArray()` for returning complex
+ * results while all hooked-in methods process the same parameters.
  *
  * There is an optional index to `$GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['seminars']`, provided
  * for easier conversion of existing hooks to this class.
@@ -94,6 +101,26 @@ class HookProvider
         foreach ($this->getHooks() as $hook) {
             $hook->$method(...$params);
         }
+    }
+
+    /**
+     * Executes the hooked-in methods, that return result arrays.
+     *
+     * @param string $method the method to execute
+     * @param mixed $params parameters to $method()
+     *
+     * @return array the merged result arrays
+     */
+    public function executeHookReturningMergedArray(string $method, ...$params): array
+    {
+        $this->validateHookMethod($method);
+
+        $result = [];
+        foreach ($this->getHooks() as $hook) {
+            $result = array_merge($result, $hook->$method(...$params));
+        }
+
+        return $result;
     }
 
     /**

--- a/Classes/Hooks/HookProvider.php
+++ b/Classes/Hooks/HookProvider.php
@@ -109,7 +109,7 @@ class HookProvider
      * @param string $method the method to execute
      * @param mixed $params parameters to `$method()`
      *
-     * @return array the merged result arrays
+     * @return array the merged result arrays with numeric or string keys, may contain duplicate values
      */
     public function executeHookReturningMergedArray(string $method, ...$params): array
     {

--- a/Classes/Hooks/HookProvider.php
+++ b/Classes/Hooks/HookProvider.php
@@ -24,10 +24,10 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  * call provide the method required at the point in your program.
  *
  * The most recommended way to design a hook method is passing objects to manipulate. Use `executeHook()`
- * for these methods. By passing an object to the hooked-in methods the object content can be manipulated
+ * for these methods. By passing an object to the hooked-in methods, the object content can be manipulated,
  * and by this change the behaviour of `seminars`.
  *
- * In some cases, when a return value is required, You may use `executeHookReturningMergedArray()` for returning complex
+ * In some cases, when a return value is required, you may use `executeHookReturningMergedArray()` for returning complex
  * results while all hooked-in methods process the same parameters.
  *
  * There is an optional index to `$GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['seminars']`, provided
@@ -90,7 +90,7 @@ class HookProvider
      * Executes the hooked-in methods.
      *
      * @param string $method the method to execute
-     * @param mixed $params parameters to $method()
+     * @param mixed $params parameters to `$method()`
      *
      * @return void
      */
@@ -104,10 +104,10 @@ class HookProvider
     }
 
     /**
-     * Executes the hooked-in methods, that return result arrays.
+     * Executes the hooked-in methods that return result arrays.
      *
      * @param string $method the method to execute
-     * @param mixed $params parameters to $method()
+     * @param mixed $params parameters to `$method()`
      *
      * @return array the merged result arrays
      */
@@ -117,8 +117,10 @@ class HookProvider
 
         $result = [];
         foreach ($this->getHooks() as $hook) {
-            $result = array_merge($result, $hook->$method(...$params));
+            $result[] = $hook->$method(...$params);
         }
+
+        \array_merge(...$result);
 
         return $result;
     }

--- a/Tests/Unit/Hooks/Fixtures/TestingHookImplementorReturnsArray.php
+++ b/Tests/Unit/Hooks/Fixtures/TestingHookImplementorReturnsArray.php
@@ -20,7 +20,7 @@ final class TestingHookImplementorReturnsArray implements TestingHookInterfaceRe
      */
     public function testHookMethodReturnsArray(): array
     {
-        return ['me' => 'ok','overwritten' => 'initial',];
+        return ['me' => 'ok', 'overwritten' => 'initial'];
     }
 
     /**
@@ -31,8 +31,8 @@ final class TestingHookImplementorReturnsArray implements TestingHookInterfaceRe
     public function testHookMethodReturnsNestedArray(): array
     {
         return [
-            'me' => ['status' => true ],
-            'me1' => ['status' => false, 'newValue' => 'new1', ]
+            'me' => ['status' => true],
+            'me1' => ['status' => false, 'newValue' => 'new1'],
         ];
     }
 }

--- a/Tests/Unit/Hooks/Fixtures/TestingHookImplementorReturnsArray.php
+++ b/Tests/Unit/Hooks/Fixtures/TestingHookImplementorReturnsArray.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OliverKlee\Seminars\Tests\Unit\Hooks\Fixtures;
+
+/**
+ * Valid test interface implementation to use with the HookProviderTest.
+ *
+ * Will be accepted, because it implements TestingHookInterfaceReturnsArray.
+ *
+ * @author Michael Kramer <m.kramer@mxp.de>
+ */
+final class TestingHookImplementorReturnsArray implements TestingHookInterfaceReturnsArray
+{
+    /**
+     * Gets called during HookProvider tests.
+     *
+     * @return array
+     */
+    public function testHookMethodReturnsArray(): array
+    {
+        return ['me' => 'ok','overwritten' => 'initial',];
+    }
+
+    /**
+     * Gets called during HookProvider tests.
+     *
+     * @return array[]
+     */
+    public function testHookMethodReturnsNestedArray(): array
+    {
+        return [
+            'me' => ['status' => true ],
+            'me1' => ['status' => false, 'newValue' => 'new1', ]
+        ];
+    }
+}

--- a/Tests/Unit/Hooks/Fixtures/TestingHookImplementorReturnsArray.php
+++ b/Tests/Unit/Hooks/Fixtures/TestingHookImplementorReturnsArray.php
@@ -7,7 +7,7 @@ namespace OliverKlee\Seminars\Tests\Unit\Hooks\Fixtures;
 /**
  * Valid test interface implementation to use with the HookProviderTest.
  *
- * Will be accepted, because it implements TestingHookInterfaceReturnsArray.
+ * Will be accepted because it implements TestingHookInterfaceReturnsArray.
  *
  * @author Michael Kramer <m.kramer@mxp.de>
  */
@@ -16,7 +16,7 @@ final class TestingHookImplementorReturnsArray implements TestingHookInterfaceRe
     /**
      * Gets called during HookProvider tests.
      *
-     * @return array
+     * @return string[]
      */
     public function testHookMethodReturnsArray(): array
     {

--- a/Tests/Unit/Hooks/Fixtures/TestingHookImplementorReturnsArray2.php
+++ b/Tests/Unit/Hooks/Fixtures/TestingHookImplementorReturnsArray2.php
@@ -16,7 +16,7 @@ final class TestingHookImplementorReturnsArray2 implements TestingHookInterfaceR
     /**
      * Gets called during HookProvider tests.
      *
-     * @return array
+     * @return string[]
      */
     public function testHookMethodReturnsArray(): array
     {

--- a/Tests/Unit/Hooks/Fixtures/TestingHookImplementorReturnsArray2.php
+++ b/Tests/Unit/Hooks/Fixtures/TestingHookImplementorReturnsArray2.php
@@ -20,7 +20,7 @@ final class TestingHookImplementorReturnsArray2 implements TestingHookInterfaceR
      */
     public function testHookMethodReturnsArray(): array
     {
-        return ['me2' => 'ok','overwritten' => 'replaced',];
+        return ['me2' => 'ok', 'overwritten' => 'replaced'];
     }
 
     /**
@@ -31,8 +31,8 @@ final class TestingHookImplementorReturnsArray2 implements TestingHookInterfaceR
     public function testHookMethodReturnsNestedArray(): array
     {
         return [
-            'me1' => ['status' => true ],
-            'me2' => ['status' => false, 'newValue' => 'new2', ]
+            'me1' => ['status' => true],
+            'me2' => ['status' => false, 'newValue' => 'new2'],
         ];
     }
 }

--- a/Tests/Unit/Hooks/Fixtures/TestingHookImplementorReturnsArray2.php
+++ b/Tests/Unit/Hooks/Fixtures/TestingHookImplementorReturnsArray2.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OliverKlee\Seminars\Tests\Unit\Hooks\Fixtures;
+
+/**
+ * Second valid test interface implementation to use with the HookProviderTest.
+ *
+ * Will be accepted as a second hooked-in class.
+ *
+ * @author Michael Kramer <m.kramer@mxp.de>
+ */
+final class TestingHookImplementorReturnsArray2 implements TestingHookInterfaceReturnsArray
+{
+    /**
+     * Gets called during HookProvider tests.
+     *
+     * @return array
+     */
+    public function testHookMethodReturnsArray(): array
+    {
+        return ['me2' => 'ok','overwritten' => 'replaced',];
+    }
+
+    /**
+     * Gets called during HookProvider tests.
+     *
+     * @return array[]
+     */
+    public function testHookMethodReturnsNestedArray(): array
+    {
+        return [
+            'me1' => ['status' => true ],
+            'me2' => ['status' => false, 'newValue' => 'new2', ]
+        ];
+    }
+}

--- a/Tests/Unit/Hooks/Fixtures/TestingHookInterfaceReturnsArray.php
+++ b/Tests/Unit/Hooks/Fixtures/TestingHookInterfaceReturnsArray.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OliverKlee\Seminars\Tests\Unit\Hooks\Fixtures;
+
+use OliverKlee\Seminars\Hooks\Interfaces\Hook;
+
+/**
+ * Valid test interface returning an array to use with the HookProviderTest.
+ *
+ * Will be accepted, because it extends Hook.
+ *
+ * @author Michael Kramer <m.kramer@mxp.de>
+ */
+interface TestingHookInterfaceReturnsArray extends Hook
+{
+    /**
+     * Gets called during HookProvider tests.
+     *
+     * @return array
+     */
+    public function testHookMethodReturnsArray(): array;
+
+    /**
+     * Gets called during HookProvider tests.
+     *
+     * @return array[]
+     */
+    public function testHookMethodReturnsNestedArray(): array;
+}

--- a/Tests/Unit/Hooks/Fixtures/TestingHookInterfaceReturnsArray.php
+++ b/Tests/Unit/Hooks/Fixtures/TestingHookInterfaceReturnsArray.php
@@ -9,7 +9,7 @@ use OliverKlee\Seminars\Hooks\Interfaces\Hook;
 /**
  * Valid test interface returning an array to use with the HookProviderTest.
  *
- * Will be accepted, because it extends Hook.
+ * Will be accepted because it extends `Hook`.
  *
  * @author Michael Kramer <m.kramer@mxp.de>
  */
@@ -18,7 +18,7 @@ interface TestingHookInterfaceReturnsArray extends Hook
     /**
      * Gets called during HookProvider tests.
      *
-     * @return array
+     * @return string[]
      */
     public function testHookMethodReturnsArray(): array;
 

--- a/Tests/Unit/Hooks/HookProviderTest.php
+++ b/Tests/Unit/Hooks/HookProviderTest.php
@@ -421,7 +421,7 @@ final class HookProviderTest extends UnitTestCase
         $hookObject = new HookProvider(TestingHookInterfaceReturnsArray::class);
 
         self::assertSame(
-            ['me' => 'ok','overwritten' => 'initial',],
+            ['me' => 'ok', 'overwritten' => 'initial'],
             $hookObject->executeHookReturningMergedArray('testHookMethodReturnsArray')
         );
     }
@@ -438,7 +438,7 @@ final class HookProviderTest extends UnitTestCase
         $hookObject = new HookProvider(TestingHookInterfaceReturnsArray::class);
 
         self::assertSame(
-            ['me' => 'ok','overwritten' => 'replaced','me2' => 'ok',],
+            ['me' => 'ok', 'overwritten' => 'replaced', 'me2' => 'ok'],
             $hookObject->executeHookReturningMergedArray('testHookMethodReturnsArray')
         );
     }

--- a/Tests/Unit/Hooks/HookProviderTest.php
+++ b/Tests/Unit/Hooks/HookProviderTest.php
@@ -10,8 +10,11 @@ use OliverKlee\Seminars\Hooks\Interfaces\Hook;
 use OliverKlee\Seminars\Tests\Unit\Hooks\Fixtures\TestingHookImplementor;
 use OliverKlee\Seminars\Tests\Unit\Hooks\Fixtures\TestingHookImplementor2;
 use OliverKlee\Seminars\Tests\Unit\Hooks\Fixtures\TestingHookImplementorNotImplementsInterface;
+use OliverKlee\Seminars\Tests\Unit\Hooks\Fixtures\TestingHookImplementorReturnsArray;
+use OliverKlee\Seminars\Tests\Unit\Hooks\Fixtures\TestingHookImplementorReturnsArray2;
 use OliverKlee\Seminars\Tests\Unit\Hooks\Fixtures\TestingHookInterface;
 use OliverKlee\Seminars\Tests\Unit\Hooks\Fixtures\TestingHookInterfaceNotExtendsHook;
+use OliverKlee\Seminars\Tests\Unit\Hooks\Fixtures\TestingHookInterfaceReturnsArray;
 
 /**
  * Test case.
@@ -221,6 +224,18 @@ final class HookProviderTest extends UnitTestCase
 
     /**
      * @test
+     */
+    public function hookObjectForTestHookWithIndexCanBeCreated()
+    {
+        self::assertInstanceOf(HookProvider::class, $this->createHookObject('anyIndex'));
+    }
+
+    /*
+     * Tests concerning Hook::executeHook().
+     */
+
+    /**
+     * @test
      * @doesNotPerformAssertions
      */
     public function hookObjectForTestHookWithNoHookImplementorRegisteredSucceedsForValidMethod()
@@ -305,14 +320,6 @@ final class HookProviderTest extends UnitTestCase
     /**
      * @test
      */
-    public function hookObjectForTestHookWithIndexCanBeCreated()
-    {
-        self::assertInstanceOf(HookProvider::class, $this->createHookObject('anyIndex'));
-    }
-
-    /**
-     * @test
-     */
     public function hookObjectForTestHookWithIndexWithOneHookImplementorRegisteredSucceedsWithMethodCalledOnce()
     {
         $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['seminars']['anyIndex'][1574270061] =
@@ -353,5 +360,103 @@ final class HookProviderTest extends UnitTestCase
 
         self::assertSame(0, TestingHookImplementor::$wasCalled);
         self::assertSame(1, TestingHookImplementor2::$wasCalled);
+    }
+
+    /*
+     * Tests concerning Hook::executeHookReturningMergedArray().
+     */
+
+    /**
+     * @test
+     */
+    public function hookObjectForTestingHookReturningArrayCanBeCreated()
+    {
+        self::assertInstanceOf(HookProvider::class, new HookProvider(TestingHookInterfaceReturnsArray::class));
+    }
+
+    /**
+     * @test
+     */
+    public function hookObjectForTestingHookReturningArrayWithNoHookImplementorRegisteredReturnsEmptyArray()
+    {
+        $hookObject = new HookProvider(TestingHookInterfaceReturnsArray::class);
+
+        self::assertSame([], $hookObject->executeHookReturningMergedArray('testHookMethodReturnsArray'));
+        self::assertSame([], $hookObject->executeHookReturningMergedArray('testHookMethodReturnsNestedArray'));
+    }
+
+    /**
+     * @test
+     */
+    public function hookObjectForTestingHookReturningArrayWithNoHookImplementorRegisteredFailsForEmptyMethod()
+    {
+        $hookObject = new HookProvider(TestingHookInterfaceReturnsArray::class);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionCode(1573479911);
+
+        $hookObject->executeHookReturningMergedArray('');
+    }
+
+    /**
+     * @test
+     */
+    public function hookObjectForTestingHookReturningArrayWithNoHookImplementorRegisteredFailsForUnknownMethod()
+    {
+        $hookObject = new HookProvider(TestingHookInterfaceReturnsArray::class);
+
+        $this->expectException(\UnexpectedValueException::class);
+        $this->expectExceptionCode(1573480302);
+
+        $hookObject->executeHookReturningMergedArray('methodNotImplemented');
+    }
+
+    /**
+     * @test
+     */
+    public function hookObjectForTestingHookReturningArrayWithOneHookImplementorRegisteredReturnsFilledArray()
+    {
+        $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['seminars'][TestingHookInterfaceReturnsArray::class][1577363366] =
+            TestingHookImplementorReturnsArray::class;
+        $hookObject = new HookProvider(TestingHookInterfaceReturnsArray::class);
+
+        self::assertSame(
+            ['me' => 'ok','overwritten' => 'initial',],
+            $hookObject->executeHookReturningMergedArray('testHookMethodReturnsArray')
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function hookObjectForTestingHookReturningArrayWithTwoHookImplementorsRegisteredReturnsMergedArray()
+    {
+        $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['seminars'][TestingHookInterfaceReturnsArray::class][1577363366] =
+            TestingHookImplementorReturnsArray::class;
+        $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['seminars'][TestingHookInterfaceReturnsArray::class][1577363367] =
+            TestingHookImplementorReturnsArray2::class;
+        $hookObject = new HookProvider(TestingHookInterfaceReturnsArray::class);
+
+        self::assertSame(
+            ['me' => 'ok','overwritten' => 'replaced','me2' => 'ok',],
+            $hookObject->executeHookReturningMergedArray('testHookMethodReturnsArray')
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function hookObjectForTestingHookReturningArrayWithTwoHookImplementorsRegisteredReturnsNestedMergedArray()
+    {
+        $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['seminars'][TestingHookInterfaceReturnsArray::class][1577363366] =
+            TestingHookImplementorReturnsArray::class;
+        $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['seminars'][TestingHookInterfaceReturnsArray::class][1577363367] =
+            TestingHookImplementorReturnsArray2::class;
+        $hookObject = new HookProvider(TestingHookInterfaceReturnsArray::class);
+
+        self::assertSame(
+            ['me' => ['status' => true], 'me1' => ['status' => true], 'me2' => ['status' => false, 'newValue' => 'new2']],
+            $hookObject->executeHookReturningMergedArray('testHookMethodReturnsNestedArray')
+        );
     }
 }


### PR DESCRIPTION
Split #443 as requested by @oliverklee.

I chose a merged array to be able to return complex data sets, as it is the most flexible solution I could think of. All hooks registered get the same parameters, and the resulting arrays are merged and returned to the caller.

I will add the CHANGELOG line when it is ready to merge.