### PR TITLE
[FEATURE] Add new registration list CSV hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ## x.y.z
 
 ### Added
+- Add new registration list CSV hook (#)
 - Add new data sanitization hook (#544)
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ## x.y.z
 
 ### Added
-- Add new registration list CSV hook (#)
+- Add new registration list CSV hook (#545)
 - Add new data sanitization hook (#544)
 
 ### Changed

--- a/Classes/Csv/AbstractRegistrationListView.php
+++ b/Classes/Csv/AbstractRegistrationListView.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+use OliverKlee\Seminars\Hooks\HookProvider;
+use OliverKlee\Seminars\Hooks\Interfaces\RegistrationListCsv;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
@@ -101,7 +103,15 @@ abstract class Tx_Seminars_Csv_AbstractRegistrationListView extends \Tx_Seminars
 
         $allLines = array_merge([$this->createCsvHeading()], $this->createCsvBodyLines());
 
-        return $this->createCsvSeparatorLine() . implode(self::LINE_SEPARATOR, $allLines) . self::LINE_SEPARATOR;
+        $allLines = $this->createCsvSeparatorLine()
+            . implode(self::LINE_SEPARATOR, $allLines)
+            . self::LINE_SEPARATOR;
+
+        /** @var HookProvider $csvHookProvider */
+        $csvHookProvider = GeneralUtility::makeInstance(HookProvider::class, RegistrationListCsv::class);
+        $allLines = $csvHookProvider->executeHookReturningModifiedValue('modifyCsv', $allLines, $this);
+
+        return $allLines;
     }
 
     /**

--- a/Classes/Csv/AbstractRegistrationListView.php
+++ b/Classes/Csv/AbstractRegistrationListView.php
@@ -109,9 +109,7 @@ abstract class Tx_Seminars_Csv_AbstractRegistrationListView extends \Tx_Seminars
 
         /** @var HookProvider $csvHookProvider */
         $csvHookProvider = GeneralUtility::makeInstance(HookProvider::class, RegistrationListCsv::class);
-        $allLines = $csvHookProvider->executeHookReturningModifiedValue('modifyCsv', $allLines, $this);
-
-        return $allLines;
+        return $csvHookProvider->executeHookReturningModifiedValue('modifyCsv', $allLines, $this);
     }
 
     /**

--- a/Classes/Hooks/Interfaces/RegistrationListCsv.php
+++ b/Classes/Hooks/Interfaces/RegistrationListCsv.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OliverKlee\Seminars\Hooks\Interfaces;
+
+/**
+ * Use this interface for hooks concerning the registration list CSV.
+ *
+ * @author Michael Kramer <m.kramer@mxp.de>
+ */
+interface RegistrationListCsv extends Hook
+{
+    /**
+     * Modifies the rendered CSV string.
+     *
+     * This allows modifying the complete CSV text right before it is delivered.
+     *
+     * @param string $csv the CSV text produced by `AbstractRegistrationListView::render()`
+     * @param \Tx_Seminars_Csv_AbstractRegistrationListView $registrationList the CSV data provider
+     *
+     * @return string the modified CSV text to use
+     */
+    public function modifyCsv(string $csv, \Tx_Seminars_Csv_AbstractRegistrationListView $registrationList): string;
+}

--- a/Documentation/DE/Referenz/Hooks/Index.rst
+++ b/Documentation/DE/Referenz/Hooks/Index.rst
@@ -32,6 +32,7 @@ Es gibt Hooks in diese Teile von seminars:
 * :ref:`datatimespan_de`
 * :ref:`backendemail_de`
 * :ref:`backendregistrationlistview_de`
+* :ref:`registrationlistcsv_de`
 * :ref:`datasanitization_de`
 
 Bitte nehmen Sie Kontakt zu uns auf, wenn Sie weitere Hooks benötigen.
@@ -821,6 +822,46 @@ Implementieren Sie die benötigten Methoden gemäß dem Interface:
             \Tx_Oelib_Template $template,
             int $registrationsToShow
         ) {
+            // Hier Ihr Code
+        }
+    }
+
+.. _registrationlistcsv_de:
+
+Hooks in die CSV-Generierung der Registrierungsliste
+""""""""""""""""""""""""""""""""""""""""""""""""""""
+
+Es gibt einen Hook in die CSV-Generierung der Registrierungsliste, um das erzeugte CSV
+zu verändern.
+
+Machen Sie seminars Ihre Klasse, die :php:`\OliverKlee\Seminars\Hooks\Interfaces\RegistrationListCsv`
+implementiert, in :file:`ext_localconf.php` Ihrer Extension bekannt:
+
+.. code-block:: php
+
+    $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['seminars'][\OliverKlee\Seminars\Hooks\Interfaces\RegistrationListCsv::class][]
+        = \Tx_Seminarspaypal_Hooks_RegistrationListCsv::class;
+
+Implementieren Sie die benötigten Methoden gemäß dem Interface:
+
+.. code-block:: php
+
+    use \OliverKlee\Seminars\Hooks\Interfaces\RegistrationListCsv;
+
+    class Tx_Seminarspaypal_Hooks_RegistrationListCsv implements RegistrationListCsv
+    {
+        /**
+         * Modifies the rendered CSV string.
+         *
+         * This allows modifying the complete CSV text right before it is delivered.
+         *
+         * @param string $csv the CSV text produced by `AbstractRegistrationListView::render()`
+         * @param \Tx_Seminars_Csv_AbstractRegistrationListView $registrationList the CSV data provider
+         *
+         * @return string the modified CSV text to use
+         */
+        public function modifyCsv(string $csv, \Tx_Seminars_Csv_AbstractRegistrationListView $registrationList): string
+        {
             // Hier Ihr Code
         }
     }

--- a/Documentation/EN/Reference/Hooks/Index.rst
+++ b/Documentation/EN/Reference/Hooks/Index.rst
@@ -32,6 +32,7 @@ are hooks for these parts of seminars:
 * :ref:`datatimespan_en`
 * :ref:`backendemail_en`
 * :ref:`backendregistrationlistview_en`
+* :ref:`registrationlistcsv_en`
 * :ref:`datasanitization_en`
 
 Please contact us if you need additional hooks.
@@ -820,6 +821,45 @@ Implement the methods required by the interface:
             \Tx_Oelib_Template $template,
             int $registrationsToShow
         ) {
+            // Your code here
+        }
+    }
+
+.. _registrationlistcsv_en:
+
+Hooks for the CSV generation of registration lists
+""""""""""""""""""""""""""""""""""""""""""""""""""
+
+There is a hook into the CSV generation of registration lists to modify the generated CSV text.
+
+Register your class that implements :php:`\OliverKlee\Seminars\Hooks\Interfaces\RegistrationListCsv`
+like this in :file:`ext_localconf.php` of your extension:
+
+.. code-block:: php
+
+    $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['seminars'][\OliverKlee\Seminars\Hooks\Interfaces\RegistrationListCsv::class][]
+        = \Tx_Seminarspaypal_Hooks_RegistrationListCsv::class;
+
+Implement the methods required by the interface:
+
+.. code-block:: php
+
+    use \OliverKlee\Seminars\Hooks\Interfaces\RegistrationListCsv;
+
+    class Tx_Seminarspaypal_Hooks_RegistrationListCsv implements RegistrationListCsv
+    {
+        /**
+         * Modifies the rendered CSV string.
+         *
+         * This allows modifying the complete CSV text right before it is delivered.
+         *
+         * @param string $csv the CSV text produced by `AbstractRegistrationListView::render()`
+         * @param \Tx_Seminars_Csv_AbstractRegistrationListView $registrationList the CSV data provider
+         *
+         * @return string the modified CSV text to use
+         */
+        public function modifyCsv(string $csv, \Tx_Seminars_Csv_AbstractRegistrationListView $registrationList): string
+        {
             // Your code here
         }
     }


### PR DESCRIPTION
Includes the instance flushing from Tx_Seminars_Tests_Unit_BackEnd_RegistrationsListTest (required for the legacy unit tests).