### PR TITLE
[BUGFIX] Copy `FrontEndUserMapper::findByUserName` from oelib

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Drop support for PHP 7.0 and 7.1 (#847)
 
 ### Fixed
+- Copy `FrontEndUserMapper::findByUserName` from oelib (#1001)
 - Drop the typo3/cms-lang dependency (#980)
 - Provide a page to the fake frontend where needed (#969)
 - Add more type declarations

--- a/Classes/Mapper/FrontEndUser.php
+++ b/Classes/Mapper/FrontEndUser.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use OliverKlee\Oelib\Exception\NotFoundException;
 use OliverKlee\Oelib\Mapper\AbstractDataMapper;
 
 /**
@@ -29,4 +30,24 @@ class Tx_Seminars_Mapper_FrontEndUser extends AbstractDataMapper
         'usergroup' => \Tx_Seminars_Mapper_FrontEndUserGroup::class,
         'tx_seminars_registration' => \Tx_Seminars_Mapper_Registration::class,
     ];
+
+    /**
+     * @var array<int, string> the column names of additional string keys
+     */
+    protected $additionalKeys = ['username'];
+
+    /**
+     * Finds a front-end user by user name. Hidden user records will be retrieved as well.
+     *
+     * @param string $userName user name, case-insensitive, must not be empty
+     *
+     * @throws NotFoundException if there is no front-end user with the provided user name in the database
+     */
+    public function findByUserName(string $userName): \Tx_Seminars_Model_FrontEndUser
+    {
+        /** @var \Tx_Seminars_Model_FrontEndUser $result */
+        $result = $this->findOneByKey('username', $userName);
+
+        return $result;
+    }
 }

--- a/Tests/Functional/Mapper/FrontEndUserMapperTest.php
+++ b/Tests/Functional/Mapper/FrontEndUserMapperTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace OliverKlee\Seminars\Tests\Functional\Mapper;
 
 use Nimut\TestingFramework\TestCase\FunctionalTestCase;
+use OliverKlee\Oelib\Exception\NotFoundException;
 
 /**
  * @covers \Tx_Seminars_Mapper_FrontEndUser
@@ -74,5 +75,106 @@ final class FrontEndUserMapperTest extends FunctionalTestCase
         $registration = $model->getRegistration();
         self::assertInstanceOf(\Tx_Seminars_Model_Registration::class, $registration);
         self::assertSame(1, $registration->getUid());
+    }
+
+    // Tests concerning findByUserName
+
+    /**
+     * @test
+     */
+    public function findByUserNameForEmptyUserNameThrowsException(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('$value must not be empty.');
+
+        $this->subject->findByUserName('');
+    }
+
+    /**
+     * @test
+     */
+    public function findByUserNameWithNameOfExistingUserReturnsFrontEndUserInstance(): void
+    {
+        $userName = 'max.doe';
+        $this->getDatabaseConnection()->insertArray('fe_users', ['username' => $userName]);
+
+        self::assertInstanceOf(
+            \Tx_Seminars_Model_FrontEndUser::class,
+            $this->subject->findByUserName($userName)
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function findByUserNameWithNameOfExistingUserReturnsModelWithThatUid(): void
+    {
+        $userName = 'max.doe';
+        $this->getDatabaseConnection()->insertArray('fe_users', ['username' => $userName]);
+        $uid = (int)$this->getDatabaseConnection()->lastInsertId();
+
+        self::assertSame(
+            $uid,
+            $this->subject->findByUserName($userName)->getUid()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function findByUserNameWithUppercasedNameOfExistingLowercasedUserReturnsModelWithThatUid(): void
+    {
+        $userName = 'max.doe';
+        $this->getDatabaseConnection()->insertArray('fe_users', ['username' => $userName]);
+        $uid = (int)$this->getDatabaseConnection()->lastInsertId();
+
+        self::assertSame(
+            $uid,
+            $this->subject->findByUserName(strtoupper($userName))->getUid()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function findByUserNameWithUppercasedNameOfExistingUppercasedUserReturnsModelWithThatUid(): void
+    {
+        $userName = 'MAX.DOE';
+        $this->getDatabaseConnection()->insertArray('fe_users', ['username' => $userName]);
+        $uid = (int)$this->getDatabaseConnection()->lastInsertId();
+
+        self::assertSame(
+            $uid,
+            $this->subject->findByUserName($userName)->getUid()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function findByUserNameWithLowercasedNameOfExistingUppercasedUserReturnsModelWithThatUid(): void
+    {
+        $userName = 'max.doe';
+        $this->getDatabaseConnection()->insertArray('fe_users', ['username' => strtoupper($userName)]);
+        $uid = (int)$this->getDatabaseConnection()->lastInsertId();
+
+        self::assertSame(
+            $uid,
+            $this->subject->findByUserName($userName)->getUid()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function findByUserNameWithNameOfNonExistentUserThrowsException(): void
+    {
+        $this->expectException(NotFoundException::class);
+        $this->expectExceptionMessage('No records found in the table "fe_users" matching: {"username":"max.doe"}');
+
+        $userName = 'max.doe';
+        $this->getDatabaseConnection()->insertArray('fe_users', ['username' => $userName, 'deleted' => 1]);
+
+        $this->subject->findByUserName($userName);
     }
 }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -116,11 +116,6 @@ parameters:
 			path: Classes/FrontEnd/EventEditor.php
 
 		-
-			message: "#^Call to an undefined method Tx_Seminars_Mapper_FrontEndUser\\:\\:findByUserName\\(\\)\\.$#"
-			count: 1
-			path: Classes/FrontEnd/RegistrationForm.php
-
-		-
 			message: "#^Constant CR not found\\.$#"
 			count: 1
 			path: Classes/FrontEnd/RegistrationForm.php


### PR DESCRIPTION
This method is needed because we have switched from the oelib mapper
to the seminars mapper, and it is called in the registration manager.

Fixes #973