### PR TITLE
[TASK] Drop redirects to the list view configuration check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 - Migrate to the new configuration check
-  (#935, #937, #939, #940, #943, #944, #946, #948)
+  (#935, #937, #939, #940, #943, #944, #946, #948, #949)
 - Add sr_feuser_register as a dev dependency (#926)
 - Require static_info_tables >= 6.9.5 (#925)
 - Add more type declarations (#887)

--- a/Classes/ConfigCheck.php
+++ b/Classes/ConfigCheck.php
@@ -87,7 +87,6 @@ class Tx_Seminars_ConfigCheck extends ConfigurationCheck
      */
     protected function check_Tx_Seminars_FrontEnd_DefaultController_my_vip_events()
     {
-        $this->check_Tx_Seminars_FrontEnd_DefaultController_seminar_list();
         $this->checkRegistrationsVipListPid();
         $this->checkDefaultEventVipsFeGroupID();
         $this->checkMayManagersEditTheirEvents();
@@ -105,7 +104,6 @@ class Tx_Seminars_ConfigCheck extends ConfigurationCheck
      */
     protected function check_Tx_Seminars_FrontEnd_DefaultController_topic_list()
     {
-        $this->check_Tx_Seminars_FrontEnd_DefaultController_seminar_list();
     }
 
     /**
@@ -115,7 +113,6 @@ class Tx_Seminars_ConfigCheck extends ConfigurationCheck
      */
     protected function check_Tx_Seminars_FrontEnd_DefaultController_my_events()
     {
-        $this->check_Tx_Seminars_FrontEnd_DefaultController_seminar_list();
     }
 
     /**
@@ -149,7 +146,6 @@ class Tx_Seminars_ConfigCheck extends ConfigurationCheck
      */
     protected function check_Tx_Seminars_FrontEnd_DefaultController_my_entered_events()
     {
-        $this->check_Tx_Seminars_FrontEnd_DefaultController_seminar_list();
         $this->checkEventEditorFeGroupID();
         $this->checkEventEditorPID();
     }
@@ -176,7 +172,6 @@ class Tx_Seminars_ConfigCheck extends ConfigurationCheck
      */
     protected function check_Tx_Seminars_FrontEnd_DefaultController_favorites_list()
     {
-        $this->check_Tx_Seminars_FrontEnd_DefaultController_seminar_list();
     }
 
     /**


### PR DESCRIPTION
The default controller now calls the list view configuration check
directly.

Part of #928