### PR TITLE
[BUGFIX] Fix the alignment of labels with umlauts in the emails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Removed
 
 ### Fixed
+- Fix the alignment of labels with umlauts in the emails (#536)
 - Use proper label tags for the terms checkboxes (#535)
 - Check the dates for checkboxes, not the topics (#533)
 

--- a/Classes/OldModel/Event.php
+++ b/Classes/OldModel/Event.php
@@ -2357,9 +2357,10 @@ class Tx_Seminars_OldModel_Event extends \Tx_Seminars_OldModel_AbstractTimeSpan
             }
 
             // Check whether there is a value to display.
-            // If not, we don't use the padding and break the line directly after the label.
+            // If not, we will not use the padding and break the line directly after the label.
             if ($value !== '') {
-                $result .= \str_pad($currentLabel . ': ', $maxLength + 2, ' ') . $value . LF;
+                $padding = \str_pad('', $maxLength - \mb_strlen($currentLabel, 'utf-8'));
+                $result .= $currentLabel . ': ' . $padding . $value . "\n";
             } else {
                 $result .= $currentLabel . ':' . LF;
             }

--- a/Classes/OldModel/Registration.php
+++ b/Classes/OldModel/Registration.php
@@ -810,9 +810,10 @@ class Tx_Seminars_OldModel_Registration extends AbstractModel implements \Tx_Oel
             $label = $labels[$key];
             $value = $this->getUserData($key);
             // Checks whether there is a value to display.
-            // If not, we don't use  the padding and break the line directly after the label.
+            // If not, we will not use the padding and break the line directly after the label.
             if ($value !== '') {
-                $result .= \str_pad($label . ': ', $maximumLabelLength + 2, ' ') . $value . LF;
+                $padding = \str_pad('', $maximumLabelLength - \mb_strlen($label, 'utf-8'));
+                $result .= $label . ': ' . $padding . $value . "\n";
             } else {
                 $result .= $label . ':' . LF;
             }
@@ -860,7 +861,8 @@ class Tx_Seminars_OldModel_Registration extends AbstractModel implements \Tx_Oel
             if (\strpos($value, LF) !== false) {
                 $result .= $currentLabel . ': ' . LF;
             } else {
-                $result .= \str_pad($currentLabel . ': ', $maximumLabelLength + 2, ' ');
+                $padding = \str_pad('', $maximumLabelLength - \mb_strlen($currentLabel, 'utf-8'));
+                $result .= $currentLabel . ': ' . $padding;
             }
             $result .= $value . LF;
         }


### PR DESCRIPTION
`str_pad` does not work correctly with multibyte characters.