### PR TITLE
[TASK] Use the Extbase localization features in the legacy models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Add Rector to the toolchain (#1094)
 
 ### Changed
-- Switch to the new configuration classes in more places (#1112, #1113)
+- Use the Extbase localization features in the legacy models (#1116)
+- Switch to the new configuration classes in more places (#1112, #1114)
 - Stop calling `initTemplate()` in the link builder (#1098)
 - Use PHP 7.2 features (#1095)
 - Raise PHPStan to level 6 (#1093)

--- a/Classes/OldModel/AbstractModel.php
+++ b/Classes/OldModel/AbstractModel.php
@@ -16,6 +16,7 @@ use TYPO3\CMS\Core\Imaging\Icon;
 use TYPO3\CMS\Core\Imaging\IconFactory;
 use TYPO3\CMS\Core\Resource\FileRepository;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
 
 /**
  * This class represents an object that is created from a DB record or can be written to a DB record.
@@ -574,5 +575,19 @@ abstract class AbstractModel extends TemplateHelper
         $fileRepository = GeneralUtility::makeInstance(FileRepository::class);
 
         return $fileRepository;
+    }
+
+    /**
+     * Retrieves the localized string for the given key within the seminars extension.
+     *
+     * Note: This method does not take the salutation mode (formal/informal) nor its suffixes into account.
+     *
+     * @return string the localized label, or the given key if there is no label with that key
+     */
+    public function translate(string $key): string
+    {
+        $label = LocalizationUtility::translate($key, 'seminars');
+
+        return \is_string($label) ? $label : $key;
     }
 }


### PR DESCRIPTION
One more step towards getting rid of `TemplateHelper` in the legacy models.

Fixes #908
Fixes #1101