### PR TITLE
[TASK] Replace usages of `getConfValue*` in the legacy models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Add Rector to the toolchain (#1094)
 
 ### Changed
-- Switch to the new configuration classes in more places (#1112)
+- Switch to the new configuration classes in more places (#1112, #1113)
 - Stop calling `initTemplate()` in the link builder (#1098)
 - Use PHP 7.2 features (#1095)
 - Raise PHPStan to level 6 (#1093)

--- a/Classes/OldModel/LegacyEvent.php
+++ b/Classes/OldModel/LegacyEvent.php
@@ -946,7 +946,7 @@ class LegacyEvent extends AbstractTimeSpan
     /**
      * Gets our regular price as a string containing amount and currency. If
      * no regular price has been set, either "free" or "to be announced" will
-     * be returned, depending on the TS variable showToBeAnnouncedForEmptyPrice.
+     * be returned, depending on the TypoScript variable showToBeAnnouncedForEmptyPrice.
      */
     public function getPriceRegular(): string
     {
@@ -954,7 +954,7 @@ class LegacyEvent extends AbstractTimeSpan
             $result = $this->formatPrice($this->getPriceRegularAmount());
         } else {
             $result =
-                $this->getConfValueBoolean('showToBeAnnouncedForEmptyPrice')
+                $this->getSharedConfiguration()->getAsBoolean('showToBeAnnouncedForEmptyPrice')
                     ? $this->translate('message_willBeAnnounced')
                     : $this->translate('message_forFree');
         }
@@ -1534,7 +1534,7 @@ class LegacyEvent extends AbstractTimeSpan
         }
 
         $vacancies = $this->getVacancies();
-        $vacanciesThreshold = $this->getConfValueInteger('showVacanciesThreshold');
+        $vacanciesThreshold = $this->getSharedConfiguration()->getAsInteger('showVacanciesThreshold');
 
         if ($vacancies === 0) {
             $result = $this->translate('message_fullyBooked');
@@ -1703,7 +1703,7 @@ class LegacyEvent extends AbstractTimeSpan
                 $this->getDateFormat(),
                 $this->getRecordPropertyInteger('deadline_registration')
             );
-            if ($this->getConfValueBoolean('showTimeOfRegistrationDeadline')) {
+            if ($this->getSharedConfiguration()->getAsBoolean('showTimeOfRegistrationDeadline')) {
                 $result .= \strftime(
                     ' ' . $this->getTimeFormat(),
                     $this->getRecordPropertyInteger('deadline_registration')
@@ -1744,7 +1744,7 @@ class LegacyEvent extends AbstractTimeSpan
 
         if ($this->hasEarlyBirdDeadline()) {
             $result = \strftime($this->getDateFormat(), $this->getRecordPropertyInteger('deadline_early_bird'));
-            if ($this->getConfValueBoolean('showTimeOfEarlyBirdDeadline')) {
+            if ($this->getSharedConfiguration()->getAsBoolean('showTimeOfEarlyBirdDeadline')) {
                 $result .= \strftime(
                     ' ' . $this->getTimeFormat(),
                     $this->getRecordPropertyInteger('deadline_early_bird')
@@ -2350,7 +2350,7 @@ class LegacyEvent extends AbstractTimeSpan
                 break;
             case 'csv_export':
                 $result = $this->isUserVip($currentUserUid, $defaultEventVipsFeGroupID)
-                    && $this->getConfValueBoolean('allowCsvExportForVips');
+                    && $this->getSharedConfiguration()->getAsBoolean('allowCsvExportForVips');
                 break;
             default:
                 $result = false;
@@ -2401,7 +2401,7 @@ class LegacyEvent extends AbstractTimeSpan
         switch ($whichPlugin) {
             case 'csv_export':
                 $result = $this->isUserVip($currentUserUid, $defaultEventVipsFeGroupID)
-                    && $this->getConfValueBoolean('allowCsvExportForVips');
+                    && $this->getSharedConfiguration()->getAsBoolean('allowCsvExportForVips');
                 break;
             case 'my_vip_events':
                 $result = $this->isUserVip($currentUserUid, $defaultEventVipsFeGroupID) && $hasVipListPid;
@@ -2459,7 +2459,7 @@ class LegacyEvent extends AbstractTimeSpan
         switch ($whichPlugin) {
             case 'csv_export':
                 $result = $isLoggedIn && $this->isUserVip($currentUserUid, $defaultEventVipsFeGroupID)
-                    && $this->getConfValueBoolean('allowCsvExportForVips');
+                    && $this->getSharedConfiguration()->getAsBoolean('allowCsvExportForVips');
                 break;
             case 'my_vip_events':
                 $result = $isLoggedIn && $this->isUserVip($currentUserUid, $defaultEventVipsFeGroupID)
@@ -3472,7 +3472,7 @@ class LegacyEvent extends AbstractTimeSpan
      */
     private function skipCollisionCheck(): bool
     {
-        return $this->getConfValueBoolean('skipRegistrationCollisionCheck') ||
+        return $this->getSharedConfiguration()->getAsBoolean('skipRegistrationCollisionCheck') ||
             $this->getRecordPropertyBoolean('skip_collision_check');
     }
 

--- a/Classes/OldModel/LegacyRegistration.php
+++ b/Classes/OldModel/LegacyRegistration.php
@@ -253,7 +253,7 @@ class LegacyRegistration extends AbstractModel
         $this->recordData['notes'] = $registrationData['notes'];
 
         $this->recordData['pid'] = $this->seminar->hasAttendancesPid()
-            ? $this->seminar->getAttendancesPid() : $this->getConfValueInteger('attendancesPID');
+            ? $this->seminar->getAttendancesPid() : $this->getSharedConfiguration()->getAsInteger('attendancesPID');
 
         $this->processAdditionalRegistrationData($registrationData);
 

--- a/Tests/LegacyUnit/OldModel/LegacyEventTest.php
+++ b/Tests/LegacyUnit/OldModel/LegacyEventTest.php
@@ -4760,7 +4760,7 @@ final class LegacyEventTest extends TestCase
             ['seminar' => $registeredEventUid, 'user' => $userUid]
         );
 
-        $this->subject->setConfigurationValue('skipRegistrationCollisionCheck', true);
+        $this->configuration->setAsBoolean('skipRegistrationCollisionCheck', true);
 
         self::assertFalse($this->subject->isUserBlocked($userUid));
     }
@@ -5819,7 +5819,7 @@ final class LegacyEventTest extends TestCase
      */
     public function getVacanciesStringForCanceledEventWithVacanciesReturnsEmptyString(): void
     {
-        $this->subject->setConfigurationValue('showVacanciesThreshold', 10);
+        $this->configuration->setAsInteger('showVacanciesThreshold', 10);
         $this->subject->setBeginDate($this->now + 10000);
         $this->subject->setAttendancesMax(5);
         $this->subject->setNumberOfAttendances(0);
@@ -5833,7 +5833,7 @@ final class LegacyEventTest extends TestCase
      */
     public function getVacanciesStringWithoutRegistrationNeededReturnsEmptyString(): void
     {
-        $this->subject->setConfigurationValue('showVacanciesThreshold', 10);
+        $this->configuration->setAsInteger('showVacanciesThreshold', 10);
         $this->subject->setBeginDate($this->now + 10000);
         $this->subject->setNeedsRegistration(false);
 
@@ -5845,7 +5845,7 @@ final class LegacyEventTest extends TestCase
      */
     public function getVacanciesStringForNonZeroVacanciesAndPastDeadlineReturnsEmptyString(): void
     {
-        $this->subject->setConfigurationValue('showVacanciesThreshold', 10);
+        $this->configuration->setAsInteger('showVacanciesThreshold', 10);
         $this->subject->setAttendancesMax(5);
         $this->subject->setNumberOfAttendances(0);
         $this->subject->setBeginDate($this->now + 10000);
@@ -5859,7 +5859,7 @@ final class LegacyEventTest extends TestCase
      */
     public function getVacanciesStringForNonZeroVacanciesBelowThresholdReturnsNumberOfVacancies(): void
     {
-        $this->subject->setConfigurationValue('showVacanciesThreshold', 10);
+        $this->configuration->setAsInteger('showVacanciesThreshold', 10);
         $this->subject->setBeginDate($this->now + 10000);
         $this->subject->setAttendancesMax(5);
         $this->subject->setNumberOfAttendances(0);
@@ -5875,7 +5875,7 @@ final class LegacyEventTest extends TestCase
      */
     public function getVacanciesStringForNoVancanciesReturnsFullyBooked(): void
     {
-        $this->subject->setConfigurationValue('showVacanciesThreshold', 10);
+        $this->configuration->setAsInteger('showVacanciesThreshold', 10);
         $this->subject->setBeginDate($this->now + 10000);
         $this->subject->setAttendancesMax(5);
         $this->subject->setNumberOfAttendances(5);
@@ -5891,7 +5891,7 @@ final class LegacyEventTest extends TestCase
      */
     public function getVacanciesStringForVacanciesGreaterThanThresholdReturnsEnough(): void
     {
-        $this->subject->setConfigurationValue('showVacanciesThreshold', 10);
+        $this->configuration->setAsInteger('showVacanciesThreshold', 10);
         $this->subject->setBeginDate($this->now + 10000);
         $this->subject->setAttendancesMax(42);
         $this->subject->setNumberOfAttendances(0);
@@ -5907,7 +5907,7 @@ final class LegacyEventTest extends TestCase
      */
     public function getVacanciesStringForVacanciesEqualToThresholdReturnsEnough(): void
     {
-        $this->subject->setConfigurationValue('showVacanciesThreshold', 42);
+        $this->configuration->setAsInteger('showVacanciesThreshold', 42);
         $this->subject->setBeginDate($this->now + 10000);
         $this->subject->setAttendancesMax(42);
         $this->subject->setNumberOfAttendances(0);
@@ -8235,15 +8235,15 @@ final class LegacyEventTest extends TestCase
         bool $isVip,
         bool $allowCsvExportForVips
     ): void {
+        $this->configuration->setAsBoolean('allowCsvExportForVips', $allowCsvExportForVips);
+
         /** @var LegacyEvent&MockObject $subject */
         $subject = $this->createPartialMock(LegacyEvent::class, ['needsRegistration', 'isUserVip']);
         $subject->method('needsRegistration')
             ->willReturn(true);
         $subject->method('isUserVip')
             ->willReturn($isVip);
-        $subject->init(
-            ['allowCsvExportForVips' => $allowCsvExportForVips]
-        );
+        $subject->init([]);
 
         if ($loggedIn) {
             $pageUid = $this->testingFramework->createFrontEndPage();


### PR DESCRIPTION
One steps towards getting rid of `TemplateHelper` in the legacy models.

Fixes #1100