### PR TITLE
[FOLLOWUP] De-deprecate the time slot wizard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ## x.y.z
 
 ### Added
-- Add a BE forms wizard for creating a series of time slots (#820)
+- Add a BE forms wizard for creating a series of time slots (#820, #832)
 - Add PHPStan to the CI builds (#763)
 - Allow installations up to PHP 8.0 (#758)
 

--- a/Classes/BackEnd/TimeSlotWizard.php
+++ b/Classes/BackEnd/TimeSlotWizard.php
@@ -13,8 +13,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
  * Form engine wizard that renders a wizard for creating a series of time slots.
- *
- * @deprecated will be removed in seminars 4.0
  */
 class TimeSlotWizard extends AbstractFormElement
 {

--- a/Classes/Hooks/DataHandlerHook.php
+++ b/Classes/Hooks/DataHandlerHook.php
@@ -46,15 +46,11 @@ class DataHandlerHook
 
     /**
      * @var string
-     *
-     * @deprecated will be removed in seminars 4.0
      */
     const DATE_RENDER_FORMAT = 'Y-m-d\\TH:i:s\\Z';
 
     /**
      * @var string
-     *
-     * @deprecated will be removed in seminars 4.0
      */
     const DATE_PARSE_FORMAT = 'Y-m-d?H:i:s?';
 
@@ -67,8 +63,6 @@ class DataHandlerHook
      * Creates the time slots requested by the time slot wizard (if any are requested).
      *
      * @return void
-     *
-     * @deprecated will be removed in seminars 4.0
      */
     public function processDatamap_beforeStart(DataHandler $dataHandler)
     {
@@ -276,9 +270,6 @@ class DataHandlerHook
         }
     }
 
-    /**
-     * @deprecated will be removed in seminars 4.0
-     */
     private function isValidTimeSlotConfiguration(array $configuration): bool
     {
         $requiredFields = ['first_start', 'first_end', 'all', 'frequency', 'until'];
@@ -308,8 +299,6 @@ class DataHandlerHook
      * @param string|int $eventUid
      *
      * @return void
-     *
-     * @deprecated will be removed in seminars 4.0
      */
     private function createTimeSlots(array &$event, $eventUid, array $configuration, array &$allTimeSlots)
     {

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -97,7 +97,6 @@ $boot = static function () {
     );
 
     // register the time slot wizard
-    // @deprecated will be removed in seminars 4.0
     $GLOBALS['TYPO3_CONF_VARS']['SYS']['formEngine']['nodeRegistry'][1558632705] = [
         'nodeName' => 'time_slot_wizard',
         'priority' => 70,


### PR DESCRIPTION
As this feature works in 9.5 after all, we can keep it for now.