### PR TITLE
[TASK] Stop using typolink for external links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Add Rector to the toolchain (#1094)
 
 ### Changed
+- Stop using typolink for external links (#1123)
 - Drop the `TemplateHelper` dependency from the legacy models (#1117)
 - Use the Extbase localization features in the legacy models (#1116)
 - Switch to the new configuration classes in more places (#1112, #1114)

--- a/Classes/FrontEnd/DefaultController.php
+++ b/Classes/FrontEnd/DefaultController.php
@@ -979,7 +979,7 @@ class DefaultController extends TemplateHelper
 
         $speakerContent = $this->getConfValueBoolean('showSpeakerDetails', 's_template_special')
             ? $this->seminar->getSpeakersWithDetails($this, $speakerType)
-            : $this->seminar->getSpeakersShort($this, $speakerType);
+            : $this->seminar->getSpeakersShort($speakerType);
         $this->setMarker($speakerType, $speakerContent);
     }
 
@@ -1910,7 +1910,7 @@ class DefaultController extends TemplateHelper
             );
             $this->setMarker('credit_points', $this->seminar->getCreditPoints());
             $this->setMarker('teaser', $this->createSingleViewLink($event, $event->getTeaser()));
-            $this->setMarker('speakers', $this->seminar->getSpeakersShort($this));
+            $this->setMarker('speakers', $this->seminar->getSpeakersShort());
             $this->setMarker('language', \htmlspecialchars($this->seminar->getLanguageName(), ENT_QUOTES | ENT_HTML5));
 
             $currentDate = $this->seminar->getDate();
@@ -2885,17 +2885,14 @@ class DefaultController extends TemplateHelper
         $result = '';
         /** @var LegacyOrganizer $organizer */
         foreach ($this->seminar->getOrganizerBag() as $organizer) {
+            $encodedName = \htmlspecialchars($organizer->getName(), ENT_QUOTES | ENT_HTML5);
             if ($organizer->hasHomepage()) {
-                $organizerTitle = $this->cObj->getTypoLink(
-                    \htmlspecialchars($organizer->getName(), ENT_QUOTES | ENT_HTML5),
-                    $organizer->getHomepage(),
-                    [],
-                    $this->getConfValueString('externalLinkTarget')
-                );
+                $encodedUrl = \htmlspecialchars($organizer->getHomepage(), ENT_QUOTES | ENT_HTML5);
+                $organizerHtml = '<a href="' . $encodedUrl . '">' . $encodedName . '</a>';
             } else {
-                $organizerTitle = \htmlspecialchars($organizer->getName(), ENT_QUOTES | ENT_HTML5);
+                $organizerHtml = $encodedName;
             }
-            $this->setMarker('organizer_item_title', $organizerTitle);
+            $this->setMarker('organizer_item_title', $organizerHtml);
 
             if ($organizer->hasDescription()) {
                 $this->setMarker(

--- a/Classes/OldModel/AbstractModel.php
+++ b/Classes/OldModel/AbstractModel.php
@@ -566,4 +566,15 @@ abstract class AbstractModel
 
         return \is_string($label) ? $label : $key;
     }
+
+    protected function addMissingProtocolToUrl(string $url): string
+    {
+        if ($url === '') {
+            return '';
+        }
+
+        $hasProtocol = \strpos($url, '://') !== false;
+
+        return $hasProtocol ? $url : ('http://' . $url);
+    }
 }

--- a/Classes/OldModel/LegacySpeaker.php
+++ b/Classes/OldModel/LegacySpeaker.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace OliverKlee\Seminars\OldModel;
 
 use OliverKlee\Oelib\Mapper\MapperRegistry;
-use OliverKlee\Oelib\Templating\TemplateHelper;
 use OliverKlee\Seminars\Mapper\FrontEndUserMapper;
 use OliverKlee\Seminars\Model\FrontEndUser;
 use TYPO3\CMS\Core\Resource\FileReference;
@@ -209,28 +208,23 @@ class LegacySpeaker extends AbstractModel
     /**
      * Creates a link to this speaker's homepage, with the title as link text.
      *
-     * @param TemplateHelper $plugin object with current configuration values
-     *
-     * @return string this speaker's title wrapped in an link tag, or if the
+     * @return string this speaker's title wrapped in a link tag, or if the
      *                speaker has no homepage just the speaker name, will not
      *                be empty
      */
-    public function getLinkedTitle(TemplateHelper $plugin): string
+    public function getLinkedTitle(): string
     {
-        $safeTitle = \htmlspecialchars($this->getTitle(), ENT_QUOTES | ENT_HTML5);
-
-        if ($this->hasHomepage()) {
-            $result = $plugin->cObj->getTypoLink(
-                $safeTitle,
-                $this->getHomepage(),
-                [],
-                $plugin->getConfValueString('externalLinkTarget')
-            );
-        } else {
-            $result = $safeTitle;
+        $encodedTitle = \htmlspecialchars($this->getTitle(), ENT_QUOTES | ENT_HTML5);
+        if (!$this->hasHomepage()) {
+            return $encodedTitle;
         }
 
-        return $result;
+        $encodedUrl = \htmlspecialchars(
+            $this->addMissingProtocolToUrl($this->getHomepage()),
+            ENT_QUOTES | ENT_HTML5
+        );
+
+        return '<a href="' . $encodedUrl . '">' . $encodedTitle . '</a>';
     }
 
     /**

--- a/Tests/LegacyUnit/OldModel/LegacyEventTest.php
+++ b/Tests/LegacyUnit/OldModel/LegacyEventTest.php
@@ -4508,19 +4508,19 @@ final class LegacyEventTest extends TestCase
 
         self::assertSame(
             '',
-            $this->subject->getSpeakersShort($this->pi1)
+            $this->subject->getSpeakersShort()
         );
         self::assertSame(
             '',
-            $this->subject->getSpeakersShort($this->pi1, 'partners')
+            $this->subject->getSpeakersShort('partners')
         );
         self::assertSame(
             '',
-            $this->subject->getSpeakersShort($this->pi1, 'tutors')
+            $this->subject->getSpeakersShort('tutors')
         );
         self::assertSame(
             '',
-            $this->subject->getSpeakersShort($this->pi1, 'leaders')
+            $this->subject->getSpeakersShort('leaders')
         );
     }
 
@@ -4535,25 +4535,25 @@ final class LegacyEventTest extends TestCase
         $this->addSpeakerRelation($speaker);
         self::assertSame(
             $speaker['title'],
-            $this->subject->getSpeakersShort($this->pi1)
+            $this->subject->getSpeakersShort()
         );
 
         $this->addPartnerRelation($speaker);
         self::assertSame(
             $speaker['title'],
-            $this->subject->getSpeakersShort($this->pi1, 'partners')
+            $this->subject->getSpeakersShort('partners')
         );
 
         $this->addTutorRelation($speaker);
         self::assertSame(
             $speaker['title'],
-            $this->subject->getSpeakersShort($this->pi1, 'tutors')
+            $this->subject->getSpeakersShort('tutors')
         );
 
         $this->addLeaderRelation($speaker);
         self::assertSame(
             $speaker['title'],
-            $this->subject->getSpeakersShort($this->pi1, 'leaders')
+            $this->subject->getSpeakersShort('leaders')
         );
     }
 
@@ -4570,28 +4570,28 @@ final class LegacyEventTest extends TestCase
         $this->createPi1();
         self::assertSame(
             $firstSpeaker['title'] . ', ' . $secondSpeaker['title'],
-            $this->subject->getSpeakersShort($this->pi1)
+            $this->subject->getSpeakersShort()
         );
 
         $this->addPartnerRelation($firstSpeaker);
         $this->addPartnerRelation($secondSpeaker);
         self::assertSame(
             $firstSpeaker['title'] . ', ' . $secondSpeaker['title'],
-            $this->subject->getSpeakersShort($this->pi1, 'partners')
+            $this->subject->getSpeakersShort('partners')
         );
 
         $this->addTutorRelation($firstSpeaker);
         $this->addTutorRelation($secondSpeaker);
         self::assertSame(
             $firstSpeaker['title'] . ', ' . $secondSpeaker['title'],
-            $this->subject->getSpeakersShort($this->pi1, 'tutors')
+            $this->subject->getSpeakersShort('tutors')
         );
 
         $this->addLeaderRelation($firstSpeaker);
         $this->addLeaderRelation($secondSpeaker);
         self::assertSame(
             $firstSpeaker['title'] . ', ' . $secondSpeaker['title'],
-            $this->subject->getSpeakersShort($this->pi1, 'leaders')
+            $this->subject->getSpeakersShort('leaders')
         );
     }
 
@@ -4609,7 +4609,7 @@ final class LegacyEventTest extends TestCase
 
         self::assertRegExp(
             '/href="http:\\/\\/www.foo.com".*>test speaker/',
-            $this->subject->getSpeakersShort($this->pi1)
+            $this->subject->getSpeakersShort()
         );
     }
 
@@ -4625,8 +4625,7 @@ final class LegacyEventTest extends TestCase
         $this->addSpeakerRelation($speaker);
         $this->createPi1();
 
-        $shortSpeakerOutput
-            = $this->subject->getSpeakersShort($this->pi1);
+        $shortSpeakerOutput = $this->subject->getSpeakersShort();
 
         self::assertStringContainsString(
             'test speaker',


### PR DESCRIPTION
This reduces dependencies on `ContentObjectRenderer` and improves
performance.

Fixes #1119