### PR TITLE
[CLEANUP] Use more namespaced oelib classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Removed
 
 ### Fixed
-- Use the namespaced oelib classes (#658, #569, #661, #662, #663, #664, #665, #666, #667, #668)
+- Use the namespaced oelib classes (#658, #569, #661, #662, #663, #664, #665, #666, #667, #668, #669)
 - Stop using event model prophecies in the scheduler task tests (#651)
 - Stop converting class names to PSR-4 (#597)
 

--- a/Classes/BackEnd/AbstractEventMailForm.php
+++ b/Classes/BackEnd/AbstractEventMailForm.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace OliverKlee\Seminars\BackEnd;
 
+use OliverKlee\Oelib\Configuration\PageFinder;
+use OliverKlee\Oelib\Exception\NotFoundException;
+use OliverKlee\Oelib\Http\HeaderProxyFactory;
 use OliverKlee\Oelib\Mapper\MapperRegistry;
 use OliverKlee\Seminar\Email\Salutation;
 use TYPO3\CMS\Backend\Routing\UriBuilder;
@@ -82,7 +85,7 @@ abstract class AbstractEventMailForm
      * @param int $eventUid UID of an event, must be > 0
      *
      * @throws \InvalidArgumentException
-     * @throws \Tx_Oelib_Exception_NotFound if event could not be instantiated
+     * @throws NotFoundException if event could not be instantiated
      */
     public function __construct(int $eventUid)
     {
@@ -93,7 +96,7 @@ abstract class AbstractEventMailForm
         $this->oldEvent = GeneralUtility::makeInstance(\Tx_Seminars_OldModel_Event::class, $eventUid);
 
         if (!$this->oldEvent->comesFromDatabase()) {
-            throw new \Tx_Oelib_Exception_NotFound('There is no event with this UID.', 1333292164);
+            throw new NotFoundException('There is no event with this UID.', 1333292164);
         }
 
         /** @var \Tx_Seminars_Mapper_Event $mapper */
@@ -138,7 +141,7 @@ abstract class AbstractEventMailForm
             $this->redirectToListView();
         }
 
-        $urlParameters = ['id' => \Tx_Oelib_PageFinder::getInstance()->getPageUid()];
+        $urlParameters = ['id' => PageFinder::getInstance()->getPageUid()];
         $formAction = $this->getRouteUrl(self::MODULE_NAME, $urlParameters);
 
         return '<fieldset id="EventMailForm"><form action="' . \htmlspecialchars($formAction, ENT_QUOTES | ENT_HTML5) .
@@ -485,10 +488,10 @@ abstract class AbstractEventMailForm
      */
     private function redirectToListView()
     {
-        $urlParameters = ['id' => \Tx_Oelib_PageFinder::getInstance()->getPageUid()];
+        $urlParameters = ['id' => PageFinder::getInstance()->getPageUid()];
         $url = $this->getRouteUrl(self::MODULE_NAME, $urlParameters);
 
-        \Tx_Oelib_HeaderProxyFactory::getInstance()->getHeaderProxy()->addHeader('Location: ' . $url);
+        HeaderProxyFactory::getInstance()->getHeaderProxy()->addHeader('Location: ' . $url);
     }
 
     /**

--- a/Classes/BackEnd/RegistrationsList.php
+++ b/Classes/BackEnd/RegistrationsList.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace OliverKlee\Seminars\BackEnd;
 
+use OliverKlee\Oelib\Exception\NotFoundException;
 use OliverKlee\Oelib\Mapper\MapperRegistry;
 use OliverKlee\Seminars\Hooks\HookProvider;
 use OliverKlee\Seminars\Hooks\Interfaces\BackendRegistrationListView;
@@ -174,7 +175,7 @@ class RegistrationsList extends AbstractList
 
             try {
                 $userName = \htmlspecialchars($registration->getUserName(), ENT_QUOTES | ENT_HTML5);
-            } catch (\Tx_Oelib_Exception_NotFound $exception) {
+            } catch (NotFoundException $exception) {
                 $userName = $languageService->getLL('registrationlist.deleted');
             }
             $event = $registration->getSeminarObject();

--- a/Classes/ConfigCheck.php
+++ b/Classes/ConfigCheck.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use OliverKlee\Oelib\Configuration\ConfigurationCheck;
 use OliverKlee\Oelib\System\Typo3Version;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -18,7 +19,7 @@ use TYPO3\CMS\Frontend\Resource\FilePathSanitizer;
  * @author Oliver Klee <typo3-coding@oliverklee.de>
  * @author Niels Pardon <mail@niels-pardon.de>
  */
-class Tx_Seminars_ConfigCheck extends \Tx_Oelib_ConfigCheck
+class Tx_Seminars_ConfigCheck extends ConfigurationCheck
 {
     /**
      * Checks the configuration for: \Tx_Seminars_Service_RegistrationManager/.

--- a/Classes/Csv/CsvDownloader.php
+++ b/Classes/Csv/CsvDownloader.php
@@ -6,6 +6,7 @@ namespace OliverKlee\Seminars\Csv;
 
 use OliverKlee\Oelib\Configuration\Configuration;
 use OliverKlee\Oelib\Configuration\ConfigurationRegistry;
+use OliverKlee\Oelib\Http\HeaderProxyFactory;
 use OliverKlee\Oelib\Templating\TemplateHelper;
 use TYPO3\CMS\Core\Charset\CharsetConverter;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -103,9 +104,7 @@ class CsvDownloader extends TemplateHelper
                 $result = (new CharsetConverter())->conv($result, 'utf-8', $resultCharset);
             }
         } catch (\Exception $exception) {
-            \Tx_Oelib_HeaderProxyFactory::getInstance()->getHeaderProxy()->addHeader(
-                'Status: 500 Internal Server Error'
-            );
+            HeaderProxyFactory::getInstance()->getHeaderProxy()->addHeader('Status: 500 Internal Server Error');
             $result = $exception->getMessage() . LF . LF . $exception->getTraceAsString() . LF . LF;
         }
 
@@ -296,7 +295,7 @@ class CsvDownloader extends TemplateHelper
      */
     private function setPageTypeAndDisposition(string $csvFileName)
     {
-        $headerProxy = \Tx_Oelib_HeaderProxyFactory::getInstance()->getHeaderProxy();
+        $headerProxy = HeaderProxyFactory::getInstance()->getHeaderProxy();
         $headerProxy->addHeader(
             'Content-type: text/csv; header=present; charset=' . $this->configuration->getAsString('charsetForCsv')
         );
@@ -317,11 +316,11 @@ class CsvDownloader extends TemplateHelper
     {
         switch ($errorCode) {
             case self::ACCESS_DENIED:
-                \Tx_Oelib_HeaderProxyFactory::getInstance()->getHeaderProxy()->addHeader('Status: 403 Forbidden');
+                HeaderProxyFactory::getInstance()->getHeaderProxy()->addHeader('Status: 403 Forbidden');
                 $result = $this->translate('message_403');
                 break;
             case self::NOT_FOUND:
-                \Tx_Oelib_HeaderProxyFactory::getInstance()->getHeaderProxy()->addHeader('Status: 404 Not Found');
+                HeaderProxyFactory::getInstance()->getHeaderProxy()->addHeader('Status: 404 Not Found');
                 $result = $this->translate('message_404');
                 break;
             default:

--- a/Classes/Email/Salutation.php
+++ b/Classes/Email/Salutation.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace OliverKlee\Seminar\Email;
 
 use OliverKlee\Oelib\Configuration\ConfigurationRegistry;
+use OliverKlee\Oelib\Language\Translator;
+use OliverKlee\Oelib\Language\TranslatorRegistry;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
@@ -15,7 +17,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 class Salutation
 {
     /**
-     * @var \Tx_Oelib_Translator
+     * @var Translator
      */
     private $translator = null;
 
@@ -24,7 +26,7 @@ class Salutation
      */
     public function __construct()
     {
-        $this->translator = \Tx_Oelib_TranslatorRegistry::get('seminars');
+        $this->translator = TranslatorRegistry::get('seminars');
     }
 
     /**

--- a/Classes/FrontEnd/Countdown.php
+++ b/Classes/FrontEnd/Countdown.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use OliverKlee\Oelib\Exception\NotFoundException;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
@@ -69,7 +70,7 @@ class Tx_Seminars_FrontEnd_Countdown extends \Tx_Seminars_FrontEnd_AbstractView
             $event = $this->mapper->findNextUpcoming();
 
             $message = $this->viewHelper->render($event->getBeginDateAsUnixTimeStamp());
-        } catch (\Tx_Oelib_Exception_NotFound $exception) {
+        } catch (NotFoundException $exception) {
             $message = $this->translate('message_countdown_noEventFound');
         }
 

--- a/Classes/FrontEnd/DefaultController.php
+++ b/Classes/FrontEnd/DefaultController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use OliverKlee\Oelib\Authentication\FrontEndLoginManager;
 use OliverKlee\Oelib\DataStructures\Collection;
+use OliverKlee\Oelib\Http\HeaderProxyFactory;
 use OliverKlee\Oelib\Interfaces\ConfigurationCheckable;
 use OliverKlee\Oelib\Mapper\MapperRegistry;
 use OliverKlee\Oelib\Templating\TemplateHelper;
@@ -763,13 +764,13 @@ class Tx_Seminars_FrontEnd_DefaultController extends TemplateHelper implements C
         if ($this->showUid <= 0) {
             $this->setMarker('error_text', $this->translate('message_missingSeminarNumber'));
             $result = $this->getSubpart('ERROR_VIEW');
-            \Tx_Oelib_HeaderProxyFactory::getInstance()->getHeaderProxy()->addHeader('Status: 404 Not Found');
+            HeaderProxyFactory::getInstance()->getHeaderProxy()->addHeader('Status: 404 Not Found');
         } elseif ($this->createSeminar($this->showUid, $this->isLoggedIn())) {
             $result = $this->createSingleViewForExistingEvent();
         } else {
             $this->setMarker('error_text', $this->translate('message_wrongSeminarNumber'));
             $result = $this->getSubpart('ERROR_VIEW');
-            \Tx_Oelib_HeaderProxyFactory::getInstance()->getHeaderProxy()->addHeader('Status: 404 Not Found');
+            HeaderProxyFactory::getInstance()->getHeaderProxy()->addHeader('Status: 404 Not Found');
         }
 
         $this->setMarker(
@@ -3106,9 +3107,7 @@ class Tx_Seminars_FrontEnd_DefaultController extends TemplateHelper implements C
             $result = $eventEditor->render();
         } else {
             $result = $hasAccessMessage;
-            \Tx_Oelib_HeaderProxyFactory::getInstance()->getHeaderProxy()->addHeader(
-                'Status: 403 Forbidden'
-            );
+            HeaderProxyFactory::getInstance()->getHeaderProxy()->addHeader('Status: 403 Forbidden');
         }
 
         return $result;
@@ -3606,7 +3605,7 @@ class Tx_Seminars_FrontEnd_DefaultController extends TemplateHelper implements C
     protected function redirectToCurrentUrl()
     {
         $currentUrl = GeneralUtility::locationHeaderUrl(GeneralUtility::getIndpEnv('REQUEST_URI'));
-        \Tx_Oelib_HeaderProxyFactory::getInstance()->getHeaderProxy()->addHeader('Location: ' . $currentUrl);
+        HeaderProxyFactory::getInstance()->getHeaderProxy()->addHeader('Location: ' . $currentUrl);
     }
 
     /**

--- a/Classes/FrontEnd/EventEditor.php
+++ b/Classes/FrontEnd/EventEditor.php
@@ -7,12 +7,14 @@ use OliverKlee\Oelib\Configuration\Configuration;
 use OliverKlee\Oelib\Configuration\ConfigurationRegistry;
 use OliverKlee\Oelib\DataStructures\Collection;
 use OliverKlee\Oelib\Email\SystemEmailFromBuilder;
+use OliverKlee\Oelib\Exception\NotFoundException;
 use OliverKlee\Oelib\Mapper\CountryMapper;
 use OliverKlee\Oelib\Mapper\MapperRegistry;
 use OliverKlee\Oelib\Model\AbstractModel;
 use OliverKlee\Oelib\Model\BackEndUser;
 use OliverKlee\Oelib\Model\Country;
 use OliverKlee\Oelib\Templating\Template;
+use OliverKlee\Oelib\Visibility\Tree;
 use OliverKlee\Seminars\Model\Interfaces\Titled;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
@@ -1103,11 +1105,8 @@ class Tx_Seminars_FrontEnd_EventEditor extends \Tx_Seminars_FrontEnd_Editor
      */
     private function getHiddenSubparts(): array
     {
-        /** @var \Tx_Oelib_Visibility_Tree $visibilityTree */
-        $visibilityTree = GeneralUtility::makeInstance(
-            \Tx_Oelib_Visibility_Tree::class,
-            $this->createTemplateStructure()
-        );
+        /** @var Tree $visibilityTree */
+        $visibilityTree = GeneralUtility::makeInstance(Tree::class, $this->createTemplateStructure());
 
         $visibilityTree->makeNodesVisible($this->getFieldsToShow());
         return $visibilityTree->getKeysOfHiddenSubparts();
@@ -1116,8 +1115,7 @@ class Tx_Seminars_FrontEnd_EventEditor extends \Tx_Seminars_FrontEnd_Editor
     /**
      * Creates the template subpart structure.
      *
-     * @return array the template's subpart structure for use with
-     *               \Tx_Oelib_Visibility_Tree
+     * @return array the template's subpart structure for use with Tree
      */
     private function createTemplateStructure(): array
     {
@@ -1836,7 +1834,7 @@ class Tx_Seminars_FrontEnd_EventEditor extends \Tx_Seminars_FrontEnd_Editor
         try {
             /** @var \Tx_Seminars_Model_Place $place */
             $place = $placeMapper->find((int)$placeUid);
-        } catch (\Tx_Oelib_Exception_NotFound $exception) {
+        } catch (NotFoundException $exception) {
             return $form->majixExecJs(
                 'alert("A place with the given UID does not exist.");'
             );
@@ -1856,7 +1854,7 @@ class Tx_Seminars_FrontEnd_EventEditor extends \Tx_Seminars_FrontEnd_Editor
             } else {
                 $countryUid = 0;
             }
-        } catch (\Tx_Oelib_Exception_NotFound $exception) {
+        } catch (NotFoundException $exception) {
             $countryUid = 0;
         }
 
@@ -2140,7 +2138,7 @@ class Tx_Seminars_FrontEnd_EventEditor extends \Tx_Seminars_FrontEnd_Editor
         try {
             /** @var \Tx_Seminars_Model_Speaker $speaker */
             $speaker = $speakerMapper->find((int)$speakerUid);
-        } catch (\Tx_Oelib_Exception_NotFound $exception) {
+        } catch (NotFoundException $exception) {
             return $form->majixExecJs(
                 'alert("A speaker with the given UID does not exist.");'
             );
@@ -2383,7 +2381,7 @@ class Tx_Seminars_FrontEnd_EventEditor extends \Tx_Seminars_FrontEnd_Editor
         try {
             /** @var \Tx_Seminars_Model_Checkbox $checkbox */
             $checkbox = $checkboxMapper->find((int)$checkboxUid);
-        } catch (\Tx_Oelib_Exception_NotFound $exception) {
+        } catch (NotFoundException $exception) {
             return $form->majixExecJs(
                 'alert("A checkbox with the given UID does not exist.");'
             );
@@ -2636,7 +2634,7 @@ class Tx_Seminars_FrontEnd_EventEditor extends \Tx_Seminars_FrontEnd_Editor
         try {
             /** @var \Tx_Seminars_Model_TargetGroup $targetGroup */
             $targetGroup = $targetGroupMapper->find((int)$targetGroupUid);
-        } catch (\Tx_Oelib_Exception_NotFound $exception) {
+        } catch (NotFoundException $exception) {
             return $form->majixExecJs(
                 'alert("A target group with the given UID does not exist.");'
             );

--- a/Classes/FrontEnd/RegistrationForm.php
+++ b/Classes/FrontEnd/RegistrationForm.php
@@ -5,7 +5,10 @@ declare(strict_types=1);
 use OliverKlee\Oelib\Authentication\FrontEndLoginManager;
 use OliverKlee\Oelib\Configuration\ConfigurationRegistry;
 use OliverKlee\Oelib\DataStructures\Collection;
+use OliverKlee\Oelib\Exception\NotFoundException;
+use OliverKlee\Oelib\Http\HeaderProxyFactory;
 use OliverKlee\Oelib\Mapper\MapperRegistry;
+use OliverKlee\Oelib\Session\Session;
 use OliverKlee\Oelib\System\Typo3Version;
 use SJBR\StaticInfoTables\PiBaseApi;
 use SJBR\StaticInfoTables\Utility\LocalizationUtility;
@@ -415,7 +418,7 @@ class Tx_Seminars_FrontEnd_RegistrationForm extends \Tx_Seminars_FrontEnd_Editor
                 }
                 try {
                     $userMapper->findByUserName($userName);
-                } catch (\Tx_Oelib_Exception_NotFound $exception) {
+                } catch (NotFoundException $exception) {
                     $isUnique = true;
                 }
 
@@ -701,7 +704,7 @@ class Tx_Seminars_FrontEnd_RegistrationForm extends \Tx_Seminars_FrontEnd_Editor
     {
         if (
             $this->getConfValueBoolean('logOutOneTimeAccountsAfterRegistration')
-            && \Tx_Oelib_Session::getInstance(\Tx_Oelib_Session::TYPE_USER)->getAsBoolean('onetimeaccount')
+            && Session::getInstance(Session::TYPE_USER)->getAsBoolean('onetimeaccount')
         ) {
             $this->getFrontEndController()->fe_user->logoff();
             if (Typo3Version::isNotHigherThan(8)) {
@@ -1547,7 +1550,7 @@ class Tx_Seminars_FrontEnd_RegistrationForm extends \Tx_Seminars_FrontEnd_Editor
 
         foreach ($parametersToSave as $currentKey) {
             if (isset($parameters[$currentKey])) {
-                \Tx_Oelib_Session::getInstance(\Tx_Oelib_Session::TYPE_USER)
+                Session::getInstance(Session::TYPE_USER)
                     ->setAsString($this->prefixId . '_' . $currentKey, $parameters[$currentKey]);
             }
         }
@@ -1575,8 +1578,7 @@ class Tx_Seminars_FrontEnd_RegistrationForm extends \Tx_Seminars_FrontEnd_Editor
      */
     public function retrieveDataFromSession(array $parameters): string
     {
-        return \Tx_Oelib_Session::getInstance(\Tx_Oelib_Session::TYPE_USER)
-            ->getAsString($this->prefixId . '_' . $parameters['key']);
+        return Session::getInstance(Session::TYPE_USER)->getAsString($this->prefixId . '_' . $parameters['key']);
     }
 
     /**
@@ -1733,7 +1735,7 @@ class Tx_Seminars_FrontEnd_RegistrationForm extends \Tx_Seminars_FrontEnd_Editor
                     )
                 )
             );
-            \Tx_Oelib_HeaderProxyFactory::getInstance()->getHeaderProxy()->addHeader('Location:' . $redirectUrl);
+            HeaderProxyFactory::getInstance()->getHeaderProxy()->addHeader('Location:' . $redirectUrl);
             exit;
         }
 

--- a/Classes/FrontEnd/RegistrationsList.php
+++ b/Classes/FrontEnd/RegistrationsList.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use OliverKlee\Oelib\Http\HeaderProxyFactory;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
 
@@ -101,15 +102,11 @@ class Tx_Seminars_FrontEnd_RegistrationsList extends \Tx_Seminars_FrontEnd_Abstr
                 $errorMessage = $this->seminar->canViewRegistrationsListMessage(
                     $this->whatToDisplay
                 );
-                \Tx_Oelib_HeaderProxyFactory::getInstance()->getHeaderProxy()->addHeader(
-                    'Status: 403 Forbidden'
-                );
+                HeaderProxyFactory::getInstance()->getHeaderProxy()->addHeader('Status: 403 Forbidden');
             }
         } else {
             $errorMessage = $this->translate('message_wrongSeminarNumber');
-            \Tx_Oelib_HeaderProxyFactory::getInstance()->getHeaderProxy()->addHeader(
-                'Status: 404 Not Found'
-            );
+            HeaderProxyFactory::getInstance()->getHeaderProxy()->addHeader('Status: 404 Not Found');
             $this->setMarker('title', '');
         }
 

--- a/Classes/Mapper/Event.php
+++ b/Classes/Mapper/Event.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use OliverKlee\Oelib\DataStructures\Collection;
+use OliverKlee\Oelib\Exception\NotFoundException;
 use OliverKlee\Oelib\Mapper\AbstractDataMapper;
 use OliverKlee\Oelib\Mapper\FrontEndUserMapper;
 
@@ -68,7 +69,7 @@ class Tx_Seminars_Mapper_Event extends AbstractDataMapper
         try {
             /** @var \Tx_Seminars_Model_Event $result */
             $result = $this->findSingleByWhereClause(['publication_hash' => $publicationHash]);
-        } catch (\Tx_Oelib_Exception_NotFound $exception) {
+        } catch (NotFoundException $exception) {
             $result = null;
         }
 
@@ -111,7 +112,7 @@ class Tx_Seminars_Mapper_Event extends AbstractDataMapper
      *
      * @return \Tx_Seminars_Model_Event the next upcoming event
      *
-     * @throws \Tx_Oelib_Exception_NotFound
+     * @throws NotFoundException
      */
     public function findNextUpcoming(): \Tx_Seminars_Model_Event
     {
@@ -141,7 +142,7 @@ class Tx_Seminars_Mapper_Event extends AbstractDataMapper
             ->fetch();
 
         if ($row === false) {
-            throw new \Tx_Oelib_Exception_NotFound('Not found.', 1574004668);
+            throw new NotFoundException('Not found.', 1574004668);
         }
 
         /** @var \Tx_Seminars_Model_Event $next */

--- a/Classes/Model/Place.php
+++ b/Classes/Model/Place.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use OliverKlee\Oelib\Exception\NotFoundException;
 use OliverKlee\Oelib\Mapper\CountryMapper;
 use OliverKlee\Oelib\Mapper\MapperRegistry;
 use OliverKlee\Oelib\Model\AbstractModel;
@@ -146,7 +147,7 @@ class Tx_Seminars_Model_Place extends AbstractModel implements Titled
             /** @var CountryMapper $mapper */
             $mapper = MapperRegistry::get(CountryMapper::class);
             $country = $mapper->findByIsoAlpha2Code($countryCode);
-        } catch (\Tx_Oelib_Exception_NotFound $exception) {
+        } catch (NotFoundException $exception) {
             $country = null;
         }
 

--- a/Classes/OldModel/AbstractTimeSpan.php
+++ b/Classes/OldModel/AbstractTimeSpan.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use OliverKlee\Oelib\Interfaces\ConfigurationCheckable;
 use OliverKlee\Seminars\Hooks\HookProvider;
 use OliverKlee\Seminars\Hooks\Interfaces\DateTimeSpan;
 use OliverKlee\Seminars\OldModel\AbstractModel;
@@ -13,8 +14,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  * @author Niels Pardon <mail@niels-pardon.de>
  * @author Oliver Klee <typo3-coding@oliverklee.de>
  */
-abstract class Tx_Seminars_OldModel_AbstractTimeSpan extends AbstractModel implements
-    \Tx_Oelib_Interface_ConfigurationCheckable
+abstract class Tx_Seminars_OldModel_AbstractTimeSpan extends AbstractModel implements ConfigurationCheckable
 {
     /**
      * @var HookProvider|null

--- a/Classes/OldModel/Registration.php
+++ b/Classes/OldModel/Registration.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use OliverKlee\Oelib\Exception\NotFoundException;
 use OliverKlee\Oelib\Interfaces\ConfigurationCheckable;
 use OliverKlee\Oelib\Mapper\MapperRegistry;
 use OliverKlee\Seminars\OldModel\AbstractModel;
@@ -353,7 +354,7 @@ class Tx_Seminars_OldModel_Registration extends AbstractModel implements Configu
      *
      * @return void
      *
-     * @throws \Tx_Oelib_Exception_NotFound
+     * @throws NotFoundException
      */
     private function retrieveUserData()
     {
@@ -366,7 +367,7 @@ class Tx_Seminars_OldModel_Registration extends AbstractModel implements Configu
         $table = 'fe_users';
         $data = self::getConnectionForTable($table)->select(['*'], $table, ['uid' => $uid])->fetch();
         if (!\is_array($data)) {
-            throw new \Tx_Oelib_Exception_NotFound(
+            throw new NotFoundException(
                 'The FE user with the UID ' . $uid . ' could not be retrieved.',
                 1390065114
             );

--- a/Classes/SchedulerTasks/MailNotifier.php
+++ b/Classes/SchedulerTasks/MailNotifier.php
@@ -7,6 +7,7 @@ namespace OliverKlee\Seminars\SchedulerTasks;
 use OliverKlee\Oelib\Authentication\BackEndLoginManager;
 use OliverKlee\Oelib\Configuration\Configuration;
 use OliverKlee\Oelib\Configuration\ConfigurationRegistry;
+use OliverKlee\Oelib\Configuration\PageFinder;
 use OliverKlee\Oelib\Mapper\MapperRegistry;
 use OliverKlee\Seminars\Csv\EmailRegistrationListView;
 use OliverKlee\Seminars\SchedulerTask\RegistrationDigest;
@@ -430,7 +431,7 @@ class MailNotifier extends AbstractTask
 
     protected function getConfiguration(): Configuration
     {
-        \Tx_Oelib_PageFinder::getInstance()->setPageUid($this->getConfigurationPageUid());
+        PageFinder::getInstance()->setPageUid($this->getConfigurationPageUid());
 
         return ConfigurationRegistry::get('plugin.tx_seminars');
     }

--- a/Classes/Service/RegistrationManager.php
+++ b/Classes/Service/RegistrationManager.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use OliverKlee\Oelib\Authentication\FrontEndLoginManager;
 use OliverKlee\Oelib\Configuration\ConfigurationProxy;
+use OliverKlee\Oelib\Http\HeaderProxyFactory;
 use OliverKlee\Oelib\Mapper\MapperRegistry;
 use OliverKlee\Oelib\Model\FrontEndUser;
 use OliverKlee\Oelib\Templating\TemplateHelper;
@@ -381,11 +382,11 @@ class Tx_Seminars_Service_RegistrationManager extends TemplateHelper
     public function existsSeminarMessage(int $uid): string
     {
         if ($uid <= 0) {
-            \Tx_Oelib_HeaderProxyFactory::getInstance()->getHeaderProxy()->addHeader('Status: 404 Not Found');
+            HeaderProxyFactory::getInstance()->getHeaderProxy()->addHeader('Status: 404 Not Found');
             return $this->translate('message_missingSeminarNumber');
         }
         if (!$this->existsSeminar($uid)) {
-            \Tx_Oelib_HeaderProxyFactory::getInstance()->getHeaderProxy()->addHeader('Status: 404 Not Found');
+            HeaderProxyFactory::getInstance()->getHeaderProxy()->addHeader('Status: 404 Not Found');
             return $this->translate('message_wrongSeminarNumber');
         }
 

--- a/Classes/ViewHelper/Countdown.php
+++ b/Classes/ViewHelper/Countdown.php
@@ -3,6 +3,8 @@
 declare(strict_types=1);
 
 use OliverKlee\Oelib\Interfaces\Time;
+use OliverKlee\Oelib\Language\Translator;
+use OliverKlee\Oelib\Language\TranslatorRegistry;
 
 /**
  * This class represents a view helper for rendering a countdown.
@@ -12,7 +14,7 @@ use OliverKlee\Oelib\Interfaces\Time;
 class Tx_Seminars_ViewHelper_Countdown
 {
     /**
-     * @var \Tx_Oelib_Translator
+     * @var Translator
      */
     protected $translator = null;
 
@@ -21,7 +23,7 @@ class Tx_Seminars_ViewHelper_Countdown
      */
     public function __construct()
     {
-        $this->translator = \Tx_Oelib_TranslatorRegistry::get('seminars');
+        $this->translator = TranslatorRegistry::get('seminars');
     }
 
     /**

--- a/Classes/ViewHelper/DateRange.php
+++ b/Classes/ViewHelper/DateRange.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 use OliverKlee\Oelib\Configuration\Configuration;
 use OliverKlee\Oelib\Configuration\ConfigurationRegistry;
+use OliverKlee\Oelib\Language\Translator;
+use OliverKlee\Oelib\Language\TranslatorRegistry;
 
 /**
  * This class represents a view helper for rendering date ranges.
@@ -18,7 +20,7 @@ class Tx_Seminars_ViewHelper_DateRange
     protected $configuration = null;
 
     /**
-     * @var \Tx_Oelib_Translator
+     * @var Translator
      */
     protected $translator = null;
 
@@ -28,7 +30,7 @@ class Tx_Seminars_ViewHelper_DateRange
     public function __construct()
     {
         $this->configuration = ConfigurationRegistry::get('plugin.tx_seminars');
-        $this->translator = \Tx_Oelib_TranslatorRegistry::get('seminars');
+        $this->translator = TranslatorRegistry::get('seminars');
     }
 
     /**

--- a/Classes/ViewHelper/TimeRange.php
+++ b/Classes/ViewHelper/TimeRange.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 use OliverKlee\Oelib\Configuration\Configuration;
 use OliverKlee\Oelib\Configuration\ConfigurationRegistry;
+use OliverKlee\Oelib\Language\Translator;
+use OliverKlee\Oelib\Language\TranslatorRegistry;
 
 /**
  * This class represents a view helper for rendering time ranges.
@@ -18,7 +20,7 @@ class Tx_Seminars_ViewHelper_TimeRange
     protected $configuration = null;
 
     /**
-     * @var \Tx_Oelib_Translator
+     * @var Translator
      */
     protected $translator = null;
 
@@ -28,7 +30,7 @@ class Tx_Seminars_ViewHelper_TimeRange
     public function __construct()
     {
         $this->configuration = ConfigurationRegistry::get('plugin.tx_seminars');
-        $this->translator = \Tx_Oelib_TranslatorRegistry::get('seminars');
+        $this->translator = TranslatorRegistry::get('seminars');
     }
 
     /**

--- a/Tests/Functional/BackEnd/AbstractEventMailFormTest.php
+++ b/Tests/Functional/BackEnd/AbstractEventMailFormTest.php
@@ -5,6 +5,9 @@ declare(strict_types=1);
 namespace OliverKlee\Seminars\Tests\Functional\BackEnd;
 
 use Nimut\TestingFramework\TestCase\FunctionalTestCase;
+use OliverKlee\Oelib\Configuration\PageFinder;
+use OliverKlee\Oelib\Http\HeaderCollector;
+use OliverKlee\Oelib\Http\HeaderProxyFactory;
 use OliverKlee\Seminars\BackEnd\AbstractEventMailForm;
 use OliverKlee\Seminars\Tests\Functional\BackEnd\Fixtures\TestingEventMailForm;
 use OliverKlee\Seminars\Tests\Unit\Traits\LanguageHelper;
@@ -31,7 +34,7 @@ final class AbstractEventMailFormTest extends FunctionalTestCase
     private $mailer = null;
 
     /**
-     * @var \Tx_Oelib_HeaderCollector
+     * @var HeaderCollector
      */
     private $headerProxy = null;
 
@@ -57,7 +60,7 @@ final class AbstractEventMailFormTest extends FunctionalTestCase
         $mailerFactory->enableTestMode();
         $this->mailer = $mailerFactory->getMailer();
 
-        $headerProxyFactory = \Tx_Oelib_HeaderProxyFactory::getInstance();
+        $headerProxyFactory = HeaderProxyFactory::getInstance();
         $headerProxyFactory->enableTestMode();
         $this->headerProxy = $headerProxyFactory->getHeaderProxy();
     }
@@ -281,7 +284,7 @@ final class AbstractEventMailFormTest extends FunctionalTestCase
         $this->importDataSet(__DIR__ . '/Fixtures/Records.xml');
 
         $pageUid = 3;
-        \Tx_Oelib_PageFinder::getInstance()->setPageUid($pageUid);
+        PageFinder::getInstance()->setPageUid($pageUid);
 
         $subject = new TestingEventMailForm(4);
         $subject->setPostData(

--- a/Tests/Functional/BackEnd/EventsListTest.php
+++ b/Tests/Functional/BackEnd/EventsListTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace OliverKlee\Seminars\Tests\Functional\BackEnd;
 
 use Nimut\TestingFramework\TestCase\FunctionalTestCase;
+use OliverKlee\Oelib\Configuration\PageFinder;
 use OliverKlee\Seminars\BackEnd\AbstractList;
 use OliverKlee\Seminars\BackEnd\EventsList;
 use OliverKlee\Seminars\Tests\LegacyUnit\BackEnd\Fixtures\DummyModule;
@@ -56,7 +57,7 @@ final class EventsListTest extends FunctionalTestCase
         $this->importDataSet(__DIR__ . '/Fixtures/Records.xml');
 
         $pageUid = 2;
-        \Tx_Oelib_PageFinder::getInstance()->setPageUid($pageUid);
+        PageFinder::getInstance()->setPageUid($pageUid);
         $this->backEndModule->id = $pageUid;
         $this->backEndModule->setPageData(['uid' => $pageUid, 'doktype' => AbstractList::SYSFOLDER_TYPE]);
 
@@ -74,7 +75,7 @@ final class EventsListTest extends FunctionalTestCase
         $this->importDataSet(__DIR__ . '/Fixtures/Records.xml');
 
         $pageUid = 2;
-        \Tx_Oelib_PageFinder::getInstance()->setPageUid($pageUid);
+        PageFinder::getInstance()->setPageUid($pageUid);
         $this->backEndModule->id = $pageUid;
         $this->backEndModule->setPageData(['uid' => $pageUid, 'doktype' => AbstractList::SYSFOLDER_TYPE]);
 

--- a/Tests/Functional/Csv/CsvDownloaderTest.php
+++ b/Tests/Functional/Csv/CsvDownloaderTest.php
@@ -7,6 +7,8 @@ namespace OliverKlee\Seminars\Tests\Functional\Csv;
 use Nimut\TestingFramework\TestCase\FunctionalTestCase;
 use OliverKlee\Oelib\Configuration\Configuration;
 use OliverKlee\Oelib\Configuration\ConfigurationRegistry;
+use OliverKlee\Oelib\Http\HeaderCollector;
+use OliverKlee\Oelib\Http\HeaderProxyFactory;
 use OliverKlee\Seminars\Csv\CsvDownloader;
 use OliverKlee\Seminars\Tests\Unit\Traits\LanguageHelper;
 
@@ -30,7 +32,7 @@ final class CsvDownloaderTest extends FunctionalTestCase
     private $subject = null;
 
     /**
-     * @var \Tx_Oelib_HeaderCollector
+     * @var HeaderCollector
      */
     private $headerProxy = null;
 
@@ -43,7 +45,7 @@ final class CsvDownloaderTest extends FunctionalTestCase
     {
         parent::setUp();
 
-        $headerProxyFactory = \Tx_Oelib_HeaderProxyFactory::getInstance();
+        $headerProxyFactory = HeaderProxyFactory::getInstance();
         $headerProxyFactory->enableTestMode();
         $this->headerProxy = $headerProxyFactory->getHeaderProxy();
 

--- a/Tests/LegacyUnit/BackEnd/AbstractEventMailFormTest.php
+++ b/Tests/LegacyUnit/BackEnd/AbstractEventMailFormTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace OliverKlee\Seminars\Tests\LegacyUnit\BackEnd;
 
+use OliverKlee\Oelib\Configuration\PageFinder;
+use OliverKlee\Oelib\Exception\NotFoundException;
 use OliverKlee\Oelib\Testing\TestingFramework;
 use OliverKlee\PhpUnit\TestCase;
 use OliverKlee\Seminars\Tests\Functional\BackEnd\Fixtures\TestingEventMailForm;
@@ -46,7 +48,7 @@ class AbstractEventMailFormTest extends TestCase
         $mailerFactory = GeneralUtility::makeInstance(\Tx_Oelib_MailerFactory::class);
         $mailerFactory->enableTestMode();
 
-        \Tx_Oelib_PageFinder::getInstance()->setPageUid($this->testingFramework->createSystemFolder());
+        PageFinder::getInstance()->setPageUid($this->testingFramework->createSystemFolder());
 
         $organizerUid = $this->testingFramework->createRecord(
             'tx_seminars_organizers',
@@ -91,12 +93,8 @@ class AbstractEventMailFormTest extends TestCase
      */
     public function renderThrowsExceptionForInvalidEventUid()
     {
-        $this->expectException(
-            \Tx_Oelib_Exception_NotFound::class
-        );
-        $this->expectExceptionMessage(
-            'There is no event with this UID.'
-        );
+        $this->expectException(NotFoundException::class);
+        $this->expectExceptionMessage('There is no event with this UID.');
 
         new TestingEventMailForm(
             $this->testingFramework->getAutoIncrement('tx_seminars_seminars')
@@ -112,7 +110,7 @@ class AbstractEventMailFormTest extends TestCase
      */
     public function formActionContainsCurrentPage()
     {
-        \Tx_Oelib_PageFinder::getInstance()->setPageUid(42);
+        PageFinder::getInstance()->setPageUid(42);
 
         self::assertContains(
             '&amp;id=42',

--- a/Tests/LegacyUnit/BackEnd/CancelEventMailFormTest.php
+++ b/Tests/LegacyUnit/BackEnd/CancelEventMailFormTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace OliverKlee\Seminars\Tests\LegacyUnit\BackEnd;
 
+use OliverKlee\Oelib\Configuration\PageFinder;
 use OliverKlee\Oelib\Mapper\MapperRegistry;
 use OliverKlee\Oelib\Testing\TestingFramework;
 use OliverKlee\PhpUnit\TestCase;
@@ -38,7 +39,7 @@ class CancelEventMailFormTest extends TestCase
         MapperRegistry::getInstance()->activateTestingMode($this->testingFramework);
 
         $dummySysFolderUid = $this->testingFramework->createSystemFolder();
-        \Tx_Oelib_PageFinder::getInstance()->setPageUid($dummySysFolderUid);
+        PageFinder::getInstance()->setPageUid($dummySysFolderUid);
 
         $organizerUid = $this->testingFramework->createRecord(
             'tx_seminars_organizers',

--- a/Tests/LegacyUnit/BackEnd/ConfirmEventMailFormTest.php
+++ b/Tests/LegacyUnit/BackEnd/ConfirmEventMailFormTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace OliverKlee\Seminars\Tests\LegacyUnit\BackEnd;
 
+use OliverKlee\Oelib\Configuration\PageFinder;
 use OliverKlee\Oelib\Mapper\MapperRegistry;
 use OliverKlee\Oelib\Testing\TestingFramework;
 use OliverKlee\PhpUnit\TestCase;
@@ -38,7 +39,7 @@ class ConfirmEventMailFormTest extends TestCase
         MapperRegistry::getInstance()->activateTestingMode($this->testingFramework);
 
         $dummySysFolderUid = $this->testingFramework->createSystemFolder();
-        \Tx_Oelib_PageFinder::getInstance()->setPageUid($dummySysFolderUid);
+        PageFinder::getInstance()->setPageUid($dummySysFolderUid);
 
         $organizerUid = $this->testingFramework->createRecord(
             'tx_seminars_organizers',

--- a/Tests/LegacyUnit/BackEnd/GeneralEventMailFormTest.php
+++ b/Tests/LegacyUnit/BackEnd/GeneralEventMailFormTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace OliverKlee\Seminars\Tests\LegacyUnit\BackEnd;
 
+use OliverKlee\Oelib\Configuration\PageFinder;
 use OliverKlee\Oelib\Testing\TestingFramework;
 use OliverKlee\PhpUnit\TestCase;
 use OliverKlee\Seminars\BackEnd\GeneralEventMailForm;
@@ -35,7 +36,7 @@ class GeneralEventMailFormTest extends TestCase
         $this->testingFramework = new TestingFramework('tx_seminars');
 
         $dummySysFolderUid = $this->testingFramework->createSystemFolder();
-        \Tx_Oelib_PageFinder::getInstance()->setPageUid($dummySysFolderUid);
+        PageFinder::getInstance()->setPageUid($dummySysFolderUid);
 
         $organizerUid = $this->testingFramework->createRecord(
             'tx_seminars_organizers',

--- a/Tests/LegacyUnit/FrontEnd/CountdownTest.php
+++ b/Tests/LegacyUnit/FrontEnd/CountdownTest.php
@@ -7,6 +7,7 @@ namespace OliverKlee\Seminars\Tests\LegacyUnit\FrontEnd;
 use OliverKlee\Oelib\Configuration\Configuration;
 use OliverKlee\Oelib\Configuration\ConfigurationProxy;
 use OliverKlee\Oelib\Configuration\ConfigurationRegistry;
+use OliverKlee\Oelib\Exception\NotFoundException;
 use OliverKlee\Oelib\Testing\TestingFramework;
 use OliverKlee\PhpUnit\TestCase;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -107,7 +108,7 @@ class CountdownTest extends TestCase
         $this->subject->injectEventMapper($this->mapper);
         $this->mapper->expects(self::once())
             ->method('findNextUpcoming')
-            ->will(self::throwException(new \Tx_Oelib_Exception_NotFound()));
+            ->will(self::throwException(new NotFoundException()));
 
         self::assertContains(
             'There are no upcoming events. Please come back later.',

--- a/Tests/LegacyUnit/FrontEnd/DefaultControllerTest.php
+++ b/Tests/LegacyUnit/FrontEnd/DefaultControllerTest.php
@@ -8,6 +8,8 @@ use OliverKlee\Oelib\Configuration\Configuration;
 use OliverKlee\Oelib\Configuration\ConfigurationProxy;
 use OliverKlee\Oelib\Configuration\ConfigurationRegistry;
 use OliverKlee\Oelib\DataStructures\Collection;
+use OliverKlee\Oelib\Http\HeaderCollector;
+use OliverKlee\Oelib\Http\HeaderProxyFactory;
 use OliverKlee\Oelib\Interfaces\Time;
 use OliverKlee\Oelib\Mapper\MapperRegistry;
 use OliverKlee\Oelib\Templating\TemplateHelper;
@@ -82,7 +84,7 @@ class DefaultControllerTest extends TestCase
     private $extConfBackup = [];
 
     /**
-     * @var \Tx_Oelib_HeaderCollector
+     * @var HeaderCollector
      */
     private $headerCollector = null;
 
@@ -97,8 +99,8 @@ class DefaultControllerTest extends TestCase
 
         $this->testingFramework = new TestingFramework('tx_seminars');
         $this->testingFramework->createFakeFrontEnd();
-        \Tx_Oelib_HeaderProxyFactory::getInstance()->enableTestMode();
-        $this->headerCollector = \Tx_Oelib_HeaderProxyFactory::getInstance()->getHeaderProxy();
+        HeaderProxyFactory::getInstance()->enableTestMode();
+        $this->headerCollector = HeaderProxyFactory::getInstance()->getHeaderProxy();
 
         $configuration = new Configuration();
         $configuration->setAsString('currency', 'EUR');

--- a/Tests/LegacyUnit/FrontEnd/RegistrationFormTest.php
+++ b/Tests/LegacyUnit/FrontEnd/RegistrationFormTest.php
@@ -6,6 +6,8 @@ namespace OliverKlee\Seminars\Tests\LegacyUnit\FrontEnd;
 
 use OliverKlee\Oelib\Configuration\Configuration;
 use OliverKlee\Oelib\Configuration\ConfigurationRegistry;
+use OliverKlee\Oelib\Session\FakeSession;
+use OliverKlee\Oelib\Session\Session;
 use OliverKlee\Oelib\Testing\TestingFramework;
 use OliverKlee\PhpUnit\TestCase;
 use OliverKlee\Seminars\Tests\Unit\Traits\LanguageHelper;
@@ -35,7 +37,7 @@ class RegistrationFormTest extends TestCase
     private $testingFramework = null;
 
     /**
-     * @var \Tx_Oelib_FakeSession
+     * @var FakeSession
      */
     private $session = null;
 
@@ -55,8 +57,8 @@ class RegistrationFormTest extends TestCase
         $frontEndPageUid = $this->testingFramework->createFrontEndPage();
         $this->testingFramework->createFakeFrontEnd($frontEndPageUid);
 
-        $this->session = new \Tx_Oelib_FakeSession();
-        \Tx_Oelib_Session::setInstance(\Tx_Oelib_Session::TYPE_USER, $this->session);
+        $this->session = new FakeSession();
+        Session::setInstance(Session::TYPE_USER, $this->session);
 
         $configurationRegistry = ConfigurationRegistry::getInstance();
         $configuration = new Configuration();

--- a/Tests/LegacyUnit/FrontEnd/RegistrationsListTest.php
+++ b/Tests/LegacyUnit/FrontEnd/RegistrationsListTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace OliverKlee\Seminars\Tests\LegacyUnit\FrontEnd;
 
 use OliverKlee\Oelib\Configuration\ConfigurationProxy;
+use OliverKlee\Oelib\Http\HeaderProxyFactory;
 use OliverKlee\Oelib\Testing\TestingFramework;
 use OliverKlee\PhpUnit\TestCase;
 use OliverKlee\Seminars\Tests\Unit\Traits\LanguageHelper;
@@ -50,7 +51,7 @@ class RegistrationsListTest extends TestCase
         $GLOBALS['SIM_EXEC_TIME'] = 1524751343;
 
         ConfigurationProxy::getInstance('seminars')->setAsBoolean('enableConfigCheck', false);
-        \Tx_Oelib_HeaderProxyFactory::getInstance()->enableTestMode();
+        HeaderProxyFactory::getInstance()->enableTestMode();
 
         $this->testingFramework = new TestingFramework('tx_seminars');
         $this->testingFramework->createFakeFrontEnd();
@@ -229,7 +230,7 @@ class RegistrationsListTest extends TestCase
 
         self::assertEquals(
             'Status: 404 Not Found',
-            \Tx_Oelib_HeaderProxyFactory::getInstance()->getHeaderProxy()->getLastAddedHeader()
+            HeaderProxyFactory::getInstance()->getHeaderProxy()->getLastAddedHeader()
         );
     }
 
@@ -248,7 +249,7 @@ class RegistrationsListTest extends TestCase
 
         self::assertEquals(
             'Status: 404 Not Found',
-            \Tx_Oelib_HeaderProxyFactory::getInstance()->getHeaderProxy()->getLastAddedHeader()
+            HeaderProxyFactory::getInstance()->getHeaderProxy()->getLastAddedHeader()
         );
     }
 
@@ -261,7 +262,7 @@ class RegistrationsListTest extends TestCase
 
         self::assertEquals(
             'Status: 403 Forbidden',
-            \Tx_Oelib_HeaderProxyFactory::getInstance()->getHeaderProxy()->getLastAddedHeader()
+            HeaderProxyFactory::getInstance()->getHeaderProxy()->getLastAddedHeader()
         );
     }
 
@@ -275,7 +276,7 @@ class RegistrationsListTest extends TestCase
 
         self::assertEquals(
             'Status: 403 Forbidden',
-            \Tx_Oelib_HeaderProxyFactory::getInstance()->getHeaderProxy()->getLastAddedHeader()
+            HeaderProxyFactory::getInstance()->getHeaderProxy()->getLastAddedHeader()
         );
     }
 
@@ -289,7 +290,7 @@ class RegistrationsListTest extends TestCase
 
         self::assertNotContains(
             '403',
-            \Tx_Oelib_HeaderProxyFactory::getInstance()->getHeaderProxy()->getLastAddedHeader()
+            HeaderProxyFactory::getInstance()->getHeaderProxy()->getLastAddedHeader()
         );
     }
 

--- a/Tests/LegacyUnit/Mapper/EventMapperTest.php
+++ b/Tests/LegacyUnit/Mapper/EventMapperTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace OliverKlee\Seminars\Tests\LegacyUnit\Mapper;
 
 use OliverKlee\Oelib\DataStructures\Collection;
+use OliverKlee\Oelib\Exception\NotFoundException;
 use OliverKlee\Oelib\Mapper\FrontEndUserMapper;
 use OliverKlee\Oelib\Mapper\MapperRegistry;
 use OliverKlee\Oelib\Model\FrontEndUser;
@@ -1004,7 +1005,7 @@ class EventMapperTest extends TestCase
      */
     public function findNextUpcomingWithNoEventsThrowsEmptyQueryResultException()
     {
-        $this->expectException(\Tx_Oelib_Exception_NotFound::class);
+        $this->expectException(NotFoundException::class);
 
         $this->subject->findNextUpcoming();
     }
@@ -1014,7 +1015,7 @@ class EventMapperTest extends TestCase
      */
     public function findNextUpcomingWithPastEventThrowsEmptyQueryResultException()
     {
-        $this->expectException(\Tx_Oelib_Exception_NotFound::class);
+        $this->expectException(NotFoundException::class);
 
         $this->testingFramework->createRecord(
             'tx_seminars_seminars',

--- a/Tests/LegacyUnit/Service/RegistrationManagerTest.php
+++ b/Tests/LegacyUnit/Service/RegistrationManagerTest.php
@@ -9,6 +9,8 @@ use OliverKlee\Oelib\Configuration\Configuration;
 use OliverKlee\Oelib\Configuration\ConfigurationProxy;
 use OliverKlee\Oelib\Configuration\ConfigurationRegistry;
 use OliverKlee\Oelib\DataStructures\Collection;
+use OliverKlee\Oelib\Http\HeaderCollector;
+use OliverKlee\Oelib\Http\HeaderProxyFactory;
 use OliverKlee\Oelib\Interfaces\Time;
 use OliverKlee\Oelib\Mapper\CountryMapper;
 use OliverKlee\Oelib\Mapper\MapperRegistry;
@@ -103,7 +105,7 @@ final class RegistrationManagerTest extends TestCase
     private $mailer = null;
 
     /**
-     * @var \Tx_Oelib_HeaderCollector
+     * @var HeaderCollector
      */
     private $headerCollector = null;
 
@@ -168,7 +170,7 @@ final class RegistrationManagerTest extends TestCase
             'EXT:seminars/Resources/Private/Templates/Mail/e-mail.html'
         );
 
-        $headerProxyFactory = \Tx_Oelib_HeaderProxyFactory::getInstance();
+        $headerProxyFactory = HeaderProxyFactory::getInstance();
         $headerProxyFactory->enableTestMode();
         $this->headerCollector = $headerProxyFactory->getHeaderProxy();
 

--- a/Tests/LegacyUnit/Support/Traits/BackEndTestsTrait.php
+++ b/Tests/LegacyUnit/Support/Traits/BackEndTestsTrait.php
@@ -7,6 +7,8 @@ namespace OliverKlee\Seminars\Tests\LegacyUnit\Support\Traits;
 use OliverKlee\Oelib\Configuration\Configuration;
 use OliverKlee\Oelib\Configuration\ConfigurationProxy;
 use OliverKlee\Oelib\Configuration\ConfigurationRegistry;
+use OliverKlee\Oelib\Http\HeaderCollector;
+use OliverKlee\Oelib\Http\HeaderProxyFactory;
 use PHPUnit\Framework\MockObject\MockObject;
 use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 use TYPO3\CMS\Core\Core\Bootstrap;
@@ -62,7 +64,7 @@ trait BackEndTestsTrait
     private $configuration = null;
 
     /**
-     * @var \Tx_Oelib_HeaderCollector
+     * @var HeaderCollector
      */
     private $headerProxy = null;
 
@@ -85,7 +87,7 @@ trait BackEndTestsTrait
         $this->unifyExtensionSettings();
         ConfigurationProxy::getInstance('seminars')->setAsBoolean('enableConfigCheck', false);
         $this->setUpExtensionConfiguration();
-        $headerProxyFactory = \Tx_Oelib_HeaderProxyFactory::getInstance();
+        $headerProxyFactory = HeaderProxyFactory::getInstance();
         $headerProxyFactory->enableTestMode();
         $this->headerProxy = $headerProxyFactory->getHeaderProxy();
     }

--- a/Tests/LegacyUnit/ViewHelpers/TimeRangeViewHelperTest.php
+++ b/Tests/LegacyUnit/ViewHelpers/TimeRangeViewHelperTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace OliverKlee\Seminars\Tests\LegacyUnit\ViewHelpers;
 
+use OliverKlee\Oelib\Configuration\Configuration;
 use OliverKlee\Oelib\Configuration\ConfigurationRegistry;
 use OliverKlee\Oelib\Interfaces\Time;
 use OliverKlee\Oelib\Testing\TestingFramework;
@@ -54,7 +55,7 @@ class TimeRangeViewHelperTest extends TestCase
         $this->testingFramework = new TestingFramework('tx_seminars');
         $this->testingFramework->createFakeFrontEnd($this->testingFramework->createFrontEndPage());
 
-        $configuration = new \Tx_Oelib_Configuration();
+        $configuration = new Configuration();
         $configuration->setAsString('timeFormat', self::TIME_FORMAT);
         ConfigurationRegistry::getInstance()->set('plugin.tx_seminars', $configuration);
 

--- a/Tests/Unit/FrontEnd/RegistrationFormTest.php
+++ b/Tests/Unit/FrontEnd/RegistrationFormTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace OliverKlee\Seminars\Tests\Unit\FrontEnd;
 
 use Nimut\TestingFramework\TestCase\UnitTestCase;
+use OliverKlee\Oelib\Session\FakeSession;
+use OliverKlee\Oelib\Session\Session;
 use Prophecy\Prophecy\ObjectProphecy;
 use Prophecy\Prophecy\ProphecySubjectInterface;
 use TYPO3\CMS\Frontend\Authentication\FrontendUserAuthentication;
@@ -37,7 +39,7 @@ final class RegistrationFormTest extends UnitTestCase
     ];
 
     /**
-     * @var \Tx_Oelib_FakeSession
+     * @var FakeSession
      */
     private $session = null;
 
@@ -83,8 +85,8 @@ final class RegistrationFormTest extends UnitTestCase
         $user = $this->userProphecy->reveal();
         $frontEnd->fe_user = $user;
 
-        $this->session = new \Tx_Oelib_FakeSession();
-        \Tx_Oelib_Session::setInstance(\Tx_Oelib_Session::TYPE_USER, $this->session);
+        $this->session = new FakeSession();
+        Session::setInstance(Session::TYPE_USER, $this->session);
 
         $this->eventProphecy = $this->prophesize(\Tx_Seminars_OldModel_Event::class);
         $this->event = $this->eventProphecy->reveal();
@@ -92,7 +94,7 @@ final class RegistrationFormTest extends UnitTestCase
 
     protected function tearDown()
     {
-        \Tx_Oelib_Session::purgeInstances();
+        Session::purgeInstances();
         parent::tearDown();
     }
 


### PR DESCRIPTION
- `ConfigurationCheck`
- `NotFoundException`
- `PageFinder`
- `ConfigurationCheckable`
- `Session`
- `Visibility\Tree`
- `HeaderProxy`
- `Translator`

Part of #581