### PR TITLE
[BUGFIX] Avoid double colons for labels in organizer notification emails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Drop support for TYPO3 7.6 (#248, #272, #280)
 
 ### Fixed
+- Avoid double colons after labels in organizer notification emails (#481)
 - Add the missing label for the date of birth for emails (#479)
 - Fix type error with dates in the old registration model (#477)
 - Update the locations of the mkforms JavaScript includes (#467)

--- a/Classes/OldModel/Event.php
+++ b/Classes/OldModel/Event.php
@@ -2345,17 +2345,17 @@ class Tx_Seminars_OldModel_Event extends \Tx_Seminars_OldModel_AbstractTimeSpan
      *
      * @return string formatted output (may be empty)
      */
-    public function dumpSeminarValues($keysList): string
+    public function dumpSeminarValues(string $keysList): string
     {
         $keys = GeneralUtility::trimExplode(',', $keysList, true);
         $keysWithLabels = [];
 
         $maxLength = 0;
         foreach ($keys as $currentKey) {
-            $loweredKey = strtolower($currentKey);
-            $currentLabel = $this->translate('label_' . $currentKey);
+            $loweredKey = \strtolower($currentKey);
+            $currentLabel = \rtrim($this->translate('label_' . $currentKey), ':');
             $keysWithLabels[$loweredKey] = $currentLabel;
-            $maxLength = max($maxLength, \mb_strlen($currentLabel, 'utf-8'));
+            $maxLength = \max($maxLength, \mb_strlen($currentLabel, 'utf-8'));
         }
         $result = '';
         foreach ($keysWithLabels as $currentKey => $currentLabel) {
@@ -2417,8 +2417,8 @@ class Tx_Seminars_OldModel_Event extends \Tx_Seminars_OldModel_AbstractTimeSpan
                     $value = $this->getRecordPropertyString($currentKey);
             }
 
-            // Check whether there is a value to display. If not, we don't use
-            // the padding and break the line directly after the label.
+            // Check whether there is a value to display.
+            // If not, we don't use the padding and break the line directly after the label.
             if ($value !== '') {
                 $result .= \str_pad($currentLabel . ': ', $maxLength + 2, ' ') . $value . LF;
             } else {

--- a/Classes/OldModel/Registration.php
+++ b/Classes/OldModel/Registration.php
@@ -781,6 +781,7 @@ class Tx_Seminars_OldModel_Registration extends AbstractModel implements \Tx_Oel
             } else {
                 $label = \ucfirst($key);
             }
+            $label = \rtrim($label, ':');
 
             $labels[$key] = $label;
             $maximumLabelLength = \max($maximumLabelLength, \mb_strlen($label, 'utf-8'));
@@ -811,7 +812,7 @@ class Tx_Seminars_OldModel_Registration extends AbstractModel implements \Tx_Oel
      *
      * @return string formatted output (may be empty)
      */
-    public function dumpAttendanceValues($keysList): string
+    public function dumpAttendanceValues(string $keysList): string
     {
         $keys = GeneralUtility::trimExplode(',', $keysList, true);
         $labels = [];
@@ -824,6 +825,7 @@ class Tx_Seminars_OldModel_Registration extends AbstractModel implements \Tx_Oel
             } else {
                 $currentLabel = $this->translate('label_' . $key);
             }
+            $currentLabel = \rtrim($currentLabel, ':');
             $labels[$key] = $currentLabel;
             $maximumLabelLength = \max($maximumLabelLength, \mb_strlen($currentLabel, 'utf-8'));
         }

--- a/Tests/LegacyUnit/OldModel/EventTest.php
+++ b/Tests/LegacyUnit/OldModel/EventTest.php
@@ -8447,6 +8447,62 @@ final class Tx_Seminars_Tests_Unit_OldModel_EventTest extends TestCase
         );
     }
 
+    /**
+     * @return string[][]
+     */
+    public function dumpableEventFieldsDataProvider(): array
+    {
+        $fields = [
+            'uid',
+            'event_type',
+            'title',
+            'subtitle',
+            'titleanddate',
+            'date',
+            'time',
+            'accreditation_number',
+            'credit_points',
+            'room',
+            'place',
+            'speakers',
+            'price_regular',
+            'price_regular_early',
+            'price_special',
+            'price_special_early',
+            'allows_multiple_registrations',
+            'attendees',
+            'attendees_min',
+            'attendees_max',
+            'vacancies',
+            'enough_attendees',
+            'is_full',
+            'notes',
+        ];
+
+        $result = [];
+        foreach ($fields as $field) {
+            $result[$field] = [$field];
+        }
+
+        return $result;
+    }
+
+    /**
+     * @test
+     *
+     * @param string $fieldName
+     *
+     * @dataProvider dumpableEventFieldsDataProvider
+     */
+    public function dumpSeminarValuesCreatesNoDoubleColonsAfterLabel(string $fieldName)
+    {
+        $this->subject->setRecordPropertyString($fieldName, '1234 some value');
+
+        $result = $this->subject->dumpSeminarValues($fieldName);
+
+        self::assertNotContains('::', $result);
+    }
+
     /*
      * Tests regarding the registration begin date
      */

--- a/Tests/LegacyUnit/OldModel/RegistrationTest.php
+++ b/Tests/LegacyUnit/OldModel/RegistrationTest.php
@@ -513,6 +513,64 @@ final class Tx_Seminars_Tests_Unit_OldModel_RegistrationTest extends TestCase
         );
     }
 
+    /**
+     * @return string[][]
+     */
+    public function dumpableRegistrationFieldsDataProvider(): array
+    {
+        $fields = [
+            'uid',
+            'interests',
+            'expectations',
+            'background_knowledge',
+            'lodgings',
+            'accommodation',
+            'foods',
+            'food',
+            'known_from',
+            'notes',
+            'checkboxes',
+            'price',
+            'seats',
+            'total_price',
+            'attendees_names',
+            'kids',
+            'method_of_payment',
+            'company',
+            'gender',
+            'name',
+            'address',
+            'zip',
+            'city',
+            'country',
+            'telephone',
+            'email',
+        ];
+
+        $result = [];
+        foreach ($fields as $field) {
+            $result[$field] = [$field];
+        }
+
+        return $result;
+    }
+
+    /**
+     * @test
+     *
+     * @param string $fieldName
+     *
+     * @dataProvider dumpableRegistrationFieldsDataProvider
+     */
+    public function dumpAttendanceValuesCreatesNoDoubleColonsAfterLabel(string $fieldName)
+    {
+        $subject = \Tx_Seminars_OldModel_Registration::fromData([$fieldName => '1234 some value']);
+
+        $result = $subject->dumpAttendanceValues($fieldName);
+
+        self::assertNotContains('::', $result);
+    }
+
     /*
      * Tests regarding committing registrations to the database.
      */
@@ -1098,6 +1156,61 @@ final class Tx_Seminars_Tests_Unit_OldModel_RegistrationTest extends TestCase
 
         $expected = \strftime(self::DATE_FORMAT, $value);
         self::assertContains($expected, $result);
+    }
+
+    /**
+     * @return string[][]
+     */
+    public function dumpableUserFieldsDataProvider(): array
+    {
+        $fields = [
+            'uid',
+            'username',
+            'name',
+            'first_name',
+            'middle_name',
+            'last_name',
+            'address',
+            'telephone',
+            'fax',
+            'email',
+            'crdate',
+            'title',
+            'zip',
+            'city',
+            'country',
+            'www',
+            'company',
+            'pseudonym',
+            'pseudonym',
+            'gender',
+            'date_of_birth',
+            'mobilephone',
+            'comments',
+        ];
+
+        $result = [];
+        foreach ($fields as $field) {
+            $result[$field] = [$field];
+        }
+
+        return $result;
+    }
+
+    /**
+     * @test
+     *
+     * @param string $fieldName
+     *
+     * @dataProvider dumpableUserFieldsDataProvider
+     */
+    public function dumpUserValuesCreatesNoDoubleColonsAfterLabel(string $fieldName)
+    {
+        $this->subject->setUserData([$fieldName => '1234 some value']);
+
+        $result = $this->subject->dumpUserValues($fieldName);
+
+        self::assertNotContains('::', $result);
     }
 
     /*


### PR DESCRIPTION
Some labels already have a colon that needs to be removed before a colon
is appended in order to avoid double colons.