### PR TITLE
[BUGFIX] Stop converting class names to PSR-4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Removed
 
 ### Fixed
+- Stop converting class names to PSR-4 (#597)
 
 ## 3.3.0
 

--- a/Configuration/php-cs-fixer.php
+++ b/Configuration/php-cs-fixer.php
@@ -101,7 +101,8 @@ return \PhpCsFixer\Config::create()
             'phpdoc_trim' => true,
             'phpdoc_types' => true,
             'phpdoc_types_order' => ['null_adjustment' => 'always_last', 'sort_algorithm' => 'none'],
-            'psr4' => true,
+            // We can enable this once all class use PSR-4.
+            // 'psr4' => true,
             'return_type_declaration' => ['space_before' => 'none'],
             'semicolon_after_instruction' => true,
             'short_scalar_cast' => true,


### PR DESCRIPTION
We are not using PSR-4 yet, and so we must not automatically convert
the class names accordingly in the CI builds.

This fixes the CI build with the latest version of the
PHP-CS-Fixer.