### PR TITLE
[TASK] Set fail-fast: false in the CI configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ jobs:
       - name: "Run PHP lint"
         run: "composer ci:php:lint"
     strategy:
+      fail-fast: false
       matrix:
         php-version:
           - 7.0
@@ -57,6 +58,7 @@ jobs:
       - name: "Run command"
         run: "composer ci:${{ matrix.command }}"
     strategy:
+      fail-fast: false
       matrix:
         command:
           - "php:sniff"
@@ -99,6 +101,7 @@ jobs:
       - name: "Run unit tests"
         run: "composer ci:tests:unit"
     strategy:
+      fail-fast: false
       matrix:
         include:
           - typo3-version: ^8.7
@@ -155,6 +158,7 @@ jobs:
           export typo3DatabasePassword="root";
           composer ci:tests:functional
     strategy:
+      fail-fast: false
       matrix:
         include:
           - typo3-version: ^8.7
@@ -220,6 +224,7 @@ jobs:
       - name: "Run legacy tests"
         run: "composer ci:tests:unit-legacy"
     strategy:
+      fail-fast: false
       matrix:
         include:
           - typo3-version: ^8.7


### PR DESCRIPTION
This allows us to receive feedback for which specific PHP
or TYPO3 versions we have broken something with a change.

Fixes #684