### PR TITLE
[BUGFIX] Avoid double colons for labels in organizer notification email

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Removed
 
 ### Fixed
+- Avoid double colons after labels in organizer notification emails (#481, #482)
 - Add the missing label for the date of birth for emails (#479, #480)
 - Fix type error with dates in the old registration model (#477, #478)
 

--- a/Classes/OldModel/Event.php
+++ b/Classes/OldModel/Event.php
@@ -2477,10 +2477,10 @@ class Tx_Seminars_OldModel_Event extends \Tx_Seminars_OldModel_AbstractTimeSpan
 
         $maxLength = 0;
         foreach ($keys as $currentKey) {
-            $loweredKey = strtolower($currentKey);
-            $currentLabel = $this->translate('label_' . $currentKey);
+            $loweredKey = \strtolower($currentKey);
+            $currentLabel = \rtrim($this->translate('label_' . $currentKey), ':');
             $keysWithLabels[$loweredKey] = $currentLabel;
-            $maxLength = max($maxLength, \mb_strlen($currentLabel, 'utf-8'));
+            $maxLength = \max($maxLength, \mb_strlen($currentLabel, 'utf-8'));
         }
         $result = '';
         foreach ($keysWithLabels as $currentKey => $currentLabel) {
@@ -2542,14 +2542,10 @@ class Tx_Seminars_OldModel_Event extends \Tx_Seminars_OldModel_AbstractTimeSpan
                     $value = $this->getRecordPropertyString($currentKey);
             }
 
-            // Check whether there is a value to display. If not, we don't use
-            // the padding and break the line directly after the label.
-            if ($value != '') {
-                $result .= str_pad(
-                        $currentLabel . ': ',
-                        $maxLength + 2,
-                        ' '
-                    ) . $value . LF;
+            // Check whether there is a value to display.
+            // If not, we don't use the padding and break the line directly after the label.
+            if ($value !== '') {
+                $result .= \str_pad($currentLabel . ': ', $maxLength + 2, ' ') . $value . LF;
             } else {
                 $result .= $currentLabel . ':' . LF;
             }

--- a/Classes/OldModel/Registration.php
+++ b/Classes/OldModel/Registration.php
@@ -799,6 +799,7 @@ class Tx_Seminars_OldModel_Registration extends \Tx_Seminars_OldModel_Abstract
             } else {
                 $label = \ucfirst($key);
             }
+            $label = \rtrim($label, ':');
 
             $labels[$key] = $label;
             $maximumLabelLength = \max($maximumLabelLength, \mb_strlen($label, 'utf-8'));
@@ -842,6 +843,7 @@ class Tx_Seminars_OldModel_Registration extends \Tx_Seminars_OldModel_Abstract
             } else {
                 $currentLabel = $this->translate('label_' . $key);
             }
+            $currentLabel = \rtrim($currentLabel, ':');
             $labels[$key] = $currentLabel;
             $maximumLabelLength = \max($maximumLabelLength, \mb_strlen($currentLabel, 'utf-8'));
         }

--- a/Tests/LegacyUnit/OldModel/EventTest.php
+++ b/Tests/LegacyUnit/OldModel/EventTest.php
@@ -8499,6 +8499,61 @@ class Tx_Seminars_Tests_Unit_OldModel_EventTest extends TestCase
         );
     }
 
+    /**
+     * @return string[][]
+     */
+    public function dumpableEventFieldsDataProvider()
+    {
+        $fields = [
+            'uid',
+            'title',
+            'subtitle',
+            'titleanddate',
+            'date',
+            'time',
+            'accreditation_number',
+            'credit_points',
+            'room',
+            'place',
+            'speakers',
+            'price_regular',
+            'price_regular_early',
+            'price_special',
+            'price_special_early',
+            'allows_multiple_registrations',
+            'attendees',
+            'attendees_min',
+            'attendees_max',
+            'vacancies',
+            'enough_attendees',
+            'is_full',
+            'notes',
+        ];
+
+        $result = [];
+        foreach ($fields as $field) {
+            $result[$field] = [$field];
+        }
+
+        return $result;
+    }
+
+    /**
+     * @test
+     *
+     * @param string $fieldName
+     *
+     * @dataProvider dumpableEventFieldsDataProvider
+     */
+    public function dumpSeminarValuesCreatesNoDoubleColonsAfterLabel($fieldName)
+    {
+        $this->subject->setRecordPropertyString($fieldName, '1234 some value');
+
+        $result = $this->subject->dumpSeminarValues($fieldName);
+
+        self::assertNotContains('::', $result);
+    }
+
     /*
      * Tests regarding the registration begin date
      */

--- a/Tests/LegacyUnit/OldModel/RegistrationTest.php
+++ b/Tests/LegacyUnit/OldModel/RegistrationTest.php
@@ -1109,6 +1109,61 @@ class Tx_Seminars_Tests_Unit_OldModel_RegistrationTest extends TestCase
         self::assertContains($expected, $result);
     }
 
+    /**
+     * @return string[][]
+     */
+    public function dumpableUserFieldsDataProvider()
+    {
+        $fields = [
+            'uid',
+            'username',
+            'name',
+            'first_name',
+            'middle_name',
+            'last_name',
+            'address',
+            'telephone',
+            'fax',
+            'email',
+            'crdate',
+            'title',
+            'zip',
+            'city',
+            'country',
+            'www',
+            'company',
+            'pseudonym',
+            'pseudonym',
+            'gender',
+            'date_of_birth',
+            'mobilephone',
+            'comments',
+        ];
+
+        $result = [];
+        foreach ($fields as $field) {
+            $result[$field] = [$field];
+        }
+
+        return $result;
+    }
+
+    /**
+     * @test
+     *
+     * @param string $fieldName
+     *
+     * @dataProvider dumpableUserFieldsDataProvider
+     */
+    public function dumpUserValuesCreatesNoDoubleColonsAfterLabel($fieldName)
+    {
+        $this->subject->setUserData([$fieldName => '1234 some value']);
+
+        $result = $this->subject->dumpUserValues($fieldName);
+
+        self::assertNotContains('::', $result);
+    }
+
     /*
      * Tests for isPaid()
      */


### PR DESCRIPTION
Some labels already have a colon that needs to be removed before a colon
is appended in order to avoid double colons.