### PR TITLE
[TASK] Remove outdated sentence from the installation section in the docs

### DIFF
--- a/Documentation/DE/Installation/DieErweiterungInstallieren/Index.rst
+++ b/Documentation/DE/Installation/DieErweiterungInstallieren/Index.rst
@@ -47,10 +47,6 @@ TYPO3- Erweiterungen auf Ihrem Server:
 
 Anschließend können Sie die Erweiterung installieren.
 
-Wenn Sie alle drei Extensions  *seminars* , *onetimeaccount* und
-*cal\_ts\_service* benutzen, ist die Extension **seminarscalredirect**
-möglicherweise nützlich für Sie.
-
 **Ende des überarbeiteten/übersetzen Teils**
 
 Im Extension-Manager gibt einige Konfigurationseinstellungen.  **Bitte

--- a/Documentation/EN/Installation/InstallingTheExtension/Index.rst
+++ b/Documentation/EN/Installation/InstallingTheExtension/Index.rst
@@ -44,10 +44,6 @@ extensions to be installed beforehand:
 
 Then you can install this extension.
 
-If you're using all three extensions  *seminars* , *onetimeaccount*
-and *cal\_ts\_service* , the extension **seminarscalredirect** might
-be useful for you.
-
 In the Extension Manager, there will be some options.  **Make sure to
 save these options at least once (even if you don’t change them).**
 The default values are good for starters.


### PR DESCRIPTION
The extension `cal_ts_service` is outdated (only for TYPO3 <= 7) and the extension `seminarscalredirect` is marked as abandoned in TER, so I think this sentence should be removed from the docs.