### PR TITLE
[TASK] Explicitly use Composer 2 in the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,7 @@ jobs:
         with:
           php-version: ${{ matrix.php-versions }}
           extensions: intl, mbstring, xml, soap, zip, curl
+          tools: composer:v2
           coverage: none
 
       - name: Install TYPO3 TER client


### PR DESCRIPTION
This makes sure we reap the performance and traffic benefits
of Composer V2.