### PR TITLE
[BUGFIX] Provide the `ContentObjectRenderer` with a logger in the tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Removed
 
 ### Fixed
+- Provide the `ContentObjectRenderer` with a logger in the tests (#1145)
 - Set up a site language for the fake frontend in tests (#1139)
 
 ## 4.0.3

--- a/Tests/Functional/FrontEnd/CategoryListTest.php
+++ b/Tests/Functional/FrontEnd/CategoryListTest.php
@@ -8,6 +8,7 @@ use Nimut\TestingFramework\TestCase\FunctionalTestCase;
 use OliverKlee\Oelib\System\Typo3Version;
 use OliverKlee\Seminars\FrontEnd\CategoryList;
 use OliverKlee\Seminars\Tests\Functional\Traits\LanguageHelper;
+use Psr\Log\NullLogger;
 use TYPO3\CMS\Core\Cache\Backend\NullBackend;
 use TYPO3\CMS\Core\Cache\CacheManager;
 use TYPO3\CMS\Core\Cache\Frontend\VariableFrontend;
@@ -61,12 +62,14 @@ final class CategoryListTest extends FunctionalTestCase
         }
         $GLOBALS['TSFE'] = $frontEnd;
 
+        $contentObject = new ContentObjectRenderer();
+        $contentObject->setLogger(new NullLogger());
         $this->subject = new CategoryList(
             [
                 'isStaticTemplateLoaded' => 1,
                 'templateFile' => 'EXT:seminars/Resources/Private/Templates/FrontEnd/FrontEnd.html',
             ],
-            new ContentObjectRenderer()
+            $contentObject
         );
     }
 

--- a/Tests/Functional/FrontEnd/DefaultControllerTest.php
+++ b/Tests/Functional/FrontEnd/DefaultControllerTest.php
@@ -10,6 +10,7 @@ use OliverKlee\Seminars\FrontEnd\DefaultController;
 use OliverKlee\Seminars\Service\RegistrationManager;
 use OliverKlee\Seminars\Tests\LegacyUnit\FrontEnd\Fixtures\TestingDefaultController;
 use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
 use TYPO3\CMS\Core\Cache\Backend\NullBackend;
 use TYPO3\CMS\Core\Cache\CacheManager;
 use TYPO3\CMS\Core\Cache\Frontend\VariableFrontend;
@@ -60,6 +61,7 @@ final class DefaultControllerTest extends FunctionalTestCase
         }
 
         $contentObject = new ContentObjectRenderer();
+        $contentObject->setLogger(new NullLogger());
         $this->registerNullPageCache();
 
         // Needed in TYPO3 V10; can be removed in V11.

--- a/Tests/Functional/FrontEnd/EventEditorTest.php
+++ b/Tests/Functional/FrontEnd/EventEditorTest.php
@@ -11,6 +11,7 @@ use OliverKlee\Oelib\System\Typo3Version;
 use OliverKlee\Seminars\FrontEnd\EventEditor;
 use OliverKlee\Seminars\Mapper\FrontEndUserMapper;
 use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
 use TYPO3\CMS\Core\Cache\Backend\NullBackend;
 use TYPO3\CMS\Core\Cache\CacheManager;
 use TYPO3\CMS\Core\Cache\Frontend\VariableFrontend;
@@ -90,6 +91,7 @@ final class EventEditorTest extends FunctionalTestCase
         }
 
         $contentObject = new ContentObjectRenderer();
+        $contentObject->setLogger(new NullLogger());
         $this->registerNullPageCache();
 
         // Needed in TYPO3 V10; can be removed in V11.

--- a/Tests/Functional/FrontEnd/EventHeadlineTest.php
+++ b/Tests/Functional/FrontEnd/EventHeadlineTest.php
@@ -11,6 +11,7 @@ use OliverKlee\Oelib\System\Typo3Version;
 use OliverKlee\Seminars\FrontEnd\EventHeadline;
 use OliverKlee\Seminars\Mapper\EventMapper;
 use OliverKlee\Seminars\Service\RegistrationManager;
+use Psr\Log\NullLogger;
 use TYPO3\CMS\Core\Http\Uri;
 use TYPO3\CMS\Core\Site\Entity\SiteLanguage;
 use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
@@ -59,7 +60,9 @@ final class EventHeadlineTest extends FunctionalTestCase
         $frontEnd = $frontEndProphecy->reveal();
         $GLOBALS['TSFE'] = $frontEnd;
 
-        $this->subject = new EventHeadline(self::CONFIGURATION, new ContentObjectRenderer());
+        $contentObject = new ContentObjectRenderer();
+        $contentObject->setLogger(new NullLogger());
+        $this->subject = new EventHeadline(self::CONFIGURATION, $contentObject);
 
         $mapper = new EventMapper();
         $this->subject->injectEventMapper($mapper);
@@ -80,7 +83,9 @@ final class EventHeadlineTest extends FunctionalTestCase
         $this->expectException(\BadMethodCallException::class);
         $this->expectExceptionCode(1333614794);
 
-        $subject = new EventHeadline([], new ContentObjectRenderer());
+        $contentObject = new ContentObjectRenderer();
+        $contentObject->setLogger(new NullLogger());
+        $subject = new EventHeadline([], $contentObject);
 
         $subject->render();
     }

--- a/Tests/Functional/FrontEnd/RegistrationFormTest.php
+++ b/Tests/Functional/FrontEnd/RegistrationFormTest.php
@@ -8,6 +8,7 @@ use Nimut\TestingFramework\TestCase\FunctionalTestCase;
 use OliverKlee\Oelib\System\Typo3Version;
 use OliverKlee\Seminars\FrontEnd\RegistrationForm;
 use OliverKlee\Seminars\OldModel\LegacyEvent;
+use Psr\Log\NullLogger;
 use TYPO3\CMS\Core\Http\Uri;
 use TYPO3\CMS\Core\Site\Entity\SiteLanguage;
 use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
@@ -52,7 +53,9 @@ final class RegistrationFormTest extends FunctionalTestCase
         $frontEnd = $frontEndProphecy->reveal();
         $GLOBALS['TSFE'] = $frontEnd;
 
-        $this->contentObject = $this->prophesize(ContentObjectRenderer::class)->reveal();
+        $contentObject = new ContentObjectRenderer();
+        $contentObject->setLogger(new NullLogger());
+        $this->contentObject = $contentObject;
         $this->subject = new RegistrationForm([], $this->contentObject);
         $this->subject->setTestMode();
     }

--- a/Tests/LegacyUnit/FrontEnd/DefaultControllerTest.php
+++ b/Tests/LegacyUnit/FrontEnd/DefaultControllerTest.php
@@ -30,6 +30,7 @@ use OliverKlee\Seminars\Tests\Functional\Traits\LanguageHelper;
 use OliverKlee\Seminars\Tests\LegacyUnit\Fixtures\OldModel\TestingLegacyEvent;
 use OliverKlee\Seminars\Tests\LegacyUnit\FrontEnd\Fixtures\TestingDefaultController;
 use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Log\NullLogger;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
@@ -175,12 +176,11 @@ final class DefaultControllerTest extends TestCase
             ->willReturn('index.php?id=42&tx_seminars_pi1%5BshowUid%5D=1337');
         $this->subject->injectLinkBuilder($linkBuilder);
 
-        /** @var ContentObjectRenderer&MockObject $content */
-        $content = $this->createPartialMock(ContentObjectRenderer::class, ['IMAGE', 'cObjGetSingle']);
-        $content->method('cObjGetSingle')->willReturn(
-            '<img src="foo.jpg" alt="bar"/>'
-        );
-        $this->subject->cObj = $content;
+        /** @var ContentObjectRenderer&MockObject $contentObject */
+        $contentObject = $this->createPartialMock(ContentObjectRenderer::class, ['IMAGE', 'cObjGetSingle']);
+        $contentObject->setLogger(new NullLogger());
+        $contentObject->method('cObjGetSingle')->willReturn('<img src="foo.jpg" alt="bar"/>');
+        $this->subject->cObj = $contentObject;
 
         $this->connectionPool = GeneralUtility::makeInstance(ConnectionPool::class);
     }
@@ -345,6 +345,7 @@ final class DefaultControllerTest extends TestCase
     {
         /** @var ContentObjectRenderer&MockObject $mock */
         $mock = $this->createPartialMock(ContentObjectRenderer::class, ['getTypoLink']);
+        $mock->setLogger(new NullLogger());
         $mock->method('getTypoLink')->willReturnCallback([$this, 'getTypoLink']);
 
         return $mock;

--- a/Tests/LegacyUnit/Service/SingleViewLinkBuilderTest.php
+++ b/Tests/LegacyUnit/Service/SingleViewLinkBuilderTest.php
@@ -14,6 +14,7 @@ use OliverKlee\Seminars\Mapper\EventMapper;
 use OliverKlee\Seminars\Model\Event;
 use OliverKlee\Seminars\Tests\LegacyUnit\Fixtures\Service\TestingSingleViewLinkBuilder;
 use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Log\NullLogger;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
 use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
@@ -341,6 +342,7 @@ final class SingleViewLinkBuilderTest extends TestCase
             ->willReturn($eventUid);
 
         $contentObject = $this->createPartialMock(ContentObjectRenderer::class, ['typoLink_URL']);
+        $contentObject->setLogger(new NullLogger());
         $contentObject->expects(self::once())->method('typoLink_URL')
             ->with(
                 [
@@ -371,6 +373,7 @@ final class SingleViewLinkBuilderTest extends TestCase
         $relativeUrl = 'index.php?id=42&tx_seminars%5BshowUid%5D=17';
 
         $contentObject = $this->createPartialMock(ContentObjectRenderer::class, ['typoLink_URL']);
+        $contentObject->setLogger(new NullLogger());
         $contentObject->expects(self::once())->method('typoLink_URL')
             ->willReturn($relativeUrl);
 


### PR DESCRIPTION
This prevents crashes when there are problems building a link, and helps
debugging those tests.