### PR TITLE
[TASK] Allow installations with Emogrifier 5.x and 6.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Add support for TYPO3 10LTS (#1136)
 
 ### Changed
+- Allow installations with Emogrifier 5.x and 6.x (#1147)
 - Require oelib >= 4.1 (#1143, #1146)
 
 ### Deprecated

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
 		"digedag/rn-base": "~1.13.15 || ~1.14.0",
 		"dmk/mkforms": "^10.0.2",
 		"oliverklee/oelib": "^4.1.0",
-		"pelago/emogrifier": "^4.0.0",
+		"pelago/emogrifier": "^4.0.0 || ^5.0.1 || ^6.0.0",
 		"psr/http-message": "^1.0",
 		"simshaun/recurr": "^5.0.0",
 		"sjbr/static-info-tables": "^6.9.5",


### PR DESCRIPTION
The current version is 6.0.0, but we shouldn't block installations that
only can use 4.x or 5.x at this time.

Fixes #865