### PR TITLE
[FEATURE] Add time span hooks, tests and docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ## x.y.z
 
 ### Added
+- Add new date and time span formatting hooks (#460)
 
 ### Changed
 - Improve the code autoformatting (#502)

--- a/Classes/Hooks/Interfaces/DateTimeSpan.php
+++ b/Classes/Hooks/Interfaces/DateTimeSpan.php
@@ -14,32 +14,48 @@ interface DateTimeSpan extends Hook
     /**
      * Modifies the date span string.
      *
-     * The date format for the date parts are configured in TypoScript (`dateFormatYMD` etc.).
      * This allows modifying the assembly of start and end date to the date span.
      * E.g., for Hungarian: '01.-03.01.2019' -> '2019.01.01.-03.'.
      *
+     * The date format for the date parts are configured in TypoScript (`dateFormatYMD` etc.).
+     * Get them from `$dateTimeSpan->getConfValueString('dateFormatYMD')` etc. The event
+     * dates are also retrievable:
+     * `$beginDateTime = $dateTimeSpan->getBeginDateAsTimestamp();`
+     * `$endDateTime = $dateTimeSpan->getEndDateAsTimestamp();`
+     *
      * @param string $dateSpan the date span produced by `AbstractTimeSpan::getDate()`
-     * @param string $beginDate the formatted begin date part (`dateFormatYMD`)
+     * @param \Tx_Seminars_OldModel_AbstractTimeSpan $dateTimeSpan the date provider
      * @param string $dash the glue used by `AbstractTimeSpan::getDate()` (may be HTML encoded)
-     * @param string $endDate the formatted end date part (`dateFormatYMD`)
      *
      * @return string the modified date span to use
      */
-    public function modifyDateSpan(string $dateSpan, string $beginDate, string $dash, string $endDate): string;
+    public function modifyDateSpan(
+        string $dateSpan,
+        \Tx_Seminars_OldModel_AbstractTimeSpan $dateTimeSpan,
+        string $dash
+    ): string;
 
     /**
      * Modifies the time span string.
      *
-     * The time format for the time parts is configured in TypoScript (`timeFormat`).
      * This allows modifying the assembly of start and end time to the time span.
      * E.g., for Hungarian: '9:00-10:30' -> '9:00tol 10:30ban'.
      *
+     * The time format for the time parts is configured in TypoScript (`timeFormat`).
+     * Get it from `$dateTimeSpan->getConfValueString('timeFormat')`. The event
+     * times are also retrievable:
+     * `$beginDateTime = $dateTimeSpan->getBeginDateAsTimestamp();`
+     * `$endDateTime = $dateTimeSpan->getEndDateAsTimestamp();`
+     *
      * @param string $timeSpan the time span produced by `AbstractTimeSpan::getTime()`
-     * @param string $beginTime the formatted begin time part (`timeFormat`)
+     * @param \Tx_Seminars_OldModel_AbstractTimeSpan $dateTimeSpan the date provider
      * @param string $dash the glue used by `AbstractTimeSpan::getTime()` (may be HTML encoded)
-     * @param string $endTime the formatted end time part (`timeFormat`)
      *
      * @return string the modified time span to use
      */
-    public function modifyTimeSpan(string $timeSpan, string $beginTime, string $dash, string $endTime): string;
+    public function modifyTimeSpan(
+        string $timeSpan,
+        \Tx_Seminars_OldModel_AbstractTimeSpan $dateTimeSpan,
+        string $dash
+    ): string;
 }

--- a/Classes/Hooks/Interfaces/DateTimeSpan.php
+++ b/Classes/Hooks/Interfaces/DateTimeSpan.php
@@ -5,18 +5,18 @@ declare(strict_types=1);
 namespace OliverKlee\Seminars\Hooks\Interfaces;
 
 /**
- * Use this interface for hooks concerning the date span.
+ * Use this interface for hooks concerning the date or the time span.
  *
  * @author Michael Kramer <m.kramer@mxp.de>
  */
-interface TimeSpan extends Hook
+interface DateTimeSpan extends Hook
 {
     /**
      * Modifies the date span string.
      *
-     * The date format for the date parts are configured in TypoScript (`dateFormatYMD` etc).
+     * The date format for the date parts are configured in TypoScript (`dateFormatYMD` etc.).
      * This allows modifying the assembly of start and end date to the date span.
-     * E.g. for Hungarian: '01.-03.01.2019' -> '2019.01.01.-03.'.
+     * E.g., for Hungarian: '01.-03.01.2019' -> '2019.01.01.-03.'.
      *
      * @param string $dateSpan the date span produced by `AbstractTimeSpan::getDate()`
      * @param string $beginDate the formatted begin date part (`dateFormatYMD`)
@@ -32,7 +32,7 @@ interface TimeSpan extends Hook
      *
      * The time format for the time parts is configured in TypoScript (`timeFormat`).
      * This allows modifying the assembly of start and end time to the time span.
-     * E.g. for Hungarian: '9:00-10:30' -> '9:00tol 10:30ban'.
+     * E.g., for Hungarian: '9:00-10:30' -> '9:00tol 10:30ban'.
      *
      * @param string $timeSpan the time span produced by `AbstractTimeSpan::getTime()`
      * @param string $beginTime the formatted begin time part (`timeFormat`)

--- a/Classes/Hooks/Interfaces/TimeSpan.php
+++ b/Classes/Hooks/Interfaces/TimeSpan.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OliverKlee\Seminars\Hooks\Interfaces;
+
+/**
+ * Use this interface for hooks concerning the date span.
+ *
+ * @author Michael Kramer <m.kramer@mxp.de>
+ */
+interface TimeSpan extends Hook
+{
+    /**
+     * Modifies the date span string.
+     *
+     * The date format for the date parts are configured in TypoScript (`dateFormatYMD` etc).
+     * This allows modifying the assembly of start and end date to the date span.
+     * E.g. for Hungarian: '01.-03.01.2019' -> '2019.01.01.-03.'.
+     *
+     * @param string $dateSpan the date span produced by `AbstractTimeSpan::getDate()`
+     * @param string $beginDate the formatted begin date part (`dateFormatYMD`)
+     * @param string $dash the glue used by `AbstractTimeSpan::getDate()` (may be HTML encoded)
+     * @param string $endDate the formatted end date part (`dateFormatYMD`)
+     *
+     * @return string the modified date span to use
+     */
+    public function modifyDateSpan(string $dateSpan, string $beginDate, string $dash, string $endDate): string;
+
+    /**
+     * Modifies the time span string.
+     *
+     * The time format for the time parts is configured in TypoScript (`timeFormat`).
+     * This allows modifying the assembly of start and end time to the time span.
+     * E.g. for Hungarian: '9:00-10:30' -> '9:00tol 10:30ban'.
+     *
+     * @param string $timeSpan the time span produced by `AbstractTimeSpan::getTime()`
+     * @param string $beginTime the formatted begin time part (`timeFormat`)
+     * @param string $dash the glue used by `AbstractTimeSpan::getTime()` (may be HTML encoded)
+     * @param string $endTime the formatted end time part (`timeFormat`)
+     *
+     * @return string the modified time span to use
+     */
+    public function modifyTimeSpan(string $timeSpan, string $beginTime, string $dash, string $endTime): string;
+}

--- a/Classes/OldModel/AbstractTimeSpan.php
+++ b/Classes/OldModel/AbstractTimeSpan.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 use OliverKlee\Seminars\Hooks\HookProvider;
-use OliverKlee\Seminars\Hooks\Interfaces\TimeSpan;
+use OliverKlee\Seminars\Hooks\Interfaces\DateTimeSpan;
 use OliverKlee\Seminars\OldModel\AbstractModel;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
@@ -19,7 +19,7 @@ abstract class Tx_Seminars_OldModel_AbstractTimeSpan extends AbstractModel imple
     /**
      * @var HookProvider|null
      */
-    protected $timeSpanHookProvider = null;
+    protected $dateTimeSpanHookProvider = null;
 
     /**
      * Gets the begin date.
@@ -121,7 +121,7 @@ abstract class Tx_Seminars_OldModel_AbstractTimeSpan extends AbstractModel imple
                     $result = $beginDateDay;
                 }
                 $result .= $dash . $endDateDay;
-                $result = $this->getTimeSpanHookProvider()->executeHookReturningModifiedValue(
+                $result = $this->getDateTimeSpanHookProvider()->executeHookReturningModifiedValue(
                     'modifyDateSpan',
                     $result,
                     $beginDateDay,
@@ -174,7 +174,7 @@ abstract class Tx_Seminars_OldModel_AbstractTimeSpan extends AbstractModel imple
         // and the end time is not the same as the begin time.
         if (($beginTime !== $endTime) && $this->hasEndTime()) {
             $result .= $dash . $endTime;
-            $result = $this->getTimeSpanHookProvider()->executeHookReturningModifiedValue(
+            $result = $this->getDateTimeSpanHookProvider()->executeHookReturningModifiedValue(
                 'modifyTimeSpan',
                 $result,
                 $beginTime,
@@ -328,19 +328,19 @@ abstract class Tx_Seminars_OldModel_AbstractTimeSpan extends AbstractModel imple
     abstract public function getPlaceShort(): string;
 
     /**
-     * Gets the hook provider for the list view.
+     * Gets the hook provider for the date and time span.
      *
      * @return HookProvider
      */
-    protected function getTimeSpanHookProvider(): HookProvider
+    protected function getDateTimeSpanHookProvider(): HookProvider
     {
-        if (!$this->timeSpanHookProvider instanceof HookProvider) {
-            $this->timeSpanHookProvider = GeneralUtility::makeInstance(
+        if (!$this->dateTimeSpanHookProvider instanceof HookProvider) {
+            $this->dateTimeSpanHookProvider = GeneralUtility::makeInstance(
                 HookProvider::class,
-                TimeSpan::class
+                DateTimeSpan::class
             );
         }
 
-        return $this->timeSpanHookProvider;
+        return $this->dateTimeSpanHookProvider;
     }
 }

--- a/Classes/OldModel/AbstractTimeSpan.php
+++ b/Classes/OldModel/AbstractTimeSpan.php
@@ -124,9 +124,8 @@ abstract class Tx_Seminars_OldModel_AbstractTimeSpan extends AbstractModel imple
                 $result = $this->getDateTimeSpanHookProvider()->executeHookReturningModifiedValue(
                     'modifyDateSpan',
                     $result,
-                    $beginDateDay,
-                    $dash,
-                    $endDateDay
+                    $this,
+                    $dash
                 );
             }
         } else {
@@ -177,9 +176,8 @@ abstract class Tx_Seminars_OldModel_AbstractTimeSpan extends AbstractModel imple
             $result = $this->getDateTimeSpanHookProvider()->executeHookReturningModifiedValue(
                 'modifyTimeSpan',
                 $result,
-                $beginTime,
-                $dash,
-                $endTime
+                $this,
+                $dash
             );
         }
         $hours = $this->translate('label_hours');

--- a/Documentation/DE/Referenz/Hooks/Index.rst
+++ b/Documentation/DE/Referenz/Hooks/Index.rst
@@ -29,6 +29,7 @@ Es gibt Hooks in diese Teile von seminars:
 * :ref:`registrationform_de`
 * :ref:`notificationemail_de`
 * :ref:`emailsalutation_de`
+* :ref:`datatimespan_de`
 * :ref:`backendemail_de`
 * :ref:`backendregistrationlistview_de`
 
@@ -569,6 +570,71 @@ example:
    // register my hook objects
    $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['seminars']['modifyEmailSalutation'][] = \MyVendor\MyExt\Hooks\ModifySalutationHook::class;
 
+
+.. _datatimespan_de:
+
+Hooks zur Erstellung Datums- und Zeitspannen
+""""""""""""""""""""""""""""""""""""""""""""
+
+Es gibt Hooks in die Erstellung der Datums- und Zeitspannen der Seminare. Wenn an irgendeiner Stelle
+eine Datums- oder Zeitspanne ausgegeben werden soll, werden diese Hooks aufgerufen und erlauben das
+Anpassen der Zusammensetzung. Für die Standard-Zusammensetzung siehe
+:file:`Classes/OldModel/AbstractTimeSpan.php`.
+
+Ihre Klasse, die :php:`\OliverKlee\Seminars\Hooks\Interfaces\TimeSpan` implementiert,
+machen Sie seminars in :file:`ext_localconf.php` Ihrer Extension bekannt:
+
+.. code-block:: php
+
+    $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['seminars'][\OliverKlee\Seminars\Hooks\Interfaces\TimeSpan::class][]
+        = \Tx_Seminarspaypal_Hooks_TimeSpan::class;
+
+Implementieren Sie die benötigten Methoden gemäß dem Interface:
+
+.. code-block:: php
+
+    use \OliverKlee\Seminars\Hooks\Interfaces\TimeSpan;
+
+    class Tx_Seminarspaypal_Hooks_TimeSpan implements TimeSpan
+    {
+        /**
+         * Modifies the date span string.
+         *
+         * The date format for the date parts are configured in TypoScript (`dateFormatYMD` etc).
+         * This allows modifying the assembly of start and end date to the date span.
+         * E.g. for Hungarian: '01.-03.01.2019' -> '2019.01.01.-03.'.
+         *
+         * @param string $dateSpan the date span produced by `AbstractTimeSpan::getDate()`
+         * @param string $beginDate the formatted begin date part (`dateFormatYMD`)
+         * @param string $dash the glue used by `AbstractTimeSpan::getDate()` (may be HTML encoded)
+         * @param string $endDate the formatted end date part (`dateFormatYMD`)
+         *
+         * @return string the modified date span to use
+         */
+        public function modifyDateSpan(string $dateSpan, string $beginDate, string $dash, string $endDate): string
+        {
+            // Hier Ihr Code
+        }
+
+        /**
+         * Modifies the time span string.
+         *
+         * The time format for the time parts is configured in TypoScript (`timeFormat`).
+         * This allows modifying the assembly of start and end time to the time span.
+         * E.g. for Hungarian: '9:00-10:30' -> '9:00tol 10:30ban'.
+         *
+         * @param string $timeSpan the time span produced by `AbstractTimeSpan::getTime()`
+         * @param string $beginTime the formatted begin time part (`timeFormat`)
+         * @param string $dash the glue used by `AbstractTimeSpan::getTime()` (may be HTML encoded)
+         * @param string $endTime the formatted end time part (`timeFormat`)
+         *
+         * @return string the modified time span to use
+         */
+        public function modifyTimeSpan(string $timeSpan, string $beginTime, string $dash, string $endTime): string
+        {
+            // Hier Ihr Code
+        }
+    }
 
 .. _backendemail_de:
 

--- a/Documentation/DE/Referenz/Hooks/Index.rst
+++ b/Documentation/DE/Referenz/Hooks/Index.rst
@@ -600,18 +600,26 @@ Implementieren Sie die benötigten Methoden gemäß dem Interface:
         /**
          * Modifies the date span string.
          *
-         * The date format for the date parts are configured in TypoScript (`dateFormatYMD` etc).
          * This allows modifying the assembly of start and end date to the date span.
-         * E.g. for Hungarian: '01.-03.01.2019' -> '2019.01.01.-03.'.
+         * E.g., for Hungarian: '01.-03.01.2019' -> '2019.01.01.-03.'.
+         *
+         * The date format for the date parts are configured in TypoScript (`dateFormatYMD` etc.).
+         * Get them from `$dateTimeSpan->getConfValueString('dateFormatYMD')` etc. The event
+         * dates are also retrievable:
+         * `$beginDateTime = $dateTimeSpan->getBeginDateAsTimestamp();`
+         * `$endDateTime = $dateTimeSpan->getEndDateAsTimestamp();`
          *
          * @param string $dateSpan the date span produced by `AbstractTimeSpan::getDate()`
-         * @param string $beginDate the formatted begin date part (`dateFormatYMD`)
+         * @param \Tx_Seminars_OldModel_AbstractTimeSpan $dateTimeSpan the date provider
          * @param string $dash the glue used by `AbstractTimeSpan::getDate()` (may be HTML encoded)
-         * @param string $endDate the formatted end date part (`dateFormatYMD`)
          *
          * @return string the modified date span to use
          */
-        public function modifyDateSpan(string $dateSpan, string $beginDate, string $dash, string $endDate): string
+        public function modifyDateSpan(
+            string $dateSpan,
+            \Tx_Seminars_OldModel_AbstractTimeSpan $dateTimeSpan,
+            string $dash
+        ): string
         {
             // Hier Ihr Code
         }
@@ -619,18 +627,26 @@ Implementieren Sie die benötigten Methoden gemäß dem Interface:
         /**
          * Modifies the time span string.
          *
-         * The time format for the time parts is configured in TypoScript (`timeFormat`).
          * This allows modifying the assembly of start and end time to the time span.
-         * E.g. for Hungarian: '9:00-10:30' -> '9:00tol 10:30ban'.
+         * E.g., for Hungarian: '9:00-10:30' -> '9:00tol 10:30ban'.
+         *
+         * The time format for the time parts is configured in TypoScript (`timeFormat`).
+         * Get it from `$dateTimeSpan->getConfValueString('timeFormat')`. The event
+         * times are also retrievable:
+         * `$beginDateTime = $dateTimeSpan->getBeginDateAsTimestamp();`
+         * `$endDateTime = $dateTimeSpan->getEndDateAsTimestamp();`
          *
          * @param string $timeSpan the time span produced by `AbstractTimeSpan::getTime()`
-         * @param string $beginTime the formatted begin time part (`timeFormat`)
+         * @param \Tx_Seminars_OldModel_AbstractTimeSpan $dateTimeSpan the date provider
          * @param string $dash the glue used by `AbstractTimeSpan::getTime()` (may be HTML encoded)
-         * @param string $endTime the formatted end time part (`timeFormat`)
          *
          * @return string the modified time span to use
          */
-        public function modifyTimeSpan(string $timeSpan, string $beginTime, string $dash, string $endTime): string
+        public function modifyTimeSpan(
+            string $timeSpan,
+            \Tx_Seminars_OldModel_AbstractTimeSpan $dateTimeSpan,
+            string $dash
+        ): string
         {
             // Hier Ihr Code
         }

--- a/Documentation/DE/Referenz/Hooks/Index.rst
+++ b/Documentation/DE/Referenz/Hooks/Index.rst
@@ -581,21 +581,21 @@ eine Datums- oder Zeitspanne ausgegeben werden soll, werden diese Hooks aufgeruf
 Anpassen der Zusammensetzung. Für die Standard-Zusammensetzung siehe
 :file:`Classes/OldModel/AbstractTimeSpan.php`.
 
-Ihre Klasse, die :php:`\OliverKlee\Seminars\Hooks\Interfaces\TimeSpan` implementiert,
+Ihre Klasse, die :php:`\OliverKlee\Seminars\Hooks\Interfaces\DateTimeSpan` implementiert,
 machen Sie seminars in :file:`ext_localconf.php` Ihrer Extension bekannt:
 
 .. code-block:: php
 
-    $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['seminars'][\OliverKlee\Seminars\Hooks\Interfaces\TimeSpan::class][]
-        = \Tx_Seminarspaypal_Hooks_TimeSpan::class;
+    $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['seminars'][\OliverKlee\Seminars\Hooks\Interfaces\DateTimeSpan::class][]
+        = \Tx_Seminarspaypal_Hooks_DateTimeSpan::class;
 
 Implementieren Sie die benötigten Methoden gemäß dem Interface:
 
 .. code-block:: php
 
-    use \OliverKlee\Seminars\Hooks\Interfaces\TimeSpan;
+    use \OliverKlee\Seminars\Hooks\Interfaces\DateTimeSpan;
 
-    class Tx_Seminarspaypal_Hooks_TimeSpan implements TimeSpan
+    class Tx_Seminarspaypal_Hooks_DateTimeSpan implements DateTimeSpan
     {
         /**
          * Modifies the date span string.

--- a/Documentation/EN/Reference/Hooks/Index.rst
+++ b/Documentation/EN/Reference/Hooks/Index.rst
@@ -29,6 +29,7 @@ are hooks for these parts of seminars:
 * :ref:`registrationform_en`
 * :ref:`notificationemail_en`
 * :ref:`emailsalutation_en`
+* :ref:`datatimespan_en`
 * :ref:`backendemail_en`
 * :ref:`backendregistrationlistview_en`
 
@@ -569,6 +570,70 @@ example:
    // register my hook objects
    $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['seminars']['modifyEmailSalutation'][] = \MyVendor\MyExt\Hooks\ModifySalutationHook::class;
 
+
+.. _datatimespan_en:
+
+Hooks for the date and time span creation
+"""""""""""""""""""""""""""""""""""""""""
+
+There are hooks into the date and time span creation of the seminars. If at any place a date or time span
+is required, these hooks are called to allow modification of the date or time span assembling. See also
+:file:`Classes/OldModel/AbstractTimeSpan.php` for details about the default methods.
+
+Register your class that implements :php:`\OliverKlee\Seminars\Hooks\Interfaces\TimeSpan`
+like this in :file:`ext_localconf.php` of your extension:
+
+.. code-block:: php
+
+    $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['seminars'][\OliverKlee\Seminars\Hooks\Interfaces\TimeSpan::class][]
+        = \Tx_Seminarspaypal_Hooks_TimeSpan::class;
+
+Implement the methods required by the interface:
+
+.. code-block:: php
+
+    use \OliverKlee\Seminars\Hooks\Interfaces\TimeSpan;
+
+    class Tx_Seminarspaypal_Hooks_TimeSpan implements TimeSpan
+    {
+        /**
+         * Modifies the date span string.
+         *
+         * The date format for the date parts are configured in TypoScript (`dateFormatYMD` etc).
+         * This allows modifying the assembly of start and end date to the date span.
+         * E.g. for Hungarian: '01.-03.01.2019' -> '2019.01.01.-03.'.
+         *
+         * @param string $dateSpan the date span produced by `AbstractTimeSpan::getDate()`
+         * @param string $beginDate the formatted begin date part (`dateFormatYMD`)
+         * @param string $dash the glue used by `AbstractTimeSpan::getDate()` (may be HTML encoded)
+         * @param string $endDate the formatted end date part (`dateFormatYMD`)
+         *
+         * @return string the modified date span to use
+         */
+        public function modifyDateSpan(string $dateSpan, string $beginDate, string $dash, string $endDate): string
+        {
+            // Your code here
+        }
+
+        /**
+         * Modifies the time span string.
+         *
+         * The time format for the time parts is configured in TypoScript (`timeFormat`).
+         * This allows modifying the assembly of start and end time to the time span.
+         * E.g. for Hungarian: '9:00-10:30' -> '9:00tol 10:30ban'.
+         *
+         * @param string $timeSpan the time span produced by `AbstractTimeSpan::getTime()`
+         * @param string $beginTime the formatted begin time part (`timeFormat`)
+         * @param string $dash the glue used by `AbstractTimeSpan::getTime()` (may be HTML encoded)
+         * @param string $endTime the formatted end time part (`timeFormat`)
+         *
+         * @return string the modified time span to use
+         */
+        public function modifyTimeSpan(string $timeSpan, string $beginTime, string $dash, string $endTime): string
+        {
+            // Your code here
+        }
+    }
 
 .. _backendemail_en:
 

--- a/Documentation/EN/Reference/Hooks/Index.rst
+++ b/Documentation/EN/Reference/Hooks/Index.rst
@@ -580,21 +580,21 @@ There are hooks into the date and time span creation of the seminars. If at any 
 is required, these hooks are called to allow modification of the date or time span assembling. See also
 :file:`Classes/OldModel/AbstractTimeSpan.php` for details about the default methods.
 
-Register your class that implements :php:`\OliverKlee\Seminars\Hooks\Interfaces\TimeSpan`
+Register your class that implements :php:`\OliverKlee\Seminars\Hooks\Interfaces\DateTimeSpan`
 like this in :file:`ext_localconf.php` of your extension:
 
 .. code-block:: php
 
-    $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['seminars'][\OliverKlee\Seminars\Hooks\Interfaces\TimeSpan::class][]
-        = \Tx_Seminarspaypal_Hooks_TimeSpan::class;
+    $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['seminars'][\OliverKlee\Seminars\Hooks\Interfaces\DateTimeSpan::class][]
+        = \Tx_Seminarspaypal_Hooks_DateTimeSpan::class;
 
 Implement the methods required by the interface:
 
 .. code-block:: php
 
-    use \OliverKlee\Seminars\Hooks\Interfaces\TimeSpan;
+    use \OliverKlee\Seminars\Hooks\Interfaces\DateTimeSpan;
 
-    class Tx_Seminarspaypal_Hooks_TimeSpan implements TimeSpan
+    class Tx_Seminarspaypal_Hooks_DateTimeSpan implements DateTimeSpan
     {
         /**
          * Modifies the date span string.

--- a/Documentation/EN/Reference/Hooks/Index.rst
+++ b/Documentation/EN/Reference/Hooks/Index.rst
@@ -599,18 +599,26 @@ Implement the methods required by the interface:
         /**
          * Modifies the date span string.
          *
-         * The date format for the date parts are configured in TypoScript (`dateFormatYMD` etc).
          * This allows modifying the assembly of start and end date to the date span.
-         * E.g. for Hungarian: '01.-03.01.2019' -> '2019.01.01.-03.'.
+         * E.g., for Hungarian: '01.-03.01.2019' -> '2019.01.01.-03.'.
+         *
+         * The date format for the date parts are configured in TypoScript (`dateFormatYMD` etc.).
+         * Get them from `$dateTimeSpan->getConfValueString('dateFormatYMD')` etc. The event
+         * dates are also retrievable:
+         * `$beginDateTime = $dateTimeSpan->getBeginDateAsTimestamp();`
+         * `$endDateTime = $dateTimeSpan->getEndDateAsTimestamp();`
          *
          * @param string $dateSpan the date span produced by `AbstractTimeSpan::getDate()`
-         * @param string $beginDate the formatted begin date part (`dateFormatYMD`)
+         * @param \Tx_Seminars_OldModel_AbstractTimeSpan $dateTimeSpan the date provider
          * @param string $dash the glue used by `AbstractTimeSpan::getDate()` (may be HTML encoded)
-         * @param string $endDate the formatted end date part (`dateFormatYMD`)
          *
          * @return string the modified date span to use
          */
-        public function modifyDateSpan(string $dateSpan, string $beginDate, string $dash, string $endDate): string
+        public function modifyDateSpan(
+            string $dateSpan,
+            \Tx_Seminars_OldModel_AbstractTimeSpan $dateTimeSpan,
+            string $dash
+        ): string
         {
             // Your code here
         }
@@ -618,18 +626,26 @@ Implement the methods required by the interface:
         /**
          * Modifies the time span string.
          *
-         * The time format for the time parts is configured in TypoScript (`timeFormat`).
          * This allows modifying the assembly of start and end time to the time span.
-         * E.g. for Hungarian: '9:00-10:30' -> '9:00tol 10:30ban'.
+         * E.g., for Hungarian: '9:00-10:30' -> '9:00tol 10:30ban'.
+         *
+         * The time format for the time parts is configured in TypoScript (`timeFormat`).
+         * Get it from `$dateTimeSpan->getConfValueString('timeFormat')`. The event
+         * times are also retrievable:
+         * `$beginDateTime = $dateTimeSpan->getBeginDateAsTimestamp();`
+         * `$endDateTime = $dateTimeSpan->getEndDateAsTimestamp();`
          *
          * @param string $timeSpan the time span produced by `AbstractTimeSpan::getTime()`
-         * @param string $beginTime the formatted begin time part (`timeFormat`)
+         * @param \Tx_Seminars_OldModel_AbstractTimeSpan $dateTimeSpan the date provider
          * @param string $dash the glue used by `AbstractTimeSpan::getTime()` (may be HTML encoded)
-         * @param string $endTime the formatted end time part (`timeFormat`)
          *
          * @return string the modified time span to use
          */
-        public function modifyTimeSpan(string $timeSpan, string $beginTime, string $dash, string $endTime): string
+        public function modifyTimeSpan(
+            string $timeSpan,
+            \Tx_Seminars_OldModel_AbstractTimeSpan $dateTimeSpan,
+            string $dash
+        ): string
         {
             // Your code here
         }

--- a/Tests/Functional/OldModel/AbstractTimeSpanTest.php
+++ b/Tests/Functional/OldModel/AbstractTimeSpanTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace OliverKlee\Seminars\Tests\Functional\OldModel;
 
 use Nimut\TestingFramework\TestCase\FunctionalTestCase;
-use OliverKlee\Seminars\Hooks\Interfaces\TimeSpan;
+use OliverKlee\Seminars\Hooks\Interfaces\DateTimeSpan;
 use OliverKlee\Seminars\Tests\Unit\OldModel\Fixtures\TestingTimeSpan;
 use OliverKlee\Seminars\Tests\Unit\Traits\LanguageHelper;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -152,12 +152,12 @@ final class AbstractTimeSpanTest extends FunctionalTestCase
      */
     public function getTimeForNoTimeNotCallsHook()
     {
-        $hook = $this->createMock(TimeSpan::class);
+        $hook = $this->createMock(DateTimeSpan::class);
         $hook->expects(self::never())->method('modifyDateSpan');
         $hook->expects(self::never())->method('modifyTimeSpan');
 
         $hookClass = \get_class($hook);
-        $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['seminars'][TimeSpan::class][] = $hookClass;
+        $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['seminars'][DateTimeSpan::class][] = $hookClass;
         GeneralUtility::addInstance($hookClass, $hook);
 
         $this->subject->getTime();
@@ -170,12 +170,12 @@ final class AbstractTimeSpanTest extends FunctionalTestCase
     {
         $this->subject->setBeginDateAndTime(\mktime(9, 50, 0, 1, 1, 2010));
 
-        $hook = $this->createMock(TimeSpan::class);
+        $hook = $this->createMock(DateTimeSpan::class);
         $hook->expects(self::never())->method('modifyDateSpan');
         $hook->expects(self::never())->method('modifyTimeSpan');
 
         $hookClass = \get_class($hook);
-        $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['seminars'][TimeSpan::class][] = $hookClass;
+        $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['seminars'][DateTimeSpan::class][] = $hookClass;
         GeneralUtility::addInstance($hookClass, $hook);
 
         $this->subject->getTime();
@@ -188,12 +188,12 @@ final class AbstractTimeSpanTest extends FunctionalTestCase
     {
         $this->subject->setEndDateAndTime(\mktime(18, 30, 0, 1, 1, 2010));
 
-        $hook = $this->createMock(TimeSpan::class);
+        $hook = $this->createMock(DateTimeSpan::class);
         $hook->expects(self::never())->method('modifyDateSpan');
         $hook->expects(self::never())->method('modifyTimeSpan');
 
         $hookClass = \get_class($hook);
-        $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['seminars'][TimeSpan::class][] = $hookClass;
+        $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['seminars'][DateTimeSpan::class][] = $hookClass;
         GeneralUtility::addInstance($hookClass, $hook);
 
         $this->subject->getTime();
@@ -207,12 +207,12 @@ final class AbstractTimeSpanTest extends FunctionalTestCase
         $this->subject->setBeginDateAndTime(\mktime(9, 50, 0, 1, 1, 2010));
         $this->subject->setEndDateAndTime(\mktime(9, 50, 0, 1, 3, 2010));
 
-        $hook = $this->createMock(TimeSpan::class);
+        $hook = $this->createMock(DateTimeSpan::class);
         $hook->expects(self::never())->method('modifyDateSpan');
         $hook->expects(self::never())->method('modifyTimeSpan');
 
         $hookClass = \get_class($hook);
-        $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['seminars'][TimeSpan::class][] = $hookClass;
+        $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['seminars'][DateTimeSpan::class][] = $hookClass;
         GeneralUtility::addInstance($hookClass, $hook);
 
         $this->subject->getTime();
@@ -221,23 +221,25 @@ final class AbstractTimeSpanTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function getTimeForBeginTimeAndEndTimeOnDifferentTimesCallsHookAndReturnsModifiedValue()
+    public function getTimeForBeginTimeAndEndTimeOnDifferentTimesCallsHookAndUsesModifiedValue()
     {
+        $modifiedValue = 'modified';
+
         $this->subject->setBeginDateAndTime(\mktime(9, 50, 0, 1, 1, 2010));
         $this->subject->setEndDateAndTime(\mktime(18, 30, 0, 1, 1, 2010));
 
-        $hook = $this->createMock(TimeSpan::class);
+        $hook = $this->createMock(DateTimeSpan::class);
         $hook->expects(self::never())->method('modifyDateSpan');
         $hook->expects(self::once())->method('modifyTimeSpan')
             ->with('09:50&#8211;18:30', '09:50', '&#8211;', '18:30')
-            ->willReturn('modified');
+            ->willReturn($modifiedValue);
 
         $hookClass = \get_class($hook);
-        $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['seminars'][TimeSpan::class][] = $hookClass;
+        $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['seminars'][DateTimeSpan::class][] = $hookClass;
         GeneralUtility::addInstance($hookClass, $hook);
 
         self::assertSame(
-            'modified' . ' ' . $this->getLanguageService()->getLL('label_hours'),
+            $modifiedValue . ' ' . $this->getLanguageService()->getLL('label_hours'),
             $this->subject->getTime()
         );
     }
@@ -316,12 +318,12 @@ final class AbstractTimeSpanTest extends FunctionalTestCase
      */
     public function getDateForNoDateNotCallsHook()
     {
-        $hook = $this->createMock(TimeSpan::class);
+        $hook = $this->createMock(DateTimeSpan::class);
         $hook->expects(self::never())->method('modifyDateSpan');
         $hook->expects(self::never())->method('modifyTimeSpan');
 
         $hookClass = \get_class($hook);
-        $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['seminars'][TimeSpan::class][] = $hookClass;
+        $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['seminars'][DateTimeSpan::class][] = $hookClass;
         GeneralUtility::addInstance($hookClass, $hook);
 
         $this->subject->getDate();
@@ -334,12 +336,12 @@ final class AbstractTimeSpanTest extends FunctionalTestCase
     {
         $this->subject->setBeginDateAndTime(\mktime(0, 0, 0, 1, 1, 2010));
 
-        $hook = $this->createMock(TimeSpan::class);
+        $hook = $this->createMock(DateTimeSpan::class);
         $hook->expects(self::never())->method('modifyDateSpan');
         $hook->expects(self::never())->method('modifyTimeSpan');
 
         $hookClass = \get_class($hook);
-        $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['seminars'][TimeSpan::class][] = $hookClass;
+        $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['seminars'][DateTimeSpan::class][] = $hookClass;
         GeneralUtility::addInstance($hookClass, $hook);
 
         $this->subject->getDate();
@@ -352,12 +354,12 @@ final class AbstractTimeSpanTest extends FunctionalTestCase
     {
         $this->subject->setEndDateAndTime(\mktime(0, 0, 0, 1, 1, 2010));
 
-        $hook = $this->createMock(TimeSpan::class);
+        $hook = $this->createMock(DateTimeSpan::class);
         $hook->expects(self::never())->method('modifyDateSpan');
         $hook->expects(self::never())->method('modifyTimeSpan');
 
         $hookClass = \get_class($hook);
-        $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['seminars'][TimeSpan::class][] = $hookClass;
+        $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['seminars'][DateTimeSpan::class][] = $hookClass;
         GeneralUtility::addInstance($hookClass, $hook);
 
         $this->subject->getDate();
@@ -371,12 +373,12 @@ final class AbstractTimeSpanTest extends FunctionalTestCase
         $this->subject->setBeginDateAndTime(\mktime(0, 0, 0, 1, 1, 2010));
         $this->subject->setEndDateAndTime(\mktime(0, 0, 0, 1, 1, 2010));
 
-        $hook = $this->createMock(TimeSpan::class);
+        $hook = $this->createMock(DateTimeSpan::class);
         $hook->expects(self::never())->method('modifyDateSpan');
         $hook->expects(self::never())->method('modifyTimeSpan');
 
         $hookClass = \get_class($hook);
-        $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['seminars'][TimeSpan::class][] = $hookClass;
+        $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['seminars'][DateTimeSpan::class][] = $hookClass;
         GeneralUtility::addInstance($hookClass, $hook);
 
         $this->subject->getDate();
@@ -385,21 +387,23 @@ final class AbstractTimeSpanTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function getDateForBeginDateAndEndDateOnDifferentDaysCallsHookAndReturnsModifiedValue()
+    public function getDateForBeginDateAndEndDateOnDifferentDaysCallsHookAndUsesModifiedValue()
     {
+        $modifiedValue = 'modified';
+
         $this->subject->setBeginDateAndTime(\mktime(0, 0, 0, 1, 1, 2010));
         $this->subject->setEndDateAndTime(\mktime(0, 0, 0, 1, 3, 2010));
 
-        $hook = $this->createMock(TimeSpan::class);
+        $hook = $this->createMock(DateTimeSpan::class);
         $hook->expects(self::once())->method('modifyDateSpan')
             ->with('01.&#8211;03.01.2010', '01.01.2010', '&#8211;', '03.01.2010')
-            ->willReturn('modified');
+            ->willReturn($modifiedValue);
         $hook->expects(self::never())->method('modifyTimeSpan');
 
         $hookClass = \get_class($hook);
-        $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['seminars'][TimeSpan::class][] = $hookClass;
+        $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['seminars'][DateTimeSpan::class][] = $hookClass;
         GeneralUtility::addInstance($hookClass, $hook);
 
-        self::assertSame('modified', $this->subject->getDate());
+        self::assertSame($modifiedValue, $this->subject->getDate());
     }
 }

--- a/Tests/Functional/OldModel/AbstractTimeSpanTest.php
+++ b/Tests/Functional/OldModel/AbstractTimeSpanTest.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace OliverKlee\Seminars\Tests\Functional\OldModel;
 
 use Nimut\TestingFramework\TestCase\FunctionalTestCase;
+use OliverKlee\Seminars\Hooks\Interfaces\TimeSpan;
 use OliverKlee\Seminars\Tests\Unit\OldModel\Fixtures\TestingTimeSpan;
 use OliverKlee\Seminars\Tests\Unit\Traits\LanguageHelper;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
  * Test case.
@@ -21,6 +23,31 @@ final class AbstractTimeSpanTest extends FunctionalTestCase
      * @var string
      */
     const TIME_FORMAT = '%H:%M';
+
+    /**
+     * @var string
+     */
+    const DATE_FORMAT_YMD = '%d.%m.%Y';
+
+    /**
+     * @var string
+     */
+    const DATE_FORMAT_MD = '%d.%m.';
+
+    /**
+     * @var string
+     */
+    const DATE_FORMAT_D = '%d.';
+
+    /**
+     * @var string
+     */
+    const DATE_FORMAT_M = '%m';
+
+    /**
+     * @var string
+     */
+    const DATE_FORMAT_Y = '%Y';
 
     /**
      * @var string[]
@@ -39,7 +66,15 @@ final class AbstractTimeSpanTest extends FunctionalTestCase
         $this->initializeBackEndLanguage();
 
         $this->subject = new TestingTimeSpan();
-        $this->subject->overrideConfiguration(['timeFormat' => self::TIME_FORMAT]);
+        $this->subject->overrideConfiguration([
+            'timeFormat' => self::TIME_FORMAT,
+            'dateFormatYMD' => self::DATE_FORMAT_YMD,
+            'dateFormatMD' => self::DATE_FORMAT_MD,
+            'dateFormatD' => self::DATE_FORMAT_D,
+            'dateFormatM' => self::DATE_FORMAT_M,
+            'dateFormatY' => self::DATE_FORMAT_Y,
+            'abbreviateDateRanges' => 1,
+        ]);
     }
 
     /*
@@ -110,5 +145,261 @@ final class AbstractTimeSpanTest extends FunctionalTestCase
             '09:50&#8211;18:30' . ' ' . $this->getLanguageService()->getLL('label_hours'),
             $this->subject->getTime()
         );
+    }
+
+    /**
+     * @test
+     */
+    public function getTimeForNoTimeNotCallsHook()
+    {
+        $hook = $this->createMock(TimeSpan::class);
+        $hook->expects(self::never())->method('modifyDateSpan');
+        $hook->expects(self::never())->method('modifyTimeSpan');
+
+        $hookClass = \get_class($hook);
+        $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['seminars'][TimeSpan::class][] = $hookClass;
+        GeneralUtility::addInstance($hookClass, $hook);
+
+        $this->subject->getTime();
+    }
+
+    /**
+     * @test
+     */
+    public function getTimeForBeginTimeOnlyNotCallsHook()
+    {
+        $this->subject->setBeginDateAndTime(\mktime(9, 50, 0, 1, 1, 2010));
+
+        $hook = $this->createMock(TimeSpan::class);
+        $hook->expects(self::never())->method('modifyDateSpan');
+        $hook->expects(self::never())->method('modifyTimeSpan');
+
+        $hookClass = \get_class($hook);
+        $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['seminars'][TimeSpan::class][] = $hookClass;
+        GeneralUtility::addInstance($hookClass, $hook);
+
+        $this->subject->getTime();
+    }
+
+    /**
+     * @test
+     */
+    public function getTimeForEndTimeOnlyNotCallsHook()
+    {
+        $this->subject->setEndDateAndTime(\mktime(18, 30, 0, 1, 1, 2010));
+
+        $hook = $this->createMock(TimeSpan::class);
+        $hook->expects(self::never())->method('modifyDateSpan');
+        $hook->expects(self::never())->method('modifyTimeSpan');
+
+        $hookClass = \get_class($hook);
+        $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['seminars'][TimeSpan::class][] = $hookClass;
+        GeneralUtility::addInstance($hookClass, $hook);
+
+        $this->subject->getTime();
+    }
+
+    /**
+     * @test
+     */
+    public function getTimeForBeginTimeAndEndTimeOnSameTimeNotCallsHook()
+    {
+        $this->subject->setBeginDateAndTime(\mktime(9, 50, 0, 1, 1, 2010));
+        $this->subject->setEndDateAndTime(\mktime(9, 50, 0, 1, 3, 2010));
+
+        $hook = $this->createMock(TimeSpan::class);
+        $hook->expects(self::never())->method('modifyDateSpan');
+        $hook->expects(self::never())->method('modifyTimeSpan');
+
+        $hookClass = \get_class($hook);
+        $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['seminars'][TimeSpan::class][] = $hookClass;
+        GeneralUtility::addInstance($hookClass, $hook);
+
+        $this->subject->getTime();
+    }
+
+    /**
+     * @test
+     */
+    public function getTimeForBeginTimeAndEndTimeOnDifferentTimesCallsHookAndReturnsModifiedValue()
+    {
+        $this->subject->setBeginDateAndTime(\mktime(9, 50, 0, 1, 1, 2010));
+        $this->subject->setEndDateAndTime(\mktime(18, 30, 0, 1, 1, 2010));
+
+        $hook = $this->createMock(TimeSpan::class);
+        $hook->expects(self::never())->method('modifyDateSpan');
+        $hook->expects(self::once())->method('modifyTimeSpan')
+            ->with('09:50&#8211;18:30', '09:50', '&#8211;', '18:30')
+            ->willReturn('modified');
+
+        $hookClass = \get_class($hook);
+        $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['seminars'][TimeSpan::class][] = $hookClass;
+        GeneralUtility::addInstance($hookClass, $hook);
+
+        self::assertSame(
+            'modified' . ' ' . $this->getLanguageService()->getLL('label_hours'),
+            $this->subject->getTime()
+        );
+    }
+
+    /*
+     * Test for getting the date.
+     */
+
+    /**
+     * @test
+     */
+    public function getDateForNoDateReturnsWillBeAnnouncedMessage()
+    {
+        self::assertSame(
+            $this->getLanguageService()->getLL('message_willBeAnnounced'),
+            $this->subject->getDate()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function getDateForBeginDateReturnsBeginDate()
+    {
+        $this->subject->setBeginDateAndTime(\mktime(0, 0, 0, 1, 1, 2010));
+
+        self::assertSame(
+            '01.01.2010',
+            $this->subject->getDate()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function getDateForEndDateReturnsWillBeAnnouncedMessage()
+    {
+        $this->subject->setEndDateAndTime(\mktime(0, 0, 0, 1, 1, 2010));
+
+        self::assertSame(
+            $this->getLanguageService()->getLL('message_willBeAnnounced'),
+            $this->subject->getDate()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function getDateForBeginDateAndEndDateOnSameDayReturnsBeginDate()
+    {
+        $this->subject->setBeginDateAndTime(\mktime(0, 0, 0, 1, 1, 2010));
+        $this->subject->setEndDateAndTime(\mktime(0, 0, 0, 1, 1, 2010));
+
+        self::assertSame(
+            '01.01.2010',
+            $this->subject->getDate()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function getDateForBeginDateAndEndDateOnDifferentDaysReturnsDateSpan()
+    {
+        $this->subject->setBeginDateAndTime(\mktime(0, 0, 0, 1, 1, 2010));
+        $this->subject->setEndDateAndTime(\mktime(0, 0, 0, 1, 3, 2010));
+
+        self::assertSame(
+            '01.&#8211;03.01.2010',
+            $this->subject->getDate()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function getDateForNoDateNotCallsHook()
+    {
+        $hook = $this->createMock(TimeSpan::class);
+        $hook->expects(self::never())->method('modifyDateSpan');
+        $hook->expects(self::never())->method('modifyTimeSpan');
+
+        $hookClass = \get_class($hook);
+        $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['seminars'][TimeSpan::class][] = $hookClass;
+        GeneralUtility::addInstance($hookClass, $hook);
+
+        $this->subject->getDate();
+    }
+
+    /**
+     * @test
+     */
+    public function getDateForBeginDateNotCallsHook()
+    {
+        $this->subject->setBeginDateAndTime(\mktime(0, 0, 0, 1, 1, 2010));
+
+        $hook = $this->createMock(TimeSpan::class);
+        $hook->expects(self::never())->method('modifyDateSpan');
+        $hook->expects(self::never())->method('modifyTimeSpan');
+
+        $hookClass = \get_class($hook);
+        $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['seminars'][TimeSpan::class][] = $hookClass;
+        GeneralUtility::addInstance($hookClass, $hook);
+
+        $this->subject->getDate();
+    }
+
+    /**
+     * @test
+     */
+    public function getDateForEndDateNotCallsHook()
+    {
+        $this->subject->setEndDateAndTime(\mktime(0, 0, 0, 1, 1, 2010));
+
+        $hook = $this->createMock(TimeSpan::class);
+        $hook->expects(self::never())->method('modifyDateSpan');
+        $hook->expects(self::never())->method('modifyTimeSpan');
+
+        $hookClass = \get_class($hook);
+        $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['seminars'][TimeSpan::class][] = $hookClass;
+        GeneralUtility::addInstance($hookClass, $hook);
+
+        $this->subject->getDate();
+    }
+
+    /**
+     * @test
+     */
+    public function getDateForBeginDateAndEndDateOnSameDayNotCallsHook()
+    {
+        $this->subject->setBeginDateAndTime(\mktime(0, 0, 0, 1, 1, 2010));
+        $this->subject->setEndDateAndTime(\mktime(0, 0, 0, 1, 1, 2010));
+
+        $hook = $this->createMock(TimeSpan::class);
+        $hook->expects(self::never())->method('modifyDateSpan');
+        $hook->expects(self::never())->method('modifyTimeSpan');
+
+        $hookClass = \get_class($hook);
+        $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['seminars'][TimeSpan::class][] = $hookClass;
+        GeneralUtility::addInstance($hookClass, $hook);
+
+        $this->subject->getDate();
+    }
+
+    /**
+     * @test
+     */
+    public function getDateForBeginDateAndEndDateOnDifferentDaysCallsHookAndReturnsModifiedValue()
+    {
+        $this->subject->setBeginDateAndTime(\mktime(0, 0, 0, 1, 1, 2010));
+        $this->subject->setEndDateAndTime(\mktime(0, 0, 0, 1, 3, 2010));
+
+        $hook = $this->createMock(TimeSpan::class);
+        $hook->expects(self::once())->method('modifyDateSpan')
+            ->with('01.&#8211;03.01.2010', '01.01.2010', '&#8211;', '03.01.2010')
+            ->willReturn('modified');
+        $hook->expects(self::never())->method('modifyTimeSpan');
+
+        $hookClass = \get_class($hook);
+        $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['seminars'][TimeSpan::class][] = $hookClass;
+        GeneralUtility::addInstance($hookClass, $hook);
+
+        self::assertSame('modified', $this->subject->getDate());
     }
 }

--- a/Tests/Functional/OldModel/AbstractTimeSpanTest.php
+++ b/Tests/Functional/OldModel/AbstractTimeSpanTest.php
@@ -231,7 +231,7 @@ final class AbstractTimeSpanTest extends FunctionalTestCase
         $hook = $this->createMock(DateTimeSpan::class);
         $hook->expects(self::never())->method('modifyDateSpan');
         $hook->expects(self::once())->method('modifyTimeSpan')
-            ->with('09:50&#8211;18:30', '09:50', '&#8211;', '18:30')
+            ->with('09:50&#8211;18:30', $this->subject, '&#8211;')
             ->willReturn($modifiedValue);
 
         $hookClass = \get_class($hook);
@@ -396,7 +396,7 @@ final class AbstractTimeSpanTest extends FunctionalTestCase
 
         $hook = $this->createMock(DateTimeSpan::class);
         $hook->expects(self::once())->method('modifyDateSpan')
-            ->with('01.&#8211;03.01.2010', '01.01.2010', '&#8211;', '03.01.2010')
+            ->with('01.&#8211;03.01.2010', $this->subject, '&#8211;')
             ->willReturn($modifiedValue);
         $hook->expects(self::never())->method('modifyTimeSpan');
 


### PR DESCRIPTION
The first hook to utilize the modified values hook.

I called the interface `TimeSpan` in accordance to your `AbstractTimeSpan` class. But I would also call it `DateTimeSpan` to better reflect that is used for both.