### PR TITLE
[TASK] Stop calling `initTemplate()` in the link builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Add Rector to the toolchain (#1094)
 
 ### Changed
+- Stop calling `initTemplate()` in the link builder (#1098)
 - Use PHP 7.2 features (#1095)
 - Raise PHPStan to level 6 (#1093)
 - Require mkforms 10 and allow rn_base 1.14 (#1088)

--- a/Classes/Service/SingleViewLinkBuilder.php
+++ b/Classes/Service/SingleViewLinkBuilder.php
@@ -106,7 +106,6 @@ class SingleViewLinkBuilder
         $frontEnd->fe_user = GeneralUtility::makeInstance(FrontendUserAuthentication::class);
 
         $frontEnd->determineId();
-        $frontEnd->initTemplate();
         $frontEnd->config = [];
 
         $frontEnd->newCObj();


### PR DESCRIPTION
Starting with TYPO3 9LTS, this method usually does not need to be
explictly called anymore.