### PR TITLE
[TASK] Use aliases for the oelib user (group) models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 - !!! Namespace all classes
-  (#1004, #1005, #1007, #1010, #1011, #1012, #1014, #1016, #1017, #1019, #1020, #1021, #1025, #1026, #1028, #1029)
+  (#1004, #1005, #1007, #1010, #1011, #1012, #1014, #1016, #1017, #1019, #1020, #1021, #1025, #1026, #1028, #1029, #1031)
 - Migrate to the new configuration check
   (#935, #937, #939, #940, #943, #944, #946, #948, #949, #950, #951, #953, #954, #955, #956, #957, #958, #959, #962)
 - Add sr_feuser_register as a dev dependency (#926)

--- a/Classes/FrontEnd/EventEditor.php
+++ b/Classes/FrontEnd/EventEditor.php
@@ -14,7 +14,7 @@ use OliverKlee\Oelib\Interfaces\MailRole;
 use OliverKlee\Oelib\Mapper\CountryMapper;
 use OliverKlee\Oelib\Mapper\MapperRegistry;
 use OliverKlee\Oelib\Model\AbstractModel;
-use OliverKlee\Oelib\Model\BackEndUser;
+use OliverKlee\Oelib\Model\BackEndUser as OelibBackEndUser;
 use OliverKlee\Oelib\Model\Country;
 use OliverKlee\Oelib\Templating\Template;
 use OliverKlee\Oelib\Visibility\Tree;
@@ -1366,7 +1366,7 @@ class EventEditor extends AbstractEditor
     /**
      * Gets the reviewer for new/edited records.
      */
-    protected function getReviewer(): ?BackEndUser
+    protected function getReviewer(): ?OelibBackEndUser
     {
         MapperRegistry::purgeInstance();
         return self::getLoggedInUser()->getReviewerFromGroup();

--- a/Classes/Model/FrontEndUser.php
+++ b/Classes/Model/FrontEndUser.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 use OliverKlee\Oelib\DataStructures\Collection;
-use OliverKlee\Oelib\Model\BackEndUser;
+use OliverKlee\Oelib\Model\BackEndUser as OelibBackEndUser;
 use OliverKlee\Oelib\Model\FrontEndUser as OelibFrontEndUser;
 
 /**
@@ -77,7 +77,7 @@ class Tx_Seminars_Model_FrontEndUser extends OelibFrontEndUser
      *
      * Will return the first reviewer found.
      */
-    public function getReviewerFromGroup(): ?BackEndUser
+    public function getReviewerFromGroup(): ?OelibBackEndUser
     {
         $result = null;
 

--- a/Classes/Model/FrontEndUserGroup.php
+++ b/Classes/Model/FrontEndUserGroup.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 use OliverKlee\Oelib\DataStructures\Collection;
-use OliverKlee\Oelib\Model\BackEndUser;
+use OliverKlee\Oelib\Model\BackEndUser as OelibBackEndUser;
 use OliverKlee\Oelib\Model\FrontEndUserGroup as OelibFrontEndUserGroup;
 use OliverKlee\Seminars\Model\Interfaces\Titled;
 
@@ -61,9 +61,9 @@ class Tx_Seminars_Model_FrontEndUserGroup extends OelibFrontEndUserGroup impleme
         return $this->getReviewer() !== null;
     }
 
-    public function getReviewer(): ?BackEndUser
+    public function getReviewer(): ?OelibBackEndUser
     {
-        /** @var BackEndUser|null $reviewer */
+        /** @var OelibBackEndUser|null $reviewer */
         $reviewer = $this->getAsModel('tx_seminars_reviewer');
 
         return $reviewer;

--- a/Classes/OldModel/LegacyEvent.php
+++ b/Classes/OldModel/LegacyEvent.php
@@ -10,7 +10,7 @@ use OliverKlee\Oelib\DataStructures\Collection;
 use OliverKlee\Oelib\Interfaces\Time;
 use OliverKlee\Oelib\Mapper\FrontEndUserMapper as OelibFrontEndUserMapper;
 use OliverKlee\Oelib\Mapper\MapperRegistry;
-use OliverKlee\Oelib\Model\FrontEndUser;
+use OliverKlee\Oelib\Model\FrontEndUser as OelibFrontEndUser;
 use OliverKlee\Oelib\Templating\TemplateHelper;
 use OliverKlee\Oelib\ViewHelpers\PriceViewHelper;
 use OliverKlee\Seminars\Bag\EventBag;
@@ -3030,7 +3030,7 @@ class LegacyEvent extends \Tx_Seminars_OldModel_AbstractTimeSpan
     /**
      * Gets this event's owner (the FE user who has created this event).
      */
-    public function getOwner(): ?FrontEndUser
+    public function getOwner(): ?OelibFrontEndUser
     {
         if (!$this->hasRecordPropertyInteger('owner_feuser')) {
             return null;

--- a/Classes/Service/RegistrationManager.php
+++ b/Classes/Service/RegistrationManager.php
@@ -6,7 +6,7 @@ use OliverKlee\Oelib\Authentication\FrontEndLoginManager;
 use OliverKlee\Oelib\Configuration\ConfigurationProxy;
 use OliverKlee\Oelib\Http\HeaderProxyFactory;
 use OliverKlee\Oelib\Mapper\MapperRegistry;
-use OliverKlee\Oelib\Model\FrontEndUser;
+use OliverKlee\Oelib\Model\FrontEndUser as OelibFrontEndUser;
 use OliverKlee\Oelib\Templating\Template;
 use OliverKlee\Oelib\Templating\TemplateHelper;
 use OliverKlee\Oelib\Templating\TemplateRegistry;
@@ -557,8 +557,8 @@ class Tx_Seminars_Service_RegistrationManager extends TemplateHelper
         $company = isset($formData['company']) ? strip_tags($formData['company']) : '';
         $registration->setCompany($company);
 
-        $validGenderMale = (string)FrontEndUser::GENDER_MALE;
-        $validGenderFemale = (string)FrontEndUser::GENDER_FEMALE;
+        $validGenderMale = (string)OelibFrontEndUser::GENDER_MALE;
+        $validGenderFemale = (string)OelibFrontEndUser::GENDER_FEMALE;
         if (
             isset($formData['gender'])
             && (
@@ -567,7 +567,7 @@ class Tx_Seminars_Service_RegistrationManager extends TemplateHelper
         ) {
             $gender = (int)$formData['gender'];
         } else {
-            $gender = FrontEndUser::GENDER_UNKNOWN;
+            $gender = OelibFrontEndUser::GENDER_UNKNOWN;
         }
         $registration->setGender($gender);
 

--- a/Tests/LegacyUnit/Mapper/EventMapperTest.php
+++ b/Tests/LegacyUnit/Mapper/EventMapperTest.php
@@ -8,7 +8,7 @@ use OliverKlee\Oelib\DataStructures\Collection;
 use OliverKlee\Oelib\Exception\NotFoundException;
 use OliverKlee\Oelib\Mapper\FrontEndUserMapper as OelibFrontEndUserMapper;
 use OliverKlee\Oelib\Mapper\MapperRegistry;
-use OliverKlee\Oelib\Model\FrontEndUser;
+use OliverKlee\Oelib\Model\FrontEndUser as OelibFrontEndUser;
 use OliverKlee\Oelib\Testing\TestingFramework;
 use OliverKlee\PhpUnit\TestCase;
 use OliverKlee\Seminars\Mapper\EventMapper;
@@ -613,7 +613,7 @@ final class EventMapperTest extends TestCase
             ->getLoadedTestingModel([]);
         $testingModel = $this->subject->getLoadedTestingModel(['owner_feuser' => $frontEndUser->getUid()]);
 
-        self::assertInstanceOf(FrontEndUser::class, $testingModel->getOwner());
+        self::assertInstanceOf(OelibFrontEndUser::class, $testingModel->getOwner());
     }
 
     // Tests regarding getEventManagers().
@@ -643,7 +643,7 @@ final class EventMapperTest extends TestCase
         );
 
         $model = $this->subject->find($uid);
-        self::assertInstanceOf(FrontEndUser::class, $model->getEventManagers()->first());
+        self::assertInstanceOf(OelibFrontEndUser::class, $model->getEventManagers()->first());
     }
 
     /**

--- a/Tests/LegacyUnit/Mapper/FrontEndUserGroupMapperTest.php
+++ b/Tests/LegacyUnit/Mapper/FrontEndUserGroupMapperTest.php
@@ -6,7 +6,7 @@ namespace OliverKlee\Seminars\Tests\LegacyUnit\Mapper;
 
 use OliverKlee\Oelib\Mapper\BackEndUserMapper as OelibBackEndUserMapper;
 use OliverKlee\Oelib\Mapper\MapperRegistry;
-use OliverKlee\Oelib\Model\BackEndUser;
+use OliverKlee\Oelib\Model\BackEndUser as OelibBackEndUser;
 use OliverKlee\Oelib\Testing\TestingFramework;
 use OliverKlee\PhpUnit\TestCase;
 
@@ -59,7 +59,7 @@ final class FrontEndUserGroupMapperTest extends TestCase
 
         $model = $this->subject->find($frontEndUserGroup->getUid());
 
-        self::assertInstanceOf(BackEndUser::class, $model->getReviewer());
+        self::assertInstanceOf(OelibBackEndUser::class, $model->getReviewer());
     }
 
     // Tests concerning the default categories

--- a/Tests/LegacyUnit/Model/FrontEndUserGroupTest.php
+++ b/Tests/LegacyUnit/Model/FrontEndUserGroupTest.php
@@ -6,7 +6,7 @@ namespace OliverKlee\Seminars\Tests\LegacyUnit\Model;
 
 use OliverKlee\Oelib\DataStructures\Collection;
 use OliverKlee\Oelib\Mapper\MapperRegistry;
-use OliverKlee\Oelib\Model\BackEndUser;
+use OliverKlee\Oelib\Model\BackEndUser as OelibBackEndUser;
 use OliverKlee\PhpUnit\TestCase;
 
 final class FrontEndUserGroupTest extends TestCase
@@ -156,7 +156,7 @@ final class FrontEndUserGroupTest extends TestCase
      */
     public function hasReviewerForGroupWithReviewerReturnsTrue(): void
     {
-        $backEndUser = new BackEndUser();
+        $backEndUser = new OelibBackEndUser();
 
         $this->subject->setData(['tx_seminars_reviewer' => $backEndUser]);
 
@@ -182,7 +182,7 @@ final class FrontEndUserGroupTest extends TestCase
      */
     public function getReviewerForGroupWithReviewerReturnsReviewer(): void
     {
-        $backEndUser = new BackEndUser();
+        $backEndUser = new OelibBackEndUser();
 
         $this->subject->setData(['tx_seminars_reviewer' => $backEndUser]);
 

--- a/Tests/LegacyUnit/Model/FrontEndUserTest.php
+++ b/Tests/LegacyUnit/Model/FrontEndUserTest.php
@@ -6,7 +6,7 @@ namespace OliverKlee\Seminars\Tests\LegacyUnit\Model;
 
 use OliverKlee\Oelib\DataStructures\Collection;
 use OliverKlee\Oelib\Mapper\MapperRegistry;
-use OliverKlee\Oelib\Model\BackEndUser;
+use OliverKlee\Oelib\Model\BackEndUser as OelibBackEndUser;
 use OliverKlee\Oelib\Testing\TestingFramework;
 use OliverKlee\PhpUnit\TestCase;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -377,7 +377,7 @@ final class FrontEndUserTest extends TestCase
      */
     public function getReviewerFromGroupForUserWithGroupWithReviewerReturnsReviewer(): void
     {
-        $backEndUser = new BackEndUser();
+        $backEndUser = new OelibBackEndUser();
 
         $userGroup = new \Tx_Seminars_Model_FrontEndUserGroup();
         $userGroup->setData(['tx_seminars_reviewer' => $backEndUser]);
@@ -398,7 +398,7 @@ final class FrontEndUserTest extends TestCase
      */
     public function getReviewerFromGroupForUserWithTwoGroupsOneWithReviewerOneWithoutReviewerReturnsReviewer(): void
     {
-        $backEndUser = new BackEndUser();
+        $backEndUser = new OelibBackEndUser();
 
         $userGroup1 = new \Tx_Seminars_Model_FrontEndUserGroup();
         $userGroup2 = new \Tx_Seminars_Model_FrontEndUserGroup();
@@ -423,8 +423,8 @@ final class FrontEndUserTest extends TestCase
      */
     public function getReviewerFromGroupForUserWithTwoGroupsWithReviewersReturnsReviewerOfFirstGroup(): void
     {
-        $backEndUser1 = new BackEndUser();
-        $backEndUser2 = new BackEndUser();
+        $backEndUser1 = new OelibBackEndUser();
+        $backEndUser2 = new OelibBackEndUser();
 
         $userGroup1 = new \Tx_Seminars_Model_FrontEndUserGroup();
         $userGroup2 = new \Tx_Seminars_Model_FrontEndUserGroup();

--- a/Tests/LegacyUnit/Model/RegistrationTest.php
+++ b/Tests/LegacyUnit/Model/RegistrationTest.php
@@ -6,7 +6,7 @@ namespace OliverKlee\Seminars\Tests\LegacyUnit\Model;
 
 use OliverKlee\Oelib\DataStructures\Collection;
 use OliverKlee\Oelib\Mapper\MapperRegistry;
-use OliverKlee\Oelib\Model\FrontEndUser;
+use OliverKlee\Oelib\Model\FrontEndUser as OelibFrontEndUser;
 use OliverKlee\Oelib\Testing\TestingFramework;
 use OliverKlee\PhpUnit\TestCase;
 use OliverKlee\Seminars\Mapper\EventMapper;
@@ -845,7 +845,7 @@ final class RegistrationTest extends TestCase
         $this->subject->setData([]);
 
         self::assertEquals(
-            FrontEndUser::GENDER_MALE,
+            OelibFrontEndUser::GENDER_MALE,
             $this->subject->getGender()
         );
     }
@@ -856,11 +856,11 @@ final class RegistrationTest extends TestCase
     public function getGenderWithGenderFemaleReturnsGenderFemale(): void
     {
         $this->subject->setData(
-            ['gender' => FrontEndUser::GENDER_FEMALE]
+            ['gender' => OelibFrontEndUser::GENDER_FEMALE]
         );
 
         self::assertEquals(
-            FrontEndUser::GENDER_FEMALE,
+            OelibFrontEndUser::GENDER_FEMALE,
             $this->subject->getGender()
         );
     }
@@ -871,11 +871,11 @@ final class RegistrationTest extends TestCase
     public function getGenderWithGenderUnknownReturnsGenderUnknown(): void
     {
         $this->subject->setData(
-            ['gender' => FrontEndUser::GENDER_UNKNOWN]
+            ['gender' => OelibFrontEndUser::GENDER_UNKNOWN]
         );
 
         self::assertEquals(
-            FrontEndUser::GENDER_UNKNOWN,
+            OelibFrontEndUser::GENDER_UNKNOWN,
             $this->subject->getGender()
         );
     }
@@ -901,10 +901,10 @@ final class RegistrationTest extends TestCase
      */
     public function setGenderWithGenderMaleSetsGender(): void
     {
-        $this->subject->setGender(FrontEndUser::GENDER_MALE);
+        $this->subject->setGender(OelibFrontEndUser::GENDER_MALE);
 
         self::assertEquals(
-            FrontEndUser::GENDER_MALE,
+            OelibFrontEndUser::GENDER_MALE,
             $this->subject->getGender()
         );
     }
@@ -914,10 +914,10 @@ final class RegistrationTest extends TestCase
      */
     public function setGenderWithGenderFemaleSetsGender(): void
     {
-        $this->subject->setGender(FrontEndUser::GENDER_FEMALE);
+        $this->subject->setGender(OelibFrontEndUser::GENDER_FEMALE);
 
         self::assertEquals(
-            FrontEndUser::GENDER_FEMALE,
+            OelibFrontEndUser::GENDER_FEMALE,
             $this->subject->getGender()
         );
     }
@@ -927,10 +927,10 @@ final class RegistrationTest extends TestCase
      */
     public function setGenderWithGenderUnknownSetsGender(): void
     {
-        $this->subject->setGender(FrontEndUser::GENDER_UNKNOWN);
+        $this->subject->setGender(OelibFrontEndUser::GENDER_UNKNOWN);
 
         self::assertEquals(
-            FrontEndUser::GENDER_UNKNOWN,
+            OelibFrontEndUser::GENDER_UNKNOWN,
             $this->subject->getGender()
         );
     }

--- a/Tests/LegacyUnit/OldModel/LegacyEventTest.php
+++ b/Tests/LegacyUnit/OldModel/LegacyEventTest.php
@@ -8,7 +8,7 @@ use OliverKlee\Oelib\Configuration\ConfigurationRegistry;
 use OliverKlee\Oelib\Configuration\DummyConfiguration;
 use OliverKlee\Oelib\DataStructures\Collection;
 use OliverKlee\Oelib\Interfaces\Time;
-use OliverKlee\Oelib\Model\FrontEndUser;
+use OliverKlee\Oelib\Model\FrontEndUser as OelibFrontEndUser;
 use OliverKlee\Oelib\Testing\TestingFramework;
 use OliverKlee\PhpUnit\TestCase;
 use OliverKlee\Seminars\Bag\EventBag;
@@ -5783,7 +5783,7 @@ final class LegacyEventTest extends TestCase
         $ownerUid = $this->testingFramework->createAndLoginFrontEndUser();
         $this->subject->setOwnerUid($ownerUid);
 
-        self::assertInstanceOf(FrontEndUser::class, $this->subject->getOwner());
+        self::assertInstanceOf(OelibFrontEndUser::class, $this->subject->getOwner());
     }
 
     /**


### PR DESCRIPTION
This prevents problems when we namespace the seminars user (group)
models.