### PR TITLE
[BUGFIX] Make the CI Composer cache more specific

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,6 @@ jobs:
         with:
           key: "php${{ matrix.php-version }}-composer-${{ hashFiles('**/composer.json') }}"
           path: ~/.composer/cache
-          restore-keys: "php${{ matrix.php-version }}-composer-\n"
       - name: "Install Composer dependencies"
         run: "composer install --no-progress"
       - name: "Run command"
@@ -87,7 +86,6 @@ jobs:
         with:
           key: "php${{ matrix.php-version }}-composer-${{ hashFiles('**/composer.json') }}"
           path: ~/.composer/cache
-          restore-keys: "php${{ matrix.php-version }}-composer-\n"
       - env:
           TYPO3: "${{ matrix.typo3-version }}"
         name: "Install TYPO3 Core"
@@ -136,7 +134,6 @@ jobs:
         with:
           key: "php${{ matrix.php-version }}-composer-${{ hashFiles('**/composer.json') }}"
           path: ~/.composer/cache
-          restore-keys: "php${{ matrix.php-version }}-composer-\n"
       - env:
           TYPO3: "${{ matrix.typo3-version }}"
         name: "Install TYPO3 Core"
@@ -206,7 +203,6 @@ jobs:
         with:
           key: "php${{ matrix.php-version }}-composer-${{ hashFiles('**/composer.json') }}"
           path: ~/.composer/cache
-          restore-keys: "php${{ matrix.php-version }}-composer-\n"
       - env:
           TYPO3: "${{ matrix.typo3-version }}"
         name: "Install TYPO3 Core"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,11 +198,11 @@ jobs:
           coverage: none
       - name: "Show Composer version"
         run: composer --version
-      - name: "Cache dependencies installed with composer"
-        uses: actions/cache@v1
-        with:
-          key: "php${{ matrix.php-version }}-composer-${{ hashFiles('**/composer.json') }}"
-          path: ~/.composer/cache
+#      - name: "Cache dependencies installed with composer"
+#        uses: actions/cache@v1
+#        with:
+#          key: "php${{ matrix.php-version }}-composer-${{ hashFiles('**/composer.json') }}"
+#          path: ~/.composer/cache
       - env:
           TYPO3: "${{ matrix.typo3-version }}"
         name: "Install TYPO3 Core"


### PR DESCRIPTION
The cache needs to take the contents of `composer.json` into account
to avoid false positives when matching caches.

Fixes #650