### PR TITLE
[BUGFIX] Use the dummy configuration in the tests for extension config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Require static_info_tables >= 6.9.5 (#925)
 - Add more type declarations (#887)
 - Use the new configuration classes
-  (#725, #910, #913, #914, #915, #916, #917, #919, #922, #927, #928, #930)
+  (#725, #910, #913, #914, #915, #916, #917, #919, #922, #927, #928, #930, #966)
 - Require oelib >= 3.6.2 (#877)
 - Use the Core email functions (#674, #874)
 - Package and use Emogrifier for inlining CSS into HTML emails (#863)

--- a/Tests/LegacyUnit/BackEnd/AbstractModuleTest.php
+++ b/Tests/LegacyUnit/BackEnd/AbstractModuleTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace OliverKlee\Seminars\Tests\LegacyUnit\BackEnd;
 
-use OliverKlee\Oelib\Configuration\ConfigurationProxy;
 use OliverKlee\PhpUnit\TestCase;
 use OliverKlee\Seminars\Tests\LegacyUnit\BackEnd\Fixtures\DummyModule;
 
@@ -17,10 +16,6 @@ final class AbstractModuleTest extends TestCase
 
     protected function setUp()
     {
-        /** @var ConfigurationProxy $configuration */
-        $configuration = ConfigurationProxy::getInstance('seminars');
-        $configuration->setAsBoolean('enableConfigCheck', false);
-
         $this->subject = new DummyModule();
     }
 

--- a/Tests/LegacyUnit/FrontEnd/CategoryListTest.php
+++ b/Tests/LegacyUnit/FrontEnd/CategoryListTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace OliverKlee\Seminars\Tests\LegacyUnit\FrontEnd;
 
-use OliverKlee\Oelib\Configuration\ConfigurationProxy;
 use OliverKlee\Oelib\Testing\TestingFramework;
 use OliverKlee\PhpUnit\TestCase;
 use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
@@ -37,10 +36,6 @@ final class CategoryListTest extends TestCase
     protected function setUp()
     {
         $GLOBALS['SIM_EXEC_TIME'] = 1524751343;
-
-        /** @var ConfigurationProxy $configuration */
-        $configuration = ConfigurationProxy::getInstance('seminars');
-        $configuration->setAsBoolean('enableConfigCheck', false);
 
         $this->testingFramework = new TestingFramework('tx_seminars');
         $this->testingFramework->createFakeFrontEnd();

--- a/Tests/LegacyUnit/FrontEnd/CountdownTest.php
+++ b/Tests/LegacyUnit/FrontEnd/CountdownTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace OliverKlee\Seminars\Tests\LegacyUnit\FrontEnd;
 
-use OliverKlee\Oelib\Configuration\ConfigurationProxy;
 use OliverKlee\Oelib\Configuration\ConfigurationRegistry;
 use OliverKlee\Oelib\Configuration\DummyConfiguration;
 use OliverKlee\Oelib\Exception\NotFoundException;
@@ -39,10 +38,6 @@ final class CountdownTest extends TestCase
         $configurationRegistry->set('config', new DummyConfiguration());
         $configurationRegistry->set('page.config', new DummyConfiguration());
         $configurationRegistry->set('plugin.tx_seminars._LOCAL_LANG.default', new DummyConfiguration());
-
-        /** @var ConfigurationProxy $configuration */
-        $configuration = ConfigurationProxy::getInstance('seminars');
-        $configuration->setAsBoolean('enableConfigCheck', false);
 
         $this->testingFramework = new TestingFramework('tx_seminars');
         $this->testingFramework->createFakeFrontEnd();

--- a/Tests/LegacyUnit/FrontEnd/DefaultControllerTest.php
+++ b/Tests/LegacyUnit/FrontEnd/DefaultControllerTest.php
@@ -111,10 +111,6 @@ final class DefaultControllerTest extends TestCase
     {
         $GLOBALS['SIM_EXEC_TIME'] = 1524751343;
 
-        /** @var ConfigurationProxy $globalConfiguration */
-        $globalConfiguration = ConfigurationProxy::getInstance('seminars');
-        $globalConfiguration->setAsBoolean('enableConfigCheck', false);
-
         $this->extConfBackup = $GLOBALS['TYPO3_CONF_VARS']['EXTCONF'];
         $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['seminars'] = [];
 

--- a/Tests/LegacyUnit/FrontEnd/RegistrationsListTest.php
+++ b/Tests/LegacyUnit/FrontEnd/RegistrationsListTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace OliverKlee\Seminars\Tests\LegacyUnit\FrontEnd;
 
-use OliverKlee\Oelib\Configuration\ConfigurationProxy;
 use OliverKlee\Oelib\Http\HeaderProxyFactory;
 use OliverKlee\Oelib\Testing\TestingFramework;
 use OliverKlee\PhpUnit\TestCase;
@@ -49,9 +48,6 @@ final class RegistrationsListTest extends TestCase
     {
         $GLOBALS['SIM_EXEC_TIME'] = 1524751343;
 
-        /** @var ConfigurationProxy $configurationProxy */
-        $configurationProxy = ConfigurationProxy::getInstance('seminars');
-        $configurationProxy->setAsBoolean('enableConfigCheck', false);
         HeaderProxyFactory::getInstance()->enableTestMode();
 
         $this->testingFramework = new TestingFramework('tx_seminars');

--- a/Tests/LegacyUnit/Service/RegistrationManagerTest.php
+++ b/Tests/LegacyUnit/Service/RegistrationManagerTest.php
@@ -123,6 +123,11 @@ final class RegistrationManagerTest extends TestCase
      */
     private $configuration;
 
+    /**
+     * @var DummyConfiguration
+     */
+    private $extensionConfiguration;
+
     protected function setUp()
     {
         $GLOBALS['SIM_EXEC_TIME'] = 1524751343;
@@ -138,9 +143,10 @@ final class RegistrationManagerTest extends TestCase
         $this->addMockedInstance(MailMessage::class, $this->secondEmail);
 
         \Tx_Seminars_OldModel_Registration::purgeCachedSeminars();
-        /** @var ConfigurationProxy $configurationProxy */
-        $configurationProxy = ConfigurationProxy::getInstance('seminars');
-        $configurationProxy->setAsInteger('eMailFormatForAttendees', TestingRegistrationManager::SEND_TEXT_MAIL);
+        $this->extensionConfiguration = new DummyConfiguration(
+            ['eMailFormatForAttendees' => TestingRegistrationManager::SEND_TEXT_MAIL]
+        );
+        ConfigurationProxy::setInstance('seminars', $this->extensionConfiguration);
         $configurationRegistry = ConfigurationRegistry::getInstance();
         $this->configuration = new DummyConfiguration(
             [
@@ -200,6 +206,7 @@ final class RegistrationManagerTest extends TestCase
 
         $this->purgeMockedInstances();
 
+        ConfigurationProxy::purgeInstances();
         TestingRegistrationManager::purgeInstance();
         $GLOBALS['TYPO3_CONF_VARS']['EXTCONF'] = $this->extConfBackup;
     }
@@ -2114,9 +2121,8 @@ final class RegistrationManagerTest extends TestCase
      */
     public function notifyAttendeeForSendConfirmationTrueCallsRegistrationEmailHookMethodsForPlainTextEmail()
     {
-        /** @var ConfigurationProxy $configurationProxy */
-        $configurationProxy = ConfigurationProxy::getInstance('seminars');
-        $configurationProxy->setAsInteger('eMailFormatForAttendees', TestingRegistrationManager::SEND_TEXT_MAIL);
+        $this->extensionConfiguration
+            ->setAsInteger('eMailFormatForAttendees', TestingRegistrationManager::SEND_TEXT_MAIL);
         $this->configuration->setAsBoolean('sendConfirmation', true);
 
         $registrationOld = $this->createRegistration();
@@ -2153,9 +2159,8 @@ final class RegistrationManagerTest extends TestCase
      */
     public function notifyAttendeeForSendConfirmationTrueCallsRegistrationEmailHookMethodsForHtmlEmail()
     {
-        /** @var ConfigurationProxy $configurationProxy */
-        $configurationProxy = ConfigurationProxy::getInstance('seminars');
-        $configurationProxy->setAsInteger('eMailFormatForAttendees', TestingRegistrationManager::SEND_HTML_MAIL);
+        $this->extensionConfiguration
+            ->setAsInteger('eMailFormatForAttendees', TestingRegistrationManager::SEND_HTML_MAIL);
         $this->configuration->setAsBoolean('sendConfirmation', true);
 
         $registrationOld = $this->createRegistration();
@@ -2407,9 +2412,8 @@ final class RegistrationManagerTest extends TestCase
     public function notifyAttendeeForHtmlMailSetHasHtmlBody()
     {
         $this->configuration->setAsBoolean('sendConfirmation', true);
-        /** @var ConfigurationProxy $configurationProxy */
-        $configurationProxy = ConfigurationProxy::getInstance('seminars');
-        $configurationProxy->setAsInteger('eMailFormatForAttendees', TestingRegistrationManager::SEND_HTML_MAIL);
+        $this->extensionConfiguration
+            ->setAsInteger('eMailFormatForAttendees', TestingRegistrationManager::SEND_HTML_MAIL);
         $pi1 = new \Tx_Seminars_FrontEnd_DefaultController();
         $pi1->init();
 
@@ -2464,9 +2468,8 @@ final class RegistrationManagerTest extends TestCase
     public function notifyAttendeeForHtmlMailHasNoUnreplacedMarkers()
     {
         $this->configuration->setAsBoolean('sendConfirmation', true);
-        /** @var ConfigurationProxy $configurationProxy */
-        $configurationProxy = ConfigurationProxy::getInstance('seminars');
-        $configurationProxy->setAsInteger('eMailFormatForAttendees', TestingRegistrationManager::SEND_HTML_MAIL);
+        $this->extensionConfiguration
+            ->setAsInteger('eMailFormatForAttendees', TestingRegistrationManager::SEND_HTML_MAIL);
         $pi1 = new \Tx_Seminars_FrontEnd_DefaultController();
         $pi1->init();
 
@@ -2485,9 +2488,8 @@ final class RegistrationManagerTest extends TestCase
     public function notifyAttendeeForMailSetToUserModeAndUserSetToHtmlMailsHasHtmlBody()
     {
         $this->configuration->setAsBoolean('sendConfirmation', true);
-        /** @var ConfigurationProxy $configurationProxy */
-        $configurationProxy = ConfigurationProxy::getInstance('seminars');
-        $configurationProxy->setAsInteger('eMailFormatForAttendees', TestingRegistrationManager::SEND_USER_MAIL);
+        $this->extensionConfiguration
+            ->setAsInteger('eMailFormatForAttendees', TestingRegistrationManager::SEND_USER_MAIL);
         $registration = $this->createRegistration();
         $registration->getFrontEndUser()->setData(
             [
@@ -2512,9 +2514,8 @@ final class RegistrationManagerTest extends TestCase
     public function notifyAttendeeForMailSetToUserModeAndUserSetToTextMailsNotHasHtmlBody()
     {
         $this->configuration->setAsBoolean('sendConfirmation', true);
-        /** @var ConfigurationProxy $configurationProxy */
-        $configurationProxy = ConfigurationProxy::getInstance('seminars');
-        $configurationProxy->setAsInteger('eMailFormatForAttendees', TestingRegistrationManager::SEND_USER_MAIL);
+        $this->extensionConfiguration
+            ->setAsInteger('eMailFormatForAttendees', TestingRegistrationManager::SEND_USER_MAIL);
         $registration = $this->createRegistration();
         $registration->getFrontEndUser()->setData(
             [
@@ -2539,9 +2540,8 @@ final class RegistrationManagerTest extends TestCase
     public function notifyAttendeeForHtmlMailsContainsNameOfUserInBody()
     {
         $this->configuration->setAsBoolean('sendConfirmation', true);
-        /** @var ConfigurationProxy $configurationProxy */
-        $configurationProxy = ConfigurationProxy::getInstance('seminars');
-        $configurationProxy->setAsInteger('eMailFormatForAttendees', TestingRegistrationManager::SEND_HTML_MAIL);
+        $this->extensionConfiguration
+            ->setAsInteger('eMailFormatForAttendees', TestingRegistrationManager::SEND_HTML_MAIL);
         $registration = $this->createRegistration();
         $this->testingFramework->changeRecord(
             'fe_users',
@@ -2565,9 +2565,8 @@ final class RegistrationManagerTest extends TestCase
     public function notifyAttendeeForHtmlMailsHasLinkToSeminarInBody()
     {
         $this->configuration->setAsBoolean('sendConfirmation', true);
-        /** @var ConfigurationProxy $configurationProxy */
-        $configurationProxy = ConfigurationProxy::getInstance('seminars');
-        $configurationProxy->setAsInteger('eMailFormatForAttendees', TestingRegistrationManager::SEND_HTML_MAIL);
+        $this->extensionConfiguration
+            ->setAsInteger('eMailFormatForAttendees', TestingRegistrationManager::SEND_HTML_MAIL);
         $registration = $this->createRegistration();
         $registration->getFrontEndUser()->setData(
             ['email' => 'foo@bar.com']
@@ -2700,9 +2699,8 @@ final class RegistrationManagerTest extends TestCase
     public function notifyAttendeeForHtmlMailsHasCssStylesFromFile()
     {
         $this->configuration->setAsBoolean('sendConfirmation', true);
-        /** @var ConfigurationProxy $configurationProxy */
-        $configurationProxy = ConfigurationProxy::getInstance('seminars');
-        $configurationProxy->setAsInteger('eMailFormatForAttendees', TestingRegistrationManager::SEND_HTML_MAIL);
+        $this->extensionConfiguration
+            ->setAsInteger('eMailFormatForAttendees', TestingRegistrationManager::SEND_HTML_MAIL);
         $this->subject->setConfigurationValue(
             'cssFileForAttendeeMail',
             'EXT:seminars/Resources/Private/CSS/thankYouMail.css'
@@ -2764,9 +2762,8 @@ final class RegistrationManagerTest extends TestCase
     public function notifyAttendeeForHtmlMailReturnsAttendeesNamesInOrderedList()
     {
         $this->configuration->setAsBoolean('sendConfirmation', true);
-        /** @var ConfigurationProxy $configurationProxy */
-        $configurationProxy = ConfigurationProxy::getInstance('seminars');
-        $configurationProxy->setAsInteger('eMailFormatForAttendees', TestingRegistrationManager::SEND_HTML_MAIL);
+        $this->extensionConfiguration
+            ->setAsInteger('eMailFormatForAttendees', TestingRegistrationManager::SEND_HTML_MAIL);
         $this->subject->setConfigurationValue(
             'cssFileForAttendeeMail',
             'EXT:seminars/Resources/Private/CSS/thankYouMail.css'
@@ -2896,9 +2893,8 @@ final class RegistrationManagerTest extends TestCase
     public function notifyAttendeeForHtmlMailSeparatesPlacesTitleAndAddressWithBreaks()
     {
         $this->configuration->setAsBoolean('sendConfirmation', true);
-        /** @var ConfigurationProxy $configurationProxy */
-        $configurationProxy = ConfigurationProxy::getInstance('seminars');
-        $configurationProxy->setAsInteger('eMailFormatForAttendees', TestingRegistrationManager::SEND_HTML_MAIL);
+        $this->extensionConfiguration
+            ->setAsInteger('eMailFormatForAttendees', TestingRegistrationManager::SEND_HTML_MAIL);
         $this->subject->setConfigurationValue(
             'cssFileForAttendeeMail',
             'EXT:seminars/Resources/Private/CSS/thankYouMail.css'
@@ -3107,9 +3103,8 @@ final class RegistrationManagerTest extends TestCase
     public function notifyAttendeeForPlaceAddressAndHtmlMailsReplacesMultipleLineFeedsWithSpaces()
     {
         $this->configuration->setAsBoolean('sendConfirmation', true);
-        /** @var ConfigurationProxy $configurationProxy */
-        $configurationProxy = ConfigurationProxy::getInstance('seminars');
-        $configurationProxy->setAsInteger('eMailFormatForAttendees', TestingRegistrationManager::SEND_HTML_MAIL);
+        $this->extensionConfiguration
+            ->setAsInteger('eMailFormatForAttendees', TestingRegistrationManager::SEND_HTML_MAIL);
         $this->subject->setConfigurationValue(
             'cssFileForAttendeeMail',
             'EXT:seminars/Resources/Private/CSS/thankYouMail.css'
@@ -3144,9 +3139,8 @@ final class RegistrationManagerTest extends TestCase
     public function notifyAttendeeForPlaceAddressReplacesMultipleLineFeedAndCarriageReturnsWithSpaces()
     {
         $this->configuration->setAsBoolean('sendConfirmation', true);
-        /** @var ConfigurationProxy $configurationProxy */
-        $configurationProxy = ConfigurationProxy::getInstance('seminars');
-        $configurationProxy->setAsInteger('eMailFormatForAttendees', TestingRegistrationManager::SEND_HTML_MAIL);
+        $this->extensionConfiguration
+            ->setAsInteger('eMailFormatForAttendees', TestingRegistrationManager::SEND_HTML_MAIL);
         $this->subject->setConfigurationValue(
             'cssFileForAttendeeMail',
             'EXT:seminars/Resources/Private/CSS/thankYouMail.css'
@@ -3300,9 +3294,8 @@ final class RegistrationManagerTest extends TestCase
     public function notifyAttendeeForPlaceAddressAndHtmlMailsSeparatresAddressAndCityLineWithBreaks()
     {
         $this->configuration->setAsBoolean('sendConfirmation', true);
-        /** @var ConfigurationProxy $configurationProxy */
-        $configurationProxy = ConfigurationProxy::getInstance('seminars');
-        $configurationProxy->setAsInteger('eMailFormatForAttendees', TestingRegistrationManager::SEND_HTML_MAIL);
+        $this->extensionConfiguration
+            ->setAsInteger('eMailFormatForAttendees', TestingRegistrationManager::SEND_HTML_MAIL);
         $this->subject->setConfigurationValue(
             'cssFileForAttendeeMail',
             'EXT:seminars/Resources/Private/CSS/thankYouMail.css'

--- a/Tests/LegacyUnit/Support/Traits/BackEndTestsTrait.php
+++ b/Tests/LegacyUnit/Support/Traits/BackEndTestsTrait.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace OliverKlee\Seminars\Tests\LegacyUnit\Support\Traits;
 
-use OliverKlee\Oelib\Configuration\ConfigurationProxy;
 use OliverKlee\Oelib\Configuration\ConfigurationRegistry;
 use OliverKlee\Oelib\Configuration\DummyConfiguration;
 use OliverKlee\Oelib\Http\HeaderCollector;
@@ -75,9 +74,6 @@ trait BackEndTestsTrait
         $this->replaceBackEndUserWithMock();
         $this->unifyBackEndLanguage();
         $this->unifyExtensionSettings();
-        /** @var ConfigurationProxy $configuration */
-        $configuration = ConfigurationProxy::getInstance('seminars');
-        $configuration->setAsBoolean('enableConfigCheck', false);
         $this->setUpExtensionConfiguration();
         $headerProxyFactory = HeaderProxyFactory::getInstance();
         $headerProxyFactory->enableTestMode();


### PR DESCRIPTION
This make the tests compatible with the immutable `ConfigurationProxy`
from oelib 4.0.