### PR TITLE
[BUGFIX] Do not cache vendor/ on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,6 @@ env:
 
 cache:
   directories:
-  - .Build/vendor
   - $HOME/.composer/cache
 
 before_install:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Removed
 
 ### Fixed
+- Do not cache `vendor/` on Travis CI (#512)
 - Improve the manual (#500, #501, #504)
 
 ## 3.0.0


### PR DESCRIPTION
This causes too much trouble with version conflicts.

Caching the Composer cache should be enough anyway.