### PR TITLE
[BUGFIX] Stop accessing FrontEndController::loginUser in TYPO3 9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Removed
 
 ### Fixed
+- Stop accessing `FrontEndController::loginUser` in TYPO3 9 (#526, #522)
 - Downgrade to PHPUnit 6.5 (#525)
 - Remove whitespace around the email salutation (#523, #205)
 

--- a/Classes/FrontEnd/RegistrationForm.php
+++ b/Classes/FrontEnd/RegistrationForm.php
@@ -6,6 +6,7 @@ use SJBR\StaticInfoTables\PiBaseApi;
 use SJBR\StaticInfoTables\Utility\LocalizationUtility;
 use TYPO3\CMS\Core\Crypto\Random;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Core\Utility\VersionNumberUtility;
 use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
 
 /**
@@ -704,7 +705,9 @@ class Tx_Seminars_FrontEnd_RegistrationForm extends \Tx_Seminars_FrontEnd_Editor
             && \Tx_Oelib_Session::getInstance(\Tx_Oelib_Session::TYPE_USER)->getAsBoolean('onetimeaccount')
         ) {
             $this->getFrontEndController()->fe_user->logoff();
-            $this->getFrontEndController()->loginUser = 0;
+            if (VersionNumberUtility::convertVersionNumberToInteger(TYPO3_version) < 9004000) {
+                $this->getFrontEndController()->loginUser = 0;
+            }
         }
 
         if ($this->getConfValueBoolean('sendParametersToThankYouAfterRegistrationPageUrl', 's_registration')) {

--- a/Tests/Unit/FrontEnd/RegistrationFormTest.php
+++ b/Tests/Unit/FrontEnd/RegistrationFormTest.php
@@ -226,8 +226,6 @@ final class RegistrationFormTest extends UnitTestCase
      */
     public function getThankYouAfterRegistrationUrlWithOneTimeAccountAndLogOutEnabledLogsUserOff()
     {
-        self::markTestIncomplete('This needs a bug fix first.');
-
         $this->session->setAsBoolean('onetimeaccount', true);
 
         $configuration = self::CONFIGURATION;


### PR DESCRIPTION
This property has been deprecated in TYPO3 9.

Fixes #522
Part of #521