### PR TITLE
[BUGFIX] Stop using the language labels of the lang extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Removed
 
 ### Fixed
+- Stop using the language labels of the lang extension (#1097)
 - Improve the type annotations (#1096)
 - Use the `LanguageService` factory methods in TYPO3 10LTS (#1091)
 

--- a/Classes/BackEnd/AbstractModule.php
+++ b/Classes/BackEnd/AbstractModule.php
@@ -51,9 +51,9 @@ abstract class AbstractModule extends BaseScriptClass
     {
         $this->moduleTemplate = GeneralUtility::makeInstance(ModuleTemplate::class);
         $languageService = $this->getLanguageService();
-        $languageService->includeLLFile('EXT:lang/Resources/Private/Language/locallang_common.xlf');
-        $languageService->includeLLFile('EXT:lang/Resources/Private/Language/locallang_show_rechis.xlf');
-        $languageService->includeLLFile('EXT:lang/Resources/Private/Language/locallang_mod_web_list.xlf');
+        $languageService->includeLLFile('EXT:backend/Resources/Private/Language/locallang_show_rechis.xlf');
+        $languageService->includeLLFile('EXT:core/Resources/Private/Language/locallang_common.xlf');
+        $languageService->includeLLFile('EXT:core/Resources/Private/Language/locallang_mod_web_list.xlf');
         $languageService->includeLLFile('EXT:seminars/Resources/Private/Language/locallang.xlf');
 
         $this->MCONF = ['name' => static::MODULE_NAME];

--- a/Classes/Csv/AbstractListView.php
+++ b/Classes/Csv/AbstractListView.php
@@ -98,7 +98,7 @@ abstract class AbstractListView
         }
 
         $this->translator = $languageService;
-        $languageService->includeLLFile('EXT:lang/Resources/Private/Language/locallang_general.xlf');
+        $languageService->includeLLFile('EXT:core/Resources/Private/Language/locallang_general.xlf');
         $languageService->includeLLFile('EXT:seminars/Resources/Private/Language/locallang_db.xlf');
         $this->includeAdditionalLanguageFiles();
 

--- a/Tests/LegacyUnit/Csv/AbstractRegistrationListViewTest.php
+++ b/Tests/LegacyUnit/Csv/AbstractRegistrationListViewTest.php
@@ -77,8 +77,8 @@ final class AbstractRegistrationListViewTest extends TestCase
         $this->extConfBackup = $GLOBALS['TYPO3_CONF_VARS']['EXTCONF'];
         $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['seminars'] = [];
 
+        $this->getLanguageService()->includeLLFile('EXT:core/Resources/Private/Language/locallang_general.xlf');
         $this->getLanguageService()->includeLLFile('EXT:seminars/Resources/Private/Language/locallang_db.xlf');
-        $this->getLanguageService()->includeLLFile('EXT:lang/Resources/Private/Language/locallang_general.xlf');
 
         $this->testingFramework = new TestingFramework('tx_seminars');
 

--- a/Tests/LegacyUnit/Csv/DownloadRegistrationListViewTest.php
+++ b/Tests/LegacyUnit/Csv/DownloadRegistrationListViewTest.php
@@ -39,8 +39,8 @@ final class DownloadRegistrationListViewTest extends TestCase
     {
         $GLOBALS['SIM_EXEC_TIME'] = 1524751343;
 
+        $this->getLanguageService()->includeLLFile('EXT:core/Resources/Private/Language/locallang_general.xlf');
         $this->getLanguageService()->includeLLFile('EXT:seminars/Resources/Private/Language/locallang_db.xlf');
-        $this->getLanguageService()->includeLLFile('EXT:lang/Resources/Private/Language/locallang_general.xlf');
 
         $this->testingFramework = new TestingFramework('tx_seminars');
 

--- a/Tests/LegacyUnit/Csv/EmailRegistrationListViewTest.php
+++ b/Tests/LegacyUnit/Csv/EmailRegistrationListViewTest.php
@@ -39,8 +39,8 @@ final class EmailRegistrationListViewTest extends TestCase
     {
         $GLOBALS['SIM_EXEC_TIME'] = 1524751343;
 
+        $this->getLanguageService()->includeLLFile('EXT:core/Resources/Private/Language/locallang_general.xlf');
         $this->getLanguageService()->includeLLFile('EXT:seminars/Resources/Private/Language/locallang_db.xlf');
-        $this->getLanguageService()->includeLLFile('EXT:lang/Resources/Private/Language/locallang_general.xlf');
 
         $this->testingFramework = new TestingFramework('tx_seminars');
 

--- a/Tests/LegacyUnit/Csv/EventListViewTest.php
+++ b/Tests/LegacyUnit/Csv/EventListViewTest.php
@@ -39,8 +39,8 @@ final class EventListViewTest extends TestCase
     {
         $GLOBALS['SIM_EXEC_TIME'] = 1524751343;
 
+        $this->getLanguageService()->includeLLFile('EXT:core/Resources/Private/Language/locallang_general.xlf');
         $this->getLanguageService()->includeLLFile('EXT:seminars/Resources/Private/Language/locallang_db.xlf');
-        $this->getLanguageService()->includeLLFile('EXT:lang/Resources/Private/Language/locallang_general.xlf');
 
         $this->testingFramework = new TestingFramework('tx_seminars');
 

--- a/Tests/LegacyUnit/Support/Traits/BackEndTestsTrait.php
+++ b/Tests/LegacyUnit/Support/Traits/BackEndTestsTrait.php
@@ -118,9 +118,9 @@ trait BackEndTestsTrait
         $languageService = $this->getLanguageService();
         $languageService->lang = 'default';
 
+        $languageService->includeLLFile('EXT:core/Resources/Private/Language/locallang_general.xlf');
         $languageService->includeLLFile('EXT:seminars/Resources/Private/Language/locallang.xlf');
         $languageService->includeLLFile('EXT:seminars/Resources/Private/Language/locallang_db.xlf');
-        $languageService->includeLLFile('EXT:lang/Resources/Private/Language/locallang_general.xlf');
     }
 
     /**


### PR DESCRIPTION
The lang extension does not have any labels anymore.

Also sort the language inclusions.