### PR TITLE
[TASK] Drop the `TemplateHelper` dependency from the legacy models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Add Rector to the toolchain (#1094)
 
 ### Changed
+- Drop the `TemplateHelper` dependency from the legacy models (#1117)
 - Use the Extbase localization features in the legacy models (#1116)
 - Switch to the new configuration classes in more places (#1112, #1114)
 - Stop calling `initTemplate()` in the link builder (#1098)

--- a/Classes/FrontEnd/DefaultController.php
+++ b/Classes/FrontEnd/DefaultController.php
@@ -462,13 +462,8 @@ class DefaultController extends TemplateHelper
     public function createRegistration(int $uid): bool
     {
         $this->registration = LegacyRegistration::fromUid($uid);
-        $exists = $this->registration instanceof LegacyRegistration;
 
-        if ($exists) {
-            $this->registration->setContentObject($this->cObj);
-        }
-
-        return $exists;
+        return $this->registration instanceof LegacyRegistration;
     }
 
     public function createHelperObjects(): void

--- a/Classes/OldModel/AbstractModel.php
+++ b/Classes/OldModel/AbstractModel.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace OliverKlee\Seminars\OldModel;
 
-use OliverKlee\Oelib\Templating\TemplateHelper;
 use OliverKlee\Seminars\Configuration\Traits\SharedPluginConfiguration;
 use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Database\ConnectionPool;
@@ -23,31 +22,14 @@ use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
  *
  * It will hold the corresponding data and can commit that data to the DB.
  */
-abstract class AbstractModel extends TemplateHelper
+abstract class AbstractModel
 {
     use SharedPluginConfiguration;
-
-    /**
-     * @var string the extension key
-     */
-    public $extKey = 'seminars';
-
-    /**
-     * faking $this->scriptRelPath so the locallang.xlf file is found
-     *
-     * @var string
-     */
-    public $scriptRelPath = 'Resources/Private/Language/locallang.xlf';
 
     /**
      * @var string the name of the SQL table this class corresponds to
      */
     protected static $tableName = '';
-
-    /**
-     * @var bool whether to call `TemplateHelper::init()` during construction
-     */
-    protected $needsTemplateHelperInitialization = true;
 
     /**
      * @var array the values from/for the DB
@@ -65,17 +47,11 @@ abstract class AbstractModel extends TemplateHelper
      */
     public function __construct(int $uid = 0, bool $allowHidden = false)
     {
-        parent::__construct(null, $GLOBALS['TSFE'] ?? null);
-
         if ($uid > 0) {
             $data = self::fetchDataByUid($uid, $allowHidden);
             if (\is_array($data)) {
                 $this->setData($data);
             }
-        }
-
-        if ($this->needsTemplateHelperInitialization) {
-            $this->init();
         }
     }
 
@@ -584,7 +560,7 @@ abstract class AbstractModel extends TemplateHelper
      *
      * @return string the localized label, or the given key if there is no label with that key
      */
-    public function translate(string $key): string
+    protected function translate(string $key): string
     {
         $label = LocalizationUtility::translate($key, 'seminars');
 

--- a/Classes/OldModel/LegacyCategory.php
+++ b/Classes/OldModel/LegacyCategory.php
@@ -16,11 +16,6 @@ class LegacyCategory extends AbstractModel
      */
     protected static $tableName = 'tx_seminars_categories';
 
-    /**
-     * @var bool whether to call `TemplateHelper::init()` during construction
-     */
-    protected $needsTemplateHelperInitialization = false;
-
     public function hasIcon(): bool
     {
         return $this->hasRecordPropertyInteger('icon');

--- a/Classes/OldModel/LegacyEvent.php
+++ b/Classes/OldModel/LegacyEvent.php
@@ -734,7 +734,7 @@ class LegacyEvent extends AbstractTimeSpan
      *
      * @return string our speakers list, will be empty if an error occurred during processing
      */
-    public function getSpeakersShort(TemplateHelper $plugin, string $speakerRelation = 'speakers'): string
+    public function getSpeakersShort(?TemplateHelper $plugin = null, string $speakerRelation = 'speakers'): string
     {
         if (!$this->hasSpeakersOfType($speakerRelation)) {
             return '';
@@ -744,7 +744,7 @@ class LegacyEvent extends AbstractTimeSpan
 
         /** @var LegacySpeaker $speaker */
         foreach ($this->getSpeakerBag($speakerRelation) as $speaker) {
-            $result[] = $speaker->getLinkedTitle($plugin);
+            $result[] = $plugin instanceof TemplateHelper ? $speaker->getLinkedTitle($plugin) : $speaker->getTitle();
         }
 
         return implode(', ', $result);
@@ -2103,7 +2103,7 @@ class LegacyEvent extends AbstractTimeSpan
                     $value = $this->getEarlyBirdPriceSpecial();
                     break;
                 case 'speakers':
-                    $value = $this->getSpeakersShort($this);
+                    $value = $this->getSpeakersShort();
                     break;
                 case 'time':
                     $value = $this->getTime('-');

--- a/Classes/OldModel/LegacyOrganizer.php
+++ b/Classes/OldModel/LegacyOrganizer.php
@@ -17,11 +17,6 @@ class LegacyOrganizer extends AbstractModel implements MailRole
     protected static $tableName = 'tx_seminars_organizers';
 
     /**
-     * @var bool whether to call `TemplateHelper::init()` during construction
-     */
-    protected $needsTemplateHelperInitialization = false;
-
-    /**
      * Gets the organizer's real name.
      *
      * @return string the organizer's real name, will not be empty for valid records

--- a/Classes/OldModel/LegacyRegistration.php
+++ b/Classes/OldModel/LegacyRegistration.php
@@ -14,7 +14,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Domain\Model\FrontendUserGroup;
 use TYPO3\CMS\Extbase\Domain\Repository\FrontendUserGroupRepository;
 use TYPO3\CMS\Extbase\Object\ObjectManager;
-use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
 use TYPO3\CMS\Frontend\Plugin\AbstractPlugin;
 
 /**
@@ -104,11 +103,6 @@ class LegacyRegistration extends AbstractModel
      * @var FrontendUserGroupRepository|null
      */
     private $frontEndUserGroupRepository = null;
-
-    public function setContentObject(?ContentObjectRenderer $contentObjectRenderer = null): void
-    {
-        $this->cObj = $contentObjectRenderer;
-    }
 
     /**
      * Purges our cached seminars array.

--- a/Classes/Service/RegistrationManager.php
+++ b/Classes/Service/RegistrationManager.php
@@ -455,7 +455,6 @@ class RegistrationManager extends TemplateHelper
     public function createRegistration(LegacyEvent $event, array $formData, AbstractPlugin $plugin): Registration
     {
         $this->registration = GeneralUtility::makeInstance(LegacyRegistration::class);
-        $this->registration->setContentObject($plugin->cObj);
         $this->registration->setRegistrationData($event, $this->getLoggedInFrontEndUserUid(), $formData);
         $this->registration->commitToDatabase();
         $event->increaseNumberOfAssociatedRegistrationRecords();
@@ -617,7 +616,6 @@ class RegistrationManager extends TemplateHelper
             return;
         }
 
-        $this->registration->setContentObject($plugin->cObj);
         if ($this->registration->getUser() !== $this->getLoggedInFrontEndUserUid()) {
             return;
         }

--- a/Tests/Functional/BackEnd/Fixtures/TestingEventMailForm.php
+++ b/Tests/Functional/BackEnd/Fixtures/TestingEventMailForm.php
@@ -44,14 +44,6 @@ final class TestingEventMailForm extends AbstractEventMailForm
     }
 
     /**
-     * Sets the date format for the event.
-     */
-    public function setDateFormat(): void
-    {
-        $this->getOldEvent()->setConfigurationValue('dateFormatYMD', '%d.%m.%Y');
-    }
-
-    /**
      * Sets an error message.
      *
      * @param string $fieldName the field name to set the error message for, must be "messageBody" or "subject"

--- a/Tests/LegacyUnit/BackEnd/AbstractEventMailFormTest.php
+++ b/Tests/LegacyUnit/BackEnd/AbstractEventMailFormTest.php
@@ -69,7 +69,6 @@ final class AbstractEventMailFormTest extends TestCase
         );
 
         $this->subject = new TestingEventMailForm($this->eventUid);
-        $this->subject->setDateFormat();
     }
 
     protected function tearDown(): void

--- a/Tests/LegacyUnit/OldModel/LegacyEventTest.php
+++ b/Tests/LegacyUnit/OldModel/LegacyEventTest.php
@@ -7338,10 +7338,7 @@ final class LegacyEventTest extends TestCase
     {
         $this->subject->setDescription('');
 
-        self::assertSame(
-            $this->getLanguageService()->getLL('label_description') . ":\n",
-            $this->subject->dumpSeminarValues('description')
-        );
+        self::assertStringContainsString(":\n", $this->subject->dumpSeminarValues('description'));
     }
 
     /**
@@ -8243,7 +8240,6 @@ final class LegacyEventTest extends TestCase
             ->willReturn(true);
         $subject->method('isUserVip')
             ->willReturn($isVip);
-        $subject->init([]);
 
         if ($loggedIn) {
             $pageUid = $this->testingFramework->createFrontEndPage();
@@ -8669,7 +8665,6 @@ final class LegacyEventTest extends TestCase
         /** @var LegacyEvent&MockObject $subject */
         $subject = $this->createPartialMock(LegacyEvent::class, ['needsRegistration']);
         $subject->method('needsRegistration')->willReturn(false);
-        $subject->init();
 
         self::assertSame(
             $this->getLanguageService()->getLL('message_noRegistrationNecessary'),
@@ -8685,7 +8680,6 @@ final class LegacyEventTest extends TestCase
         /** @var LegacyEvent&MockObject $subject */
         $subject = $this->createPartialMock(LegacyEvent::class, ['needsRegistration']);
         $subject->method('needsRegistration')->willReturn(true);
-        $subject->init();
 
         self::assertSame(
             $this->getLanguageService()->getLL('message_notLoggedIn'),
@@ -8701,7 +8695,6 @@ final class LegacyEventTest extends TestCase
         /** @var LegacyEvent&MockObject $subject */
         $subject = $this->createPartialMock(LegacyEvent::class, ['needsRegistration']);
         $subject->method('needsRegistration')->willReturn(true);
-        $subject->init();
 
         self::assertSame(
             $this->getLanguageService()->getLL('message_notLoggedIn'),
@@ -8717,7 +8710,6 @@ final class LegacyEventTest extends TestCase
         /** @var LegacyEvent&MockObject $subject */
         $subject = $this->createPartialMock(LegacyEvent::class, ['needsRegistration']);
         $subject->method('needsRegistration')->willReturn(true);
-        $subject->init();
 
         self::assertSame(
             '',
@@ -8750,7 +8742,6 @@ final class LegacyEventTest extends TestCase
         /** @var LegacyEvent&MockObject $subject */
         $subject = $this->createPartialMock(LegacyEvent::class, ['needsRegistration']);
         $subject->method('needsRegistration')->willReturn(true);
-        $subject->init();
 
         self::assertSame(
             $this->getLanguageService()->getLL('message_notLoggedIn'),
@@ -8766,7 +8757,6 @@ final class LegacyEventTest extends TestCase
         /** @var LegacyEvent&MockObject $subject */
         $subject = $this->createPartialMock(LegacyEvent::class, ['needsRegistration']);
         $subject->method('needsRegistration')->willReturn(true);
-        $subject->init();
 
         self::assertSame(
             '',

--- a/Tests/LegacyUnit/OldModel/LegacyRegistrationTest.php
+++ b/Tests/LegacyUnit/OldModel/LegacyRegistrationTest.php
@@ -60,6 +60,7 @@ final class LegacyRegistrationTest extends TestCase
         $this->testingFramework->createFakeFrontEnd();
 
         $this->configuration = new DummyConfiguration();
+        $this->configuration->setAsString('templateFile', 'EXT:seminars/Resources/Private/Templates/Mail/e-mail.html');
         ConfigurationRegistry::getInstance()->set('plugin.tx_seminars', $this->configuration);
 
         $organizerUid = $this->testingFramework->createRecord(
@@ -102,10 +103,6 @@ final class LegacyRegistrationTest extends TestCase
         );
 
         $this->subject = new LegacyRegistration($registrationUid);
-        $this->subject->setConfigurationValue(
-            'templateFile',
-            'EXT:seminars/Resources/Private/Templates/Mail/e-mail.html'
-        );
 
         $this->connectionPool = GeneralUtility::makeInstance(ConnectionPool::class);
     }

--- a/Tests/Unit/OldModel/Fixtures/TestingModel.php
+++ b/Tests/Unit/OldModel/Fixtures/TestingModel.php
@@ -17,11 +17,6 @@ final class TestingModel extends AbstractModel
     protected static $tableName = 'tx_seminars_test';
 
     /**
-     * @var bool whether to call `TemplateHelper::init()` during construction in BE mode
-     */
-    protected $needsTemplateHelperInitialization = false;
-
-    /**
      * Sets the test field of this record to a boolean value.
      *
      * @param bool $test the boolean value to set

--- a/Tests/Unit/OldModel/Fixtures/TestingTimeSpan.php
+++ b/Tests/Unit/OldModel/Fixtures/TestingTimeSpan.php
@@ -12,11 +12,6 @@ use OliverKlee\Seminars\OldModel\AbstractTimeSpan;
 final class TestingTimeSpan extends AbstractTimeSpan
 {
     /**
-     * @var bool whether to call `TemplateHelper::init()` during construction in BE mode
-     */
-    protected $needsTemplateHelperInitialization = false;
-
-    /**
      * Sets this time span's begin date and time.
      *
      * @param int $beginDate begin date and time as a UNIX timestamp, may be zero


### PR DESCRIPTION
This fixes an architectural problem that breaks all sorts of things
in TYPO3 10LTS (and also reduces performance): `AbstractPlugin` should
only be used in the frontend.

Fixes #909
Fixes #1102