### PR TITLE
[BUGFIX] Require `ext-pdo` in the `composer.json`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Drop the `approved` flag from locallang labels (#745)
 
 ### Fixed
+- Require `ext-pdo` in the `composer.json` (#837)
 - Fix the parameter type in the typolink creation calls (#811)
 - Improve the type annotations
   (#790, #791, #792, #793, #796, #797, #798, #799, #800, #801, #805, #807, #809, #812, #813, #814)

--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,7 @@
 	"require": {
 		"php": "^7.0.0 || ~8.0.0",
 		"ext-json": "*",
+		"ext-pdo": "*",
 		"digedag/rn-base": "^1.11.4",
 		"dmk/mkforms": "^9.5.2",
 		"oliverklee/oelib": "^3.6.0",


### PR DESCRIPTION
We are using PDO classes.

Fixes #833