### PR TITLE
[CLEANUP] Drop reference to a removed feature from the manual

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Drop the `approved` flag from locallang labels (#745)
 
 ### Fixed
+- Drop reference to a removed feature from the manual (#755)
 - Fix ReST rendering warnings in the documentation (#750)
 - Fix saving of new speakers with MySQL in strict mode (#749)
 

--- a/Documentation/DE/Installation/DieErweiterungInstallieren/Index.rst
+++ b/Documentation/DE/Installation/DieErweiterungInstallieren/Index.rst
@@ -62,13 +62,6 @@ speichern Sie diese Einstellungen einmal (auch wenn Sie sie nicht
   aktivieren und überprüfen, ob Warnungen auf Seiten erscheinen, auf
   denen das Plugin verwendet wird.
 
-- Aktivieren Sie “Use the page browser” ausschließlich, wenn Sie von
-  einer älteren Version geupgradet haben und Sie die Veranstalter,
-  Redner, Veranstaltungsorte, etc in mehr als einem Ordner verteilt
-  haben und diese nicht verschieben können. Es ist kein allerdings auch
-  kein Problem, die Registrierungen oder Veranstaltungen in
-  unterschiedlichen Ordnern zu haben.
-
 - Deaktivieren Sie“Select topic records from all pages” ausschließlich
   in einem der folgenden Fälle:
 

--- a/Documentation/EN/Installation/InstallingTheExtension/Index.rst
+++ b/Documentation/EN/Installation/InstallingTheExtension/Index.rst
@@ -55,12 +55,6 @@ The default values are good for starters.
   extension, you should enable it again and check whether there are any
   warnings on the FE pages with the plug-in on it.
 
-- Enable “Use the page browser” only if you have upgraded from an older
-  version and you have distributed your organizer, speaker, location
-  etc. records to more than one folder and you cannot move them. It is
-  no problem to have registrations or events in different folders,
-  though.
-
 - Disable “Select topic records from all pages” only in one of the
   following two cases:
 


### PR DESCRIPTION
The "Use the page browser" extension setting has been removed some
time ago.

Fixes #752