### PR TITLE
[TASK] Use separate fixture file tor the event checkboxes tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Changed
 - Upgrade PHPUnit and nimut/testing-framework (#513)
 - Merge the testing registration model into the regular model (#510)
-- Move more tests to the new testing framework (#507, #509, #510)
+- Move more tests to the new testing framework (#507, #509, #510, #516)
 - Change the casing of `Registration::setFrontEndUserUID` (#506)
 - Allow empty user data for registrations (#505)
 - Improve the code autoformatting (#502)

--- a/Tests/Functional/OldModel/EventTest.php
+++ b/Tests/Functional/OldModel/EventTest.php
@@ -353,9 +353,9 @@ final class EventTest extends FunctionalTestCase
      */
     public function getCheckboxesForNoCheckboxesReturnsEmptyArray()
     {
-        $this->importDataSet(__DIR__ . '/Fixtures/Events.xml');
+        $this->importDataSet(__DIR__ . '/Fixtures/Events/Checkboxes.xml');
 
-        $subject = TestingEvent::fromUid(2);
+        $subject = TestingEvent::fromUid(1);
         $result = $subject->getCheckboxes();
 
         self::assertSame([], $result);
@@ -366,9 +366,9 @@ final class EventTest extends FunctionalTestCase
      */
     public function getCheckboxesReturnsCaptionAndUidOfAssociatedCheckboxes()
     {
-        $this->importDataSet(__DIR__ . '/Fixtures/Events.xml');
+        $this->importDataSet(__DIR__ . '/Fixtures/Events/Checkboxes.xml');
 
-        $subject = TestingEvent::fromUid(10);
+        $subject = TestingEvent::fromUid(2);
         $result = $subject->getCheckboxes();
 
         $expected = [['caption' => 'Checkbox one', 'value' => 1]];
@@ -380,9 +380,9 @@ final class EventTest extends FunctionalTestCase
      */
     public function getCheckboxesReturnsAssociatedCheckboxesOrderedBySorting()
     {
-        $this->importDataSet(__DIR__ . '/Fixtures/Events.xml');
+        $this->importDataSet(__DIR__ . '/Fixtures/Events/Checkboxes.xml');
 
-        $subject = TestingEvent::fromUid(11);
+        $subject = TestingEvent::fromUid(3);
         $result = $subject->getCheckboxes();
 
         $expected = [['caption' => 'Checkbox two', 'value' => 2], ['caption' => 'Checkbox one', 'value' => 1]];

--- a/Tests/Functional/OldModel/Fixtures/Events.xml
+++ b/Tests/Functional/OldModel/Fixtures/Events.xml
@@ -126,37 +126,4 @@
         <title>event without any registrations, but with open seats</title>
         <attendees_max>12</attendees_max>
     </tx_seminars_seminars>
-
-    <tx_seminars_seminars>
-        <uid>10</uid>
-        <title>event with one checkbox</title>
-        <checkboxes>1</checkboxes>
-    </tx_seminars_seminars>
-    <tx_seminars_checkboxes>
-        <uid>1</uid>
-        <title>Checkbox one</title>
-    </tx_seminars_checkboxes>
-    <tx_seminars_seminars_checkboxes_mm>
-        <uid_local>10</uid_local>
-        <uid_foreign>1</uid_foreign>
-    </tx_seminars_seminars_checkboxes_mm>
-    <tx_seminars_seminars>
-        <uid>11</uid>
-        <title>event with two checkboxes</title>
-        <checkboxes>2</checkboxes>
-    </tx_seminars_seminars>
-    <tx_seminars_checkboxes>
-        <uid>2</uid>
-        <title>Checkbox two</title>
-    </tx_seminars_checkboxes>
-    <tx_seminars_seminars_checkboxes_mm>
-        <uid_local>11</uid_local>
-        <uid_foreign>1</uid_foreign>
-        <sorting>2</sorting>
-    </tx_seminars_seminars_checkboxes_mm>
-    <tx_seminars_seminars_checkboxes_mm>
-        <uid_local>11</uid_local>
-        <uid_foreign>2</uid_foreign>
-        <sorting>1</sorting>
-    </tx_seminars_seminars_checkboxes_mm>
 </dataset>

--- a/Tests/Functional/OldModel/Fixtures/Events/Checkboxes.xml
+++ b/Tests/Functional/OldModel/Fixtures/Events/Checkboxes.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<dataset>
+    <tx_seminars_checkboxes>
+        <uid>1</uid>
+        <title>Checkbox one</title>
+    </tx_seminars_checkboxes>
+    <tx_seminars_checkboxes>
+        <uid>2</uid>
+        <title>Checkbox two</title>
+    </tx_seminars_checkboxes>
+
+    <tx_seminars_seminars>
+        <uid>1</uid>
+        <title>event without any checkboxes</title>
+    </tx_seminars_seminars>
+
+    <tx_seminars_seminars>
+        <uid>2</uid>
+        <title>event with one checkbox</title>
+        <checkboxes>1</checkboxes>
+    </tx_seminars_seminars>
+    <tx_seminars_seminars_checkboxes_mm>
+        <uid_local>2</uid_local>
+        <uid_foreign>1</uid_foreign>
+    </tx_seminars_seminars_checkboxes_mm>
+
+    <tx_seminars_seminars>
+        <uid>3</uid>
+        <title>event with two checkboxes</title>
+        <checkboxes>2</checkboxes>
+    </tx_seminars_seminars>
+    <tx_seminars_seminars_checkboxes_mm>
+        <uid_local>3</uid_local>
+        <uid_foreign>1</uid_foreign>
+        <sorting>2</sorting>
+    </tx_seminars_seminars_checkboxes_mm>
+    <tx_seminars_seminars_checkboxes_mm>
+        <uid_local>3</uid_local>
+        <uid_foreign>2</uid_foreign>
+        <sorting>1</sorting>
+    </tx_seminars_seminars_checkboxes_mm>
+</dataset>


### PR DESCRIPTION
This should help keep the fixture files for the functional tests
shorter and speed up the tests.