### PR TITLE
[BUGFIX] Use the email abstractions in the functional tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Removed
 
 ### Fixed
-- Use the new mailer in TYPO3 10LTS (#1153, #1157, #1158)
+- Use the new mailer in TYPO3 10LTS (#1153, #1157, #1158, #1161)
 - Properly disable the Core cache in V10 in the tests (#1148)
 - Provide the `ContentObjectRenderer` with a logger in the tests (#1145)
 - Set up a site language for the fake frontend in tests (#1139)

--- a/Tests/Functional/BackEnd/AbstractEventMailFormTest.php
+++ b/Tests/Functional/BackEnd/AbstractEventMailFormTest.php
@@ -130,7 +130,7 @@ final class AbstractEventMailFormTest extends FunctionalTestCase
         );
         $subject->render();
 
-        self::assertStringContainsString('Joe Johnson', $this->email->getBody());
+        self::assertStringContainsString('Joe Johnson', $this->getTextBodyOfEmail($this->email));
     }
 
     /**
@@ -156,7 +156,7 @@ final class AbstractEventMailFormTest extends FunctionalTestCase
         $this->addMockedInstance(MailMessage::class, $this->email);
         $subject->render();
 
-        self::assertArrayHasKey('system-foo@example.com', $this->email->getFrom());
+        self::assertArrayHasKey('system-foo@example.com', $this->getFromOfEmail($this->email));
     }
 
     /**
@@ -183,7 +183,7 @@ final class AbstractEventMailFormTest extends FunctionalTestCase
         $this->addMockedInstance(MailMessage::class, $this->email);
         $subject->render();
 
-        self::assertArrayHasKey('oliver@example.com', $this->email->getFrom());
+        self::assertArrayHasKey('oliver@example.com', $this->getFromOfEmail($this->email));
     }
 
     /**
@@ -208,9 +208,7 @@ final class AbstractEventMailFormTest extends FunctionalTestCase
         $this->addMockedInstance(MailMessage::class, $this->email);
         $subject->render();
 
-        /** @var array<string, string> $replyTo */
-        $replyTo = $this->email->getReplyTo();
-        self::assertArrayHasKey('oliver@example.com', $replyTo);
+        self::assertArrayHasKey('oliver@example.com', $this->getReplyToOfEmail($this->email));
     }
 
     /**
@@ -236,7 +234,7 @@ final class AbstractEventMailFormTest extends FunctionalTestCase
         );
         $subject->render();
 
-        self::assertStringContainsString("\n-- \nThe one and only", $this->email->getBody());
+        self::assertStringContainsString("\n-- \nThe one and only", $this->getTextBodyOfEmail($this->email));
     }
 
     /**

--- a/Tests/Functional/BackEnd/CancelEventMailFormTest.php
+++ b/Tests/Functional/BackEnd/CancelEventMailFormTest.php
@@ -152,6 +152,6 @@ final class CancelEventMailFormTest extends FunctionalTestCase
 
         $subject->render();
 
-        self::assertStringContainsString('Joe Johnson', $this->email->getBody());
+        self::assertStringContainsString('Joe Johnson', $this->getTextBodyOfEmail($this->email));
     }
 }

--- a/Tests/Functional/BackEnd/ConfirmEventMailFormTest.php
+++ b/Tests/Functional/BackEnd/ConfirmEventMailFormTest.php
@@ -154,6 +154,6 @@ final class ConfirmEventMailFormTest extends FunctionalTestCase
 
         $subject->render();
 
-        self::assertStringContainsString('Joe Johnson', $this->email->getBody());
+        self::assertStringContainsString('Joe Johnson', $this->getTextBodyOfEmail($this->email));
     }
 }

--- a/Tests/Functional/BackEnd/GeneralEventMailFormTest.php
+++ b/Tests/Functional/BackEnd/GeneralEventMailFormTest.php
@@ -128,6 +128,6 @@ final class GeneralEventMailFormTest extends FunctionalTestCase
 
         $subject->render();
 
-        self::assertStringContainsString('Joe Johnson', $this->email->getBody());
+        self::assertStringContainsString('Joe Johnson', $this->getTextBodyOfEmail($this->email));
     }
 }

--- a/Tests/Functional/Service/RegistrationManagerTest.php
+++ b/Tests/Functional/Service/RegistrationManagerTest.php
@@ -84,6 +84,6 @@ final class RegistrationManagerTest extends FunctionalTestCase
         $this->subject->notifyOrganizers($registration);
 
         $expectedExpression = '/' . $this->getLanguageService()->getLL('label_vacancies') . ': 1\\n*$/';
-        self::assertRegExp($expectedExpression, $this->email->getBody());
+        self::assertRegExp($expectedExpression, $this->getTextBodyOfEmail($this->email));
     }
 }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -256,17 +256,7 @@ parameters:
 			path: Tests/Functional/BackEnd/AbstractEventMailFormTest.php
 
 		-
-			message: "#^Parameter \\#2 \\$haystack of static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertStringContainsString\\(\\) expects string, Symfony\\\\Component\\\\Mime\\\\Part\\\\AbstractPart given\\.$#"
-			count: 2
-			path: Tests/Functional/BackEnd/AbstractEventMailFormTest.php
-
-		-
 			message: "#^PHPDoc tag @var for variable \\$statement has no value type specified in iterable type Doctrine\\\\DBAL\\\\Driver\\\\Statement\\.$#"
-			count: 1
-			path: Tests/Functional/BackEnd/CancelEventMailFormTest.php
-
-		-
-			message: "#^Parameter \\#2 \\$haystack of static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertStringContainsString\\(\\) expects string, Symfony\\\\Component\\\\Mime\\\\Part\\\\AbstractPart given\\.$#"
 			count: 1
 			path: Tests/Functional/BackEnd/CancelEventMailFormTest.php
 
@@ -274,16 +264,6 @@ parameters:
 			message: "#^PHPDoc tag @var for variable \\$statement has no value type specified in iterable type Doctrine\\\\DBAL\\\\Driver\\\\Statement\\.$#"
 			count: 1
 			path: Tests/Functional/BackEnd/ConfirmEventMailFormTest.php
-
-		-
-			message: "#^Parameter \\#2 \\$haystack of static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertStringContainsString\\(\\) expects string, Symfony\\\\Component\\\\Mime\\\\Part\\\\AbstractPart given\\.$#"
-			count: 1
-			path: Tests/Functional/BackEnd/ConfirmEventMailFormTest.php
-
-		-
-			message: "#^Parameter \\#2 \\$haystack of static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertStringContainsString\\(\\) expects string, Symfony\\\\Component\\\\Mime\\\\Part\\\\AbstractPart given\\.$#"
-			count: 1
-			path: Tests/Functional/BackEnd/GeneralEventMailFormTest.php
 
 		-
 			message: "#^Method OliverKlee\\\\Seminars\\\\Tests\\\\Functional\\\\Bag\\\\SpeakerBagTest\\:\\:assertBagHasUid\\(\\) has parameter \\$bag with generic class OliverKlee\\\\Seminars\\\\Bag\\\\AbstractBag but does not specify its types\\: M$#"
@@ -369,11 +349,6 @@ parameters:
 			message: "#^PHPDoc tag @var for variable \\$objectManager contains generic class TYPO3\\\\CMS\\\\Extbase\\\\Object\\\\ObjectManager but does not specify its types\\: T$#"
 			count: 1
 			path: Tests/Functional/SchedulerTasks/RegistrationDigestTest.php
-
-		-
-			message: "#^Parameter \\#2 \\$string of static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertRegExp\\(\\) expects string, Symfony\\\\Component\\\\Mime\\\\Part\\\\AbstractPart given\\.$#"
-			count: 1
-			path: Tests/Functional/Service/RegistrationManagerTest.php
 
 		-
 			message: "#^Property OliverKlee\\\\Seminars\\\\Tests\\\\LegacyUnit\\\\BackEnd\\\\AbstractEventMailFormTest\\:\\:\\$extConfBackup type has no value type specified in iterable type array\\.$#"


### PR DESCRIPTION
This fixes the email tests in the functional tests in V10.

Part of #1109