### PR TITLE
[CLEANUP] Switch emailing in the AbstractEventMailForm from oelib mail functions to the Core SwiftMailer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Added
 
 ### Changed
+- Use the Core email functions (#674)
 - Package and use Emogrifier for inlining CSS into HTML emails (#863)
 - Update `simshaun/recurr` to version 5.0.0 (#862)
 - !!! Rename the TypoScript files to `*.typoscript` (#861)

--- a/Classes/BackEnd/CancelEventMailForm.php
+++ b/Classes/BackEnd/CancelEventMailForm.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace OliverKlee\Seminars\BackEnd;
 
-use OliverKlee\Oelib\Email\Mail;
 use OliverKlee\Seminars\Service\EventStatusService;
+use TYPO3\CMS\Core\Mail\MailMessage;
 use TYPO3\CMS\Core\Messaging\FlashMessage;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
@@ -67,12 +67,10 @@ class CancelEventMailForm extends AbstractEventMailForm
      *
      * @param \Tx_Seminars_Model_Registration $registration
      *        the registration to which the e-mail refers
-     * @param Mail $eMail
-     *        the e-mail to be sent
      *
      * @return void
      */
-    protected function modifyEmailWithHook(\Tx_Seminars_Model_Registration $registration, Mail $eMail)
+    protected function modifyEmailWithHook(\Tx_Seminars_Model_Registration $registration, MailMessage $eMail)
     {
         foreach ($this->getHooks() as $hook) {
             $hook->modifyCancelEmail($registration, $eMail);

--- a/Classes/BackEnd/ConfirmEventMailForm.php
+++ b/Classes/BackEnd/ConfirmEventMailForm.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace OliverKlee\Seminars\BackEnd;
 
-use OliverKlee\Oelib\Email\Mail;
 use OliverKlee\Seminars\Service\EventStatusService;
+use TYPO3\CMS\Core\Mail\MailMessage;
 use TYPO3\CMS\Core\Messaging\FlashMessage;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
@@ -44,12 +44,10 @@ class ConfirmEventMailForm extends AbstractEventMailForm
      *
      * @param \Tx_Seminars_Model_Registration $registration
      *        the registration to which the e-mail refers
-     * @param Mail $eMail
-     *        the e-mail to be sent
      *
      * @return void
      */
-    protected function modifyEmailWithHook(\Tx_Seminars_Model_Registration $registration, Mail $eMail)
+    protected function modifyEmailWithHook(\Tx_Seminars_Model_Registration $registration, MailMessage $eMail)
     {
         foreach ($this->getHooks() as $hook) {
             $hook->modifyConfirmEmail($registration, $eMail);

--- a/Classes/BackEnd/GeneralEventMailForm.php
+++ b/Classes/BackEnd/GeneralEventMailForm.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace OliverKlee\Seminars\BackEnd;
 
-use OliverKlee\Oelib\Email\Mail;
+use TYPO3\CMS\Core\Mail\MailMessage;
 
 /**
  * This class represents an e-mail form that does not change the event's status.
@@ -42,12 +42,10 @@ class GeneralEventMailForm extends AbstractEventMailForm
      *
      * @param \Tx_Seminars_Model_Registration $registration
      *        the registration to which the e-mail refers
-     * @param Mail $eMail
-     *        the e-mail to be sent
      *
      * @return void
      */
-    protected function modifyEmailWithHook(\Tx_Seminars_Model_Registration $registration, Mail $eMail)
+    protected function modifyEmailWithHook(\Tx_Seminars_Model_Registration $registration, MailMessage $eMail)
     {
         foreach ($this->getHooks() as $hook) {
             $hook->modifyGeneralEmail($registration, $eMail);

--- a/Classes/Interfaces/Hook/BackEndModule.php
+++ b/Classes/Interfaces/Hook/BackEndModule.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-use OliverKlee\Oelib\Email\Mail;
+use TYPO3\CMS\Core\Mail\MailMessage;
 
 /**
  * This interface needs to be used for hooks concerning the back-end module.
@@ -19,24 +19,20 @@ interface Tx_Seminars_Interfaces_Hook_BackEndModule
      *
      * @param \Tx_Seminars_Model_Registration $registration
      *        the registration to which the e-mail refers
-     * @param Mail $eMail
-     *        the e-mail that will be sent
      *
      * @return void
      */
-    public function modifyGeneralEmail(\Tx_Seminars_Model_Registration $registration, Mail $eMail);
+    public function modifyGeneralEmail(\Tx_Seminars_Model_Registration $registration, MailMessage $eMail);
 
     /**
      * Modifies the confirmation e-mail sent via the back-end module.
      *
      * @param \Tx_Seminars_Model_Registration $registration
      *        the registration to which the e-mail refers
-     * @param Mail $eMail
-     *        the e-mail that will be sent
      *
      * @return void
      */
-    public function modifyConfirmEmail(\Tx_Seminars_Model_Registration $registration, Mail $eMail);
+    public function modifyConfirmEmail(\Tx_Seminars_Model_Registration $registration, MailMessage $eMail);
 
     /**
      * Modifies the cancelation e-mail sent via the back-end module.
@@ -46,10 +42,8 @@ interface Tx_Seminars_Interfaces_Hook_BackEndModule
      *
      * @param \Tx_Seminars_Model_Registration $registration
      *        the registration to which the e-mail refers
-     * @param Mail $eMail
-     *        the e-mail that will be sent
      *
      * @return void
      */
-    public function modifyCancelEmail(\Tx_Seminars_Model_Registration $registration, Mail $eMail);
+    public function modifyCancelEmail(\Tx_Seminars_Model_Registration $registration, MailMessage $eMail);
 }

--- a/Classes/OldModel/Event.php
+++ b/Classes/OldModel/Event.php
@@ -2101,7 +2101,7 @@ class Tx_Seminars_OldModel_Event extends \Tx_Seminars_OldModel_AbstractTimeSpan
 
         /** @var \Tx_Seminars_OldModel_Organizer $organizer */
         foreach ($this->getOrganizerBag() as $organizer) {
-            $result[] = $organizer->getEMailAddress();
+            $result[] = $organizer->getEmailAddress();
         }
 
         return $result;

--- a/Documentation/EN/Reference/Hooks/Index.rst
+++ b/Documentation/EN/Reference/Hooks/Index.rst
@@ -394,8 +394,8 @@ See also :file:`Classes/Model/Registration.php` for available properties and met
 The plain text hook is always called, because a HTML email always contains a plain text version, too.
 The HTML hook is called only if emails are sent as HTML.
 
-With the other hooks you may modify the complete `Mail` object (e.g. sender or receiver addresses,
-subject line or the complete body). See also :file:`Classes/Mail.php` of extension `oelib` for
+With the other hooks you may modify the complete `MailMessage` object (e.g. sender or receiver addresses,
+subject line or the complete body). See also :file:`sysext/core/Classes/Mail/MailMessage.php` for
 available properties and methods.
 
 Register your class that implements :php:`\OliverKlee\Seminars\Hooks\Interfaces\RegistrationEmail`
@@ -428,7 +428,7 @@ Implement the methods required by the interface:
          * @return void
          */
         public function modifyAttendeeEmail(
-            Mail $email,
+            MailMessage $email,
             \Tx_Seminars_Model_Registration $registration,
             string $emailReason
         ) {
@@ -498,7 +498,7 @@ Implement the methods required by the interface:
          * @return void
          */
         public function modifyOrganizerEmail(
-            Mail $email,
+            MailMessage $email,
             \Tx_Seminars_Model_Registration $registration,
             string $emailReason
         ) {
@@ -518,7 +518,7 @@ Implement the methods required by the interface:
          * @return void
          */
         public function modifyAdditionalEmail(
-            Mail $email,
+            MailMessage $email,
             \Tx_Seminars_Model_Registration $registration,
             string $emailReason
         ) {
@@ -660,22 +660,20 @@ It's used like this:
         *
         * @param \Tx_Seminars_Model_Registration $registration
         *        the registration to which the e-mail refers
-        * @param Mail $eMail the e-mail that will be sent
         *
         * @return void
         */
-         public function modifyGeneralEmail(\Tx_Seminars_Model_Registration $registration, Mail $eMail) {…}
+         public function modifyGeneralEmail(\Tx_Seminars_Model_Registration $registration, MailMessage $eMail) {…}
 
          /**
         * Modifies the confirmation e-mail sent via the back-end module.
         *
         * @param Tx_Seminars_Model_Registration $registration
         *        the registration to which the e-mail refers
-        * @param Mail $eMail the e-mail that will be sent
         *
         * @return void
         */
-         public function modifyConfirmEmail(\Tx_Seminars_Model_Registration $registration, Mail $eMail) {…}
+         public function modifyConfirmEmail(\Tx_Seminars_Model_Registration $registration, MailMessage $eMail) {…}
 
          /**
         * Modifies the cancelation e-mail sent via the back-end module.
@@ -685,11 +683,10 @@ It's used like this:
         *
         * @param \Tx_Seminars_Model_Registration $registration
         *        the registration to which the e-mail refers
-        * @param Mail $eMail the e-mail that will be sent
         *
         * @return void
         */
-          public function modifyCancelEmail(\Tx_Seminars_Model_Registration $registration, Mail $eMail) {…}
+          public function modifyCancelEmail(\Tx_Seminars_Model_Registration $registration, MailMessage $eMail) {…}
 
 .. _backendregistrationlistview_en:
 

--- a/Tests/Functional/BackEnd/CancelEventMailFormTest.php
+++ b/Tests/Functional/BackEnd/CancelEventMailFormTest.php
@@ -6,11 +6,13 @@ namespace OliverKlee\Seminars\Tests\Functional\BackEnd;
 
 use Doctrine\DBAL\Driver\Statement;
 use Nimut\TestingFramework\TestCase\FunctionalTestCase;
-use OliverKlee\Oelib\Email\EmailCollector;
-use OliverKlee\Oelib\Email\MailerFactory;
 use OliverKlee\Seminars\BackEnd\CancelEventMailForm;
 use OliverKlee\Seminars\Tests\Functional\BackEnd\Fixtures\TestingHookImplementor;
+use OliverKlee\Seminars\Tests\Unit\Traits\EmailTrait;
 use OliverKlee\Seminars\Tests\Unit\Traits\LanguageHelper;
+use OliverKlee\Seminars\Tests\Unit\Traits\MakeInstanceTrait;
+use PHPUnit\Framework\MockObject\MockObject;
+use TYPO3\CMS\Core\Mail\MailMessage;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
@@ -22,15 +24,19 @@ final class CancelEventMailFormTest extends FunctionalTestCase
 {
     use LanguageHelper;
 
+    use EmailTrait;
+
+    use MakeInstanceTrait;
+
     /**
      * @var string[]
      */
     protected $testExtensionsToLoad = ['typo3conf/ext/oelib', 'typo3conf/ext/seminars'];
 
     /**
-     * @var EmailCollector
+     * @var MockObject|MailMessage|null
      */
-    private $mailer = null;
+    private $email = null;
 
     protected function setUp()
     {
@@ -40,12 +46,7 @@ final class CancelEventMailFormTest extends FunctionalTestCase
         $this->setUpBackendUserFromFixture(1);
         $this->initializeBackEndLanguage();
 
-        /** @var MailerFactory $mailerFactory */
-        $mailerFactory = GeneralUtility::makeInstance(MailerFactory::class);
-        $mailerFactory->enableTestMode();
-        /** @var EmailCollector $mailer */
-        $mailer = $mailerFactory->getMailer();
-        $this->mailer = $mailer;
+        $this->email = $this->createEmailMock();
     }
 
     protected function tearDown()
@@ -101,6 +102,10 @@ final class CancelEventMailFormTest extends FunctionalTestCase
                 'messageBody' => 'some message body',
             ]
         );
+
+        $this->email->expects(self::once())->method('send');
+        $this->addMockedInstance(MailMessage::class, $this->email);
+
         $subject->render();
 
         self::assertSame(1, $hook->getCountCallForCancelEmail());
@@ -127,6 +132,11 @@ final class CancelEventMailFormTest extends FunctionalTestCase
                 'messageBody' => 'some message body',
             ]
         );
+
+        $this->email->expects(self::exactly(2))->method('send');
+        $this->addMockedInstance(MailMessage::class, $this->email);
+        $this->addMockedInstance(MailMessage::class, $this->email);
+
         $subject->render();
 
         self::assertSame(2, $hook->getCountCallForCancelEmail());
@@ -150,8 +160,12 @@ final class CancelEventMailFormTest extends FunctionalTestCase
                 'messageBody' => $messageBody,
             ]
         );
+
+        $this->email->expects(self::once())->method('send');
+        $this->addMockedInstance(MailMessage::class, $this->email);
+
         $subject->render();
 
-        self::assertStringContainsString('Joe Johnson', $this->mailer->getFirstSentEmail()->getBody());
+        self::assertStringContainsString('Joe Johnson', $this->email->getBody());
     }
 }

--- a/Tests/Functional/BackEnd/Fixtures/TestingHookImplementor.php
+++ b/Tests/Functional/BackEnd/Fixtures/TestingHookImplementor.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace OliverKlee\Seminars\Tests\Functional\BackEnd\Fixtures;
 
-use OliverKlee\Oelib\Email\Mail;
+use TYPO3\CMS\Core\Mail\MailMessage;
 use TYPO3\CMS\Core\SingletonInterface;
 
 /**
@@ -29,17 +29,17 @@ final class TestingHookImplementor implements \Tx_Seminars_Interfaces_Hook_BackE
      */
     private $countCallForCancelEmail = 0;
 
-    public function modifyGeneralEmail(\Tx_Seminars_Model_Registration $registration, Mail $eMail)
+    public function modifyGeneralEmail(\Tx_Seminars_Model_Registration $registration, MailMessage $eMail)
     {
         $this->countCallForGeneralEmail++;
     }
 
-    public function modifyConfirmEmail(\Tx_Seminars_Model_Registration $registration, Mail $eMail)
+    public function modifyConfirmEmail(\Tx_Seminars_Model_Registration $registration, MailMessage $eMail)
     {
         $this->countCallForConfirmEmail++;
     }
 
-    public function modifyCancelEmail(\Tx_Seminars_Model_Registration $registration, Mail $eMail)
+    public function modifyCancelEmail(\Tx_Seminars_Model_Registration $registration, MailMessage $eMail)
     {
         $this->countCallForCancelEmail++;
     }

--- a/Tests/LegacyUnit/BackEnd/AbstractEventMailFormTest.php
+++ b/Tests/LegacyUnit/BackEnd/AbstractEventMailFormTest.php
@@ -5,13 +5,11 @@ declare(strict_types=1);
 namespace OliverKlee\Seminars\Tests\LegacyUnit\BackEnd;
 
 use OliverKlee\Oelib\Configuration\PageFinder;
-use OliverKlee\Oelib\Email\MailerFactory;
 use OliverKlee\Oelib\Exception\NotFoundException;
 use OliverKlee\Oelib\Testing\TestingFramework;
 use OliverKlee\PhpUnit\TestCase;
 use OliverKlee\Seminars\Tests\Functional\BackEnd\Fixtures\TestingEventMailForm;
 use OliverKlee\Seminars\Tests\LegacyUnit\Support\Traits\BackEndTestsTrait;
-use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
  * Test case.
@@ -44,10 +42,6 @@ class AbstractEventMailFormTest extends TestCase
         $this->unifyTestingEnvironment();
 
         $this->testingFramework = new TestingFramework('tx_seminars');
-
-        /** @var MailerFactory $mailerFactory */
-        $mailerFactory = GeneralUtility::makeInstance(MailerFactory::class);
-        $mailerFactory->enableTestMode();
 
         PageFinder::getInstance()->setPageUid($this->testingFramework->createSystemFolder());
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -16,6 +16,16 @@ parameters:
 			path: Classes/Service/RegistrationManager.php
 
 		-
+			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertArrayHasKey\\(\\) with 'oliver@example\\.com' and string will always evaluate to false\\.$#"
+			count: 1
+			path: Tests/Functional/BackEnd/AbstractEventMailFormTest.php
+
+		-
+			message: "#^Parameter \\#2 \\$array of static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertArrayHasKey\\(\\) expects array\\|ArrayAccess, string given\\.$#"
+			count: 1
+			path: Tests/Functional/BackEnd/AbstractEventMailFormTest.php
+
+		-
 			message: "#^Parameter \\#1 \\$formData of method Tx_Seminars_FrontEnd_EventEditor\\:\\:validateCheckboxes\\(\\) expects array\\<array\\>, array\\<string, array\\<int, int\\>\\|string\\> given\\.$#"
 			count: 1
 			path: Tests/Functional/FrontEnd/EventEditorTest.php


### PR DESCRIPTION


Closes #673