### PR TITLE
[BUGFIX] Always call the `AbstractPlugin` parent constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Removed
 
 ### Fixed
-- Properly initialize the languages in all views (#1083)
+- Properly initialize the languages in all views (#1083, #1084)
 
 ## 4.0.0
 

--- a/Classes/OldModel/AbstractModel.php
+++ b/Classes/OldModel/AbstractModel.php
@@ -64,6 +64,8 @@ abstract class AbstractModel extends TemplateHelper
      */
     public function __construct(int $uid = 0, bool $allowHidden = false)
     {
+        parent::__construct(null, $GLOBALS['TSFE'] ?? null);
+
         if ($uid > 0) {
             $data = self::fetchDataByUid($uid, $allowHidden);
             if (\is_array($data)) {

--- a/Classes/Service/RegistrationManager.php
+++ b/Classes/Service/RegistrationManager.php
@@ -105,6 +105,8 @@ class RegistrationManager extends TemplateHelper
      */
     public function __construct()
     {
+        parent::__construct(null, $GLOBALS['TSFE'] ?? null);
+
         $this->init();
     }
 


### PR DESCRIPTION
This fixes some language labels that were not translated or only
contained the label key.

Fixes #1074
Fixes #1081