### PR TITLE
[TASK] Use aliases for the oelib user (group) mappers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 - !!! Namespace all classes
-  (#1004, #1005, #1007, #1010, #1011, #1012, #1014, #1016, #1017, #1019, #1020, #1021, #1025, #1026, #1028)
+  (#1004, #1005, #1007, #1010, #1011, #1012, #1014, #1016, #1017, #1019, #1020, #1021, #1025, #1026, #1028, #1029)
 - Migrate to the new configuration check
   (#935, #937, #939, #940, #943, #944, #946, #948, #949, #950, #951, #953, #954, #955, #956, #957, #958, #959, #962)
 - Add sr_feuser_register as a dev dependency (#926)

--- a/Classes/Mapper/EventMapper.php
+++ b/Classes/Mapper/EventMapper.php
@@ -8,7 +8,7 @@ use Doctrine\DBAL\Driver\Connection;
 use OliverKlee\Oelib\DataStructures\Collection;
 use OliverKlee\Oelib\Exception\NotFoundException;
 use OliverKlee\Oelib\Mapper\AbstractDataMapper;
-use OliverKlee\Oelib\Mapper\FrontEndUserMapper;
+use OliverKlee\Oelib\Mapper\FrontEndUserMapper as OelibFrontEndUserMapper;
 
 /**
  * This class represents a mapper for events.
@@ -47,8 +47,8 @@ class EventMapper extends AbstractDataMapper
         'organizers' => \Tx_Seminars_Mapper_Organizer::class,
         'organizing_partners' => \Tx_Seminars_Mapper_Organizer::class,
         'target_groups' => \Tx_Seminars_Mapper_TargetGroup::class,
-        'owner_feuser' => FrontEndUserMapper::class,
-        'vips' => FrontEndUserMapper::class,
+        'owner_feuser' => OelibFrontEndUserMapper::class,
+        'vips' => OelibFrontEndUserMapper::class,
         'checkboxes' => \Tx_Seminars_Mapper_Checkbox::class,
         'requirements' => EventMapper::class,
         'dependencies' => EventMapper::class,

--- a/Classes/Mapper/FrontEndUserGroup.php
+++ b/Classes/Mapper/FrontEndUserGroup.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 use OliverKlee\Oelib\Mapper\AbstractDataMapper;
-use OliverKlee\Oelib\Mapper\BackEndUserMapper;
+use OliverKlee\Oelib\Mapper\BackEndUserMapper as OelibBackEndUserMapper;
 
 /**
  * This class represents a mapper for front-end user groups.
@@ -27,7 +27,7 @@ class Tx_Seminars_Mapper_FrontEndUserGroup extends AbstractDataMapper
      *      the (possible) relations of the created models in the format DB column name => mapper name
      */
     protected $relations = [
-        'tx_seminars_reviewer' => BackEndUserMapper::class,
+        'tx_seminars_reviewer' => OelibBackEndUserMapper::class,
         'tx_seminars_default_categories' => \Tx_Seminars_Mapper_Category::class,
         'tx_seminars_default_organizer' => \Tx_Seminars_Mapper_Organizer::class,
     ];

--- a/Classes/OldModel/LegacyEvent.php
+++ b/Classes/OldModel/LegacyEvent.php
@@ -8,7 +8,7 @@ use OliverKlee\Oelib\Authentication\FrontEndLoginManager;
 use OliverKlee\Oelib\Configuration\ConfigurationRegistry;
 use OliverKlee\Oelib\DataStructures\Collection;
 use OliverKlee\Oelib\Interfaces\Time;
-use OliverKlee\Oelib\Mapper\FrontEndUserMapper;
+use OliverKlee\Oelib\Mapper\FrontEndUserMapper as OelibFrontEndUserMapper;
 use OliverKlee\Oelib\Mapper\MapperRegistry;
 use OliverKlee\Oelib\Model\FrontEndUser;
 use OliverKlee\Oelib\Templating\TemplateHelper;
@@ -3036,7 +3036,7 @@ class LegacyEvent extends \Tx_Seminars_OldModel_AbstractTimeSpan
             return null;
         }
 
-        $mapper = MapperRegistry::get(FrontEndUserMapper::class);
+        $mapper = MapperRegistry::get(OelibFrontEndUserMapper::class);
         $owner = $mapper->find($this->getRecordPropertyInteger('owner_feuser'));
 
         return $owner;

--- a/Tests/LegacyUnit/Mapper/EventMapperTest.php
+++ b/Tests/LegacyUnit/Mapper/EventMapperTest.php
@@ -6,7 +6,7 @@ namespace OliverKlee\Seminars\Tests\LegacyUnit\Mapper;
 
 use OliverKlee\Oelib\DataStructures\Collection;
 use OliverKlee\Oelib\Exception\NotFoundException;
-use OliverKlee\Oelib\Mapper\FrontEndUserMapper;
+use OliverKlee\Oelib\Mapper\FrontEndUserMapper as OelibFrontEndUserMapper;
 use OliverKlee\Oelib\Mapper\MapperRegistry;
 use OliverKlee\Oelib\Model\FrontEndUser;
 use OliverKlee\Oelib\Testing\TestingFramework;
@@ -609,7 +609,7 @@ final class EventMapperTest extends TestCase
      */
     public function getOwnerWithOwnerReturnsOwnerInstance(): void
     {
-        $frontEndUser = MapperRegistry::get(FrontEndUserMapper::class)
+        $frontEndUser = MapperRegistry::get(OelibFrontEndUserMapper::class)
             ->getLoadedTestingModel([]);
         $testingModel = $this->subject->getLoadedTestingModel(['owner_feuser' => $frontEndUser->getUid()]);
 
@@ -634,7 +634,7 @@ final class EventMapperTest extends TestCase
     public function getEventManagersWithOneEventManagerReturnsListOfFrontEndUsers(): void
     {
         $uid = $this->testingFramework->createRecord('tx_seminars_seminars');
-        $frontEndUser = MapperRegistry::get(FrontEndUserMapper::class)->getNewGhost();
+        $frontEndUser = MapperRegistry::get(OelibFrontEndUserMapper::class)->getNewGhost();
         $this->testingFramework->createRelationAndUpdateCounter(
             'tx_seminars_seminars',
             $uid,
@@ -652,7 +652,7 @@ final class EventMapperTest extends TestCase
     public function getEventManagersWithOneEventManagerReturnsOneEventManager(): void
     {
         $uid = $this->testingFramework->createRecord('tx_seminars_seminars');
-        $frontEndUser = MapperRegistry::get(FrontEndUserMapper::class)->getNewGhost();
+        $frontEndUser = MapperRegistry::get(OelibFrontEndUserMapper::class)->getNewGhost();
         $this->testingFramework->createRelationAndUpdateCounter(
             'tx_seminars_seminars',
             $uid,

--- a/Tests/LegacyUnit/Mapper/FrontEndUserGroupMapperTest.php
+++ b/Tests/LegacyUnit/Mapper/FrontEndUserGroupMapperTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace OliverKlee\Seminars\Tests\LegacyUnit\Mapper;
 
-use OliverKlee\Oelib\Mapper\BackEndUserMapper;
+use OliverKlee\Oelib\Mapper\BackEndUserMapper as OelibBackEndUserMapper;
 use OliverKlee\Oelib\Mapper\MapperRegistry;
 use OliverKlee\Oelib\Model\BackEndUser;
 use OliverKlee\Oelib\Testing\TestingFramework;
@@ -52,7 +52,7 @@ final class FrontEndUserGroupMapperTest extends TestCase
      */
     public function frontEndUserGroupCanReturnBackEndUserModel(): void
     {
-        $backEndUser = MapperRegistry::get(BackEndUserMapper::class)->getNewGhost();
+        $backEndUser = MapperRegistry::get(OelibBackEndUserMapper::class)->getNewGhost();
         $frontEndUserGroup = $this->subject->getLoadedTestingModel(
             ['tx_seminars_reviewer' => $backEndUser->getUid()]
         );


### PR DESCRIPTION
This prevents problems when we namespace the seminars user (group)
mappers.