### PR TITLE
[FEATURE] Add tests for registration deadline sanitization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ## x.y.z
 
 ### Added
+- Add tests for the DataMapper sanitization (#454)
 - Add new backend registration list hook (#437)
 - Add new selector widget hook (#436)
 - Add documentation rendering using docker-compose (#432)

--- a/Tests/Functional/Hooks/DataHandlerHookTest.php
+++ b/Tests/Functional/Hooks/DataHandlerHookTest.php
@@ -6,6 +6,7 @@ namespace OliverKlee\Seminars\Tests\Functional\Hooks;
 
 use Nimut\TestingFramework\TestCase\FunctionalTestCase;
 use OliverKlee\Seminars\Hooks\DataHandlerHook;
+use TYPO3\CMS\Core\DataHandling\DataHandler;
 
 /**
  * Test case.
@@ -15,9 +16,33 @@ use OliverKlee\Seminars\Hooks\DataHandlerHook;
 final class DataHandlerHookTest extends FunctionalTestCase
 {
     /**
+     * @var string
+     */
+    const TABLE_SEMINARS = 'tx_seminars_seminars';
+
+    /**
      * @var string[]
      */
     protected $testExtensionsToLoad = ['typo3conf/ext/seminars'];
+
+    /**
+     * @var DataHandlerHook
+     */
+    private $subject = null;
+
+    /**
+     * @var DataHandler
+     */
+    private $dataHandler = null;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->dataHandler = new DataHandler();
+
+        $this->subject = new DataHandlerHook();
+    }
 
     private function getDataMapperConfigurationForSeminars(): string
     {
@@ -34,5 +59,97 @@ final class DataHandlerHookTest extends FunctionalTestCase
         $reference = $this->getDataMapperConfigurationForSeminars();
 
         self::assertSame(DataHandlerHook::class, $reference);
+    }
+
+    /**
+     * @return int[][]
+     */
+    public function validRegistrationDeadlineDataProvider(): array
+    {
+        return [
+            'no begin date and no deadline' => [1, 0],
+            'begin date and no deadline' => [2, 0],
+            'begin date and same deadline' => [3, 1000],
+            'begin date and earlier deadline' => [4, 999],
+        ];
+    }
+
+    /**
+     * @test
+     *
+     * @param int $uid
+     * @param int $expectedDeadline
+     *
+     * @dataProvider validRegistrationDeadlineDataProvider
+     */
+    public function afterDatabaseOperationsOnUpdateKeepsValidRegistrationDeadline(int $uid, int $expectedDeadline)
+    {
+        $this->importDataSet(__DIR__ . '/Fixtures/DataMapperHook.xml');
+        $data = $this->getDatabaseConnection()->selectSingleRow('*', self::TABLE_SEMINARS, 'uid = ' . $uid);
+
+        $this->subject
+            ->processDatamap_afterDatabaseOperations('update', self::TABLE_SEMINARS, $uid, $data, $this->dataHandler);
+        $this->subject->processDatamap_afterAllOperations();
+
+        $row = $this->getDatabaseConnection()->selectSingleRow('*', self::TABLE_SEMINARS, 'uid = ' . $uid);
+        self::assertSame($expectedDeadline, $row['deadline_registration']);
+    }
+
+    /**
+     * @return int[][]
+     */
+    public function invalidRegistrationDeadlineDataProvider(): array
+    {
+        return [
+            'begin date before registration deadline' => [5],
+            'no begin date, but registration deadline' => [6],
+        ];
+    }
+
+    /**
+     * @test
+     *
+     * @param int $uid
+     *
+     * @dataProvider invalidRegistrationDeadlineDataProvider
+     */
+    public function afterDatabaseOperationsOnUpdateResetsInvalidRegistrationDeadline(int $uid)
+    {
+        $this->importDataSet(__DIR__ . '/Fixtures/DataMapperHook.xml');
+        $data = $this->getDatabaseConnection()->selectSingleRow('*', self::TABLE_SEMINARS, 'uid = ' . $uid);
+
+        $this->subject
+            ->processDatamap_afterDatabaseOperations('update', self::TABLE_SEMINARS, $uid, $data, $this->dataHandler);
+        $this->subject->processDatamap_afterAllOperations();
+
+        $row = $this->getDatabaseConnection()->selectSingleRow('*', self::TABLE_SEMINARS, 'uid = ' . $uid);
+        self::assertSame(0, $row['deadline_registration']);
+    }
+
+    /**
+     * @test
+     *
+     * @param int $uid
+     *
+     * @dataProvider invalidRegistrationDeadlineDataProvider
+     */
+    public function afterDatabaseOperationsOnNewResetsInvalidRegistrationDeadline(int $uid)
+    {
+        $this->importDataSet(__DIR__ . '/Fixtures/DataMapperHook.xml');
+        $data = $this->getDatabaseConnection()->selectSingleRow('*', self::TABLE_SEMINARS, 'uid = ' . $uid);
+        $temporaryUid = 'NEW5e0f43477dcd4869591288';
+        $this->dataHandler->substNEWwithIDs[$temporaryUid] = $uid;
+
+        $this->subject->processDatamap_afterDatabaseOperations(
+            'new',
+            self::TABLE_SEMINARS,
+            $temporaryUid,
+            $data,
+            $this->dataHandler
+        );
+        $this->subject->processDatamap_afterAllOperations();
+
+        $row = $this->getDatabaseConnection()->selectSingleRow('*', self::TABLE_SEMINARS, 'uid = ' . $uid);
+        self::assertSame(0, $row['deadline_registration']);
     }
 }

--- a/Tests/Functional/Hooks/Fixtures/DataMapperHook.xml
+++ b/Tests/Functional/Hooks/Fixtures/DataMapperHook.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<dataset>
+    <tx_seminars_seminars>
+        <uid>1</uid>
+        <title>event with no begin date and no registration deadline</title>
+    </tx_seminars_seminars>
+    <tx_seminars_seminars>
+        <uid>2</uid>
+        <title>event with a begin date and no registration deadline</title>
+        <begin_date>1000</begin_date>
+    </tx_seminars_seminars>
+    <tx_seminars_seminars>
+        <uid>3</uid>
+        <title>event with a begin date and a equal registration deadline</title>
+        <begin_date>1000</begin_date>
+        <deadline_registration>1000</deadline_registration>
+    </tx_seminars_seminars>
+    <tx_seminars_seminars>
+        <uid>4</uid>
+        <title>event with a begin date and an earlier registration deadline</title>
+        <begin_date>1000</begin_date>
+        <deadline_registration>999</deadline_registration>
+    </tx_seminars_seminars>
+    <tx_seminars_seminars>
+        <uid>5</uid>
+        <title>event with a begin date and a later registration deadline</title>
+        <begin_date>1000</begin_date>
+        <deadline_registration>1001</deadline_registration>
+    </tx_seminars_seminars>
+    <tx_seminars_seminars>
+        <uid>6</uid>
+        <title>event with no begin date and a registration deadline</title>
+        <deadline_registration>1000</deadline_registration>
+    </tx_seminars_seminars>
+</dataset>


### PR DESCRIPTION
The DataMapper should set the registration deadline to zero if it
is later than the begin date.

Part of #450