### PR TITLE
[BUGFIX] Update the locations of the mkforms JavaScript includes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Removed
 
 ### Fixed
+- Update the locations of the mkforms JavaScript includes (#468)
 - Internally store boolean properties as integers (#386)
 - Fix the locallang path in the event publication (#367, #368, #370)
 - Fix the numbers in the countdown tests (#366)

--- a/Configuration/TypoScript/Config.txt
+++ b/Configuration/TypoScript/Config.txt
@@ -7,9 +7,9 @@ config {
         jsframework {
             jscore = jquery
             jscore {
-                tx_mkforms_base = EXT:mkforms/res/jsfwk/prototype/addons/base/Base.js
-                basewrapper = EXT:mkforms/res/jsfwk/wrapper.js
-                wrapper = EXT:mkforms/res/jsfwk/jquery/wrapper.js
+                tx_mkforms_base = EXT:mkforms/Resources/Public/JavaScript/prototype/addons/base/Base.js
+                basewrapper = EXT:mkforms/Resources/Public/JavaScript/wrapper.js
+                wrapper = EXT:mkforms/Resources/Public/JavaScript/jquery/wrapper.js
             }
         }
     }

--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,9 @@
     },
     "require": {
         "php": "^5.6.0 || ~7.0.0 || ~7.1.0 || ~7.2.0",
+        "digedag/rn-base": "^1.10.5",
+        "dmk/mkforms": "^9.5.2",
+        "oliverklee/oelib": "^2.3.5 || ^3.0.3",
         "typo3/cms-core": "^7.6.23 || ^8.7.9",
         "typo3/cms-frontend": "^7.6 || ^8.7",
         "typo3/cms-backend": "^7.6 || ^8.7",
@@ -33,10 +36,7 @@
         "typo3/cms-fluid": "^7.6 || ^8.7",
         "typo3/cms-lang": "^7.6 || ^8.7",
         "psr/http-message": "^1.0",
-        "sjbr/static-info-tables": "^6.5",
-        "oliverklee/oelib": "^2.3.3 || ^3.0",
-        "dmk/mkforms": "^3.0.21 || ^9.5.1",
-        "digedag/rn-base": "^1.8.7"
+        "sjbr/static-info-tables": "^6.5"
     },
     "require-dev": {
         "typo3/cms-scheduler": "^7.6.23 || ^8.7.9",

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -10,8 +10,8 @@ $EM_CONF[$_EXTKEY] = [
             'php' => '5.6.0-7.2.99',
             'typo3' => '7.6.0-8.7.99',
             'static_info_tables' => '6.5.0-',
-            'oelib' => '2.3.3-3.99.99',
-            'mkforms' => '3.0.21-9.5.99',
+            'oelib' => '2.3.5-3.99.99',
+            'mkforms' => '9.5.2-9.5.99',
         ],
         'conflicts' => [
             'sourceopt' => '',


### PR DESCRIPTION
This is the 2.2.x backport of #467.

Also update the oelib dependency.

Fixes #464
Fixes #465