### PR TITLE
[BUGFIX] Use the email abstractions in the legacy tests (part 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Removed
 
 ### Fixed
-- Use the new mailer in TYPO3 10LTS (#1153, #1157, #1158, #1161)
+- Use the new mailer in TYPO3 10LTS (#1153, #1157, #1158, #1161, #1163)
 - Properly disable the Core cache in V10 in the tests (#1148)
 - Provide the `ContentObjectRenderer` with a logger in the tests (#1145)
 - Fix the test setup (language, frontend) (#1139, #1162)

--- a/Tests/LegacyUnit/FrontEnd/EventEditorTest.php
+++ b/Tests/LegacyUnit/FrontEnd/EventEditorTest.php
@@ -1668,10 +1668,7 @@ final class EventEditorTest extends TestCase
 
         $this->subject->sendEmailToReviewer();
 
-        self::assertArrayHasKey(
-            'foo@bar.com',
-            $this->email->getTo()
-        );
+        self::assertArrayHasKey('foo@bar.com', $this->getToOfEmail($this->email));
     }
 
     /**
@@ -1735,10 +1732,7 @@ final class EventEditorTest extends TestCase
 
         $this->subject->sendEmailToReviewer();
 
-        self::assertStringContainsString(
-            'foo Event',
-            $this->email->getBody()
-        );
+        self::assertStringContainsString('foo Event', $this->getTextBodyOfEmail($this->email));
     }
 
     /**
@@ -1771,12 +1765,12 @@ final class EventEditorTest extends TestCase
 
         $this->subject->sendEmailToReviewer();
 
-        self::assertContains(
-            strftime(
+        self::assertStringContainsString(
+            \strftime(
                 $this->subject->getConfValueString('dateFormatYMD'),
                 $GLOBALS['SIM_EXEC_TIME']
             ),
-            $this->email->getBody()
+            $this->getTextBodyOfEmail($this->email)
         );
     }
 
@@ -1809,10 +1803,7 @@ final class EventEditorTest extends TestCase
 
         $this->subject->sendEmailToReviewer();
 
-        self::assertStringNotContainsString(
-            '###PUBLISH_EVENT_DATE###',
-            $this->email->getBody()
-        );
+        self::assertStringNotContainsString('###PUBLISH_EVENT_DATE###', $this->getTextBodyOfEmail($this->email));
     }
 
     /**
@@ -1845,10 +1836,7 @@ final class EventEditorTest extends TestCase
 
         $this->subject->sendEmailToReviewer();
 
-        self::assertStringNotContainsString(
-            'foo event,',
-            $this->email->getBody()
-        );
+        self::assertStringNotContainsString('foo event,', $this->getTextBodyOfEmail($this->email));
     }
 
     /**
@@ -1879,10 +1867,7 @@ final class EventEditorTest extends TestCase
 
         $this->subject->sendEmailToReviewer();
 
-        self::assertStringNotContainsString(
-            '###',
-            $this->email->getBody()
-        );
+        self::assertStringNotContainsString('###', $this->getTextBodyOfEmail($this->email));
     }
 
     /**
@@ -1914,10 +1899,7 @@ final class EventEditorTest extends TestCase
 
         $this->subject->sendEmailToReviewer();
 
-        self::assertStringContainsString(
-            'Foo Description',
-            $this->email->getBody()
-        );
+        self::assertStringContainsString('Foo Description', $this->getTextBodyOfEmail($this->email));
     }
 
     /**
@@ -1950,7 +1932,7 @@ final class EventEditorTest extends TestCase
 
         self::assertStringContainsString(
             'tx_seminars_publication%5Bhash%5D=' . $formData['publication_hash'],
-            $this->email->getBody()
+            $this->getTextBodyOfEmail($this->email)
         );
     }
 
@@ -1985,10 +1967,7 @@ final class EventEditorTest extends TestCase
 
         $this->subject->sendEmailToReviewer();
 
-        self::assertContains(
-            $defaultFromName,
-            $this->email->getFrom()
-        );
+        self::assertContains($defaultFromName, $this->getFromOfEmail($this->email));
     }
 
     /**
@@ -2020,9 +1999,7 @@ final class EventEditorTest extends TestCase
 
         $this->subject->sendEmailToReviewer();
 
-        /** @var array<string, string> $replyTo */
-        $replyTo = $this->email->getReplyTo();
-        self::assertSame(['mail@foo.com' => 'Mr. Bar'], $replyTo);
+        self::assertSame(['mail@foo.com' => 'Mr. Bar'], $this->getReplyToOfEmail($this->email));
     }
 
     /**
@@ -2054,10 +2031,7 @@ final class EventEditorTest extends TestCase
 
         $this->subject->sendEmailToReviewer();
 
-        self::assertContains(
-            'Mr. Bar',
-            $this->email->getFrom()
-        );
+        self::assertContains('Mr. Bar', $this->getFromOfEmail($this->email));
     }
 
     /**
@@ -2089,10 +2063,7 @@ final class EventEditorTest extends TestCase
 
         $this->subject->sendEmailToReviewer();
 
-        self::assertArrayHasKey(
-            'mail@foo.com',
-            $this->email->getFrom()
-        );
+        self::assertArrayHasKey('mail@foo.com', $this->getFromOfEmail($this->email));
     }
 
     // Tests concerning the notification e-mails
@@ -2156,10 +2127,7 @@ final class EventEditorTest extends TestCase
 
         $this->subject->sendAdditionalNotificationEmailToReviewer();
 
-        self::assertArrayHasKey(
-            'foo@bar.com',
-            $this->email->getTo()
-        );
+        self::assertArrayHasKey('foo@bar.com', $this->getToOfEmail($this->email));
     }
 
     /**
@@ -2181,10 +2149,7 @@ final class EventEditorTest extends TestCase
 
         $this->subject->sendAdditionalNotificationEmailToReviewer();
 
-        self::assertContains(
-            $defaultMailFromName,
-            $this->email->getFrom()
-        );
+        self::assertContains($defaultMailFromName, $this->getFromOfEmail($this->email));
     }
 
     /**
@@ -2206,10 +2171,7 @@ final class EventEditorTest extends TestCase
 
         $this->subject->sendAdditionalNotificationEmailToReviewer();
 
-        self::assertArrayHasKey(
-            $defaultMailFromAddress,
-            $this->email->getFrom()
-        );
+        self::assertArrayHasKey($defaultMailFromAddress, $this->getFromOfEmail($this->email));
     }
 
     /**
@@ -2229,9 +2191,7 @@ final class EventEditorTest extends TestCase
 
         $this->subject->sendAdditionalNotificationEmailToReviewer();
 
-        /** @var array<string, string> $replyTo */
-        $replyTo = $this->email->getReplyTo();
-        self::assertSame(['mail@foo.com' => 'Mr. Bar'], $replyTo);
+        self::assertSame(['mail@foo.com' => 'Mr. Bar'], $this->getReplyToOfEmail($this->email));
     }
 
     /**
@@ -2251,10 +2211,7 @@ final class EventEditorTest extends TestCase
 
         $this->subject->sendAdditionalNotificationEmailToReviewer();
 
-        self::assertContains(
-            'Mr. Bar',
-            $this->email->getFrom()
-        );
+        self::assertContains('Mr. Bar', $this->getFromOfEmail($this->email));
     }
 
     /**
@@ -2274,10 +2231,7 @@ final class EventEditorTest extends TestCase
 
         $this->subject->sendAdditionalNotificationEmailToReviewer();
 
-        self::assertArrayHasKey(
-            'mail@foo.com',
-            $this->email->getFrom()
-        );
+        self::assertArrayHasKey('mail@foo.com', $this->getFromOfEmail($this->email));
     }
 
     /**
@@ -2316,7 +2270,7 @@ final class EventEditorTest extends TestCase
 
         self::assertStringContainsString(
             $this->getLanguageService()->getLL('label_save_event_text'),
-            $this->email->getBody()
+            $this->getTextBodyOfEmail($this->email)
         );
     }
 
@@ -2336,7 +2290,7 @@ final class EventEditorTest extends TestCase
 
         self::assertStringContainsString(
             $this->getLanguageService()->getLL('label_save_event_overview'),
-            $this->email->getBody()
+            $this->getTextBodyOfEmail($this->email)
         );
     }
 
@@ -2356,7 +2310,7 @@ final class EventEditorTest extends TestCase
 
         self::assertStringNotContainsString(
             '###',
-            $this->email->getBody()
+            $this->getTextBodyOfEmail($this->email)
         );
     }
 
@@ -2377,10 +2331,7 @@ final class EventEditorTest extends TestCase
 
         $this->subject->sendAdditionalNotificationEmailToReviewer();
 
-        self::assertStringContainsString(
-            $title,
-            $this->email->getBody()
-        );
+        self::assertStringContainsString($title, $this->getTextBodyOfEmail($this->email));
     }
 
     /**
@@ -2400,10 +2351,7 @@ final class EventEditorTest extends TestCase
 
         $this->subject->sendAdditionalNotificationEmailToReviewer();
 
-        self::assertStringContainsString(
-            $description,
-            $this->email->getBody()
-        );
+        self::assertStringContainsString($description, $this->getTextBodyOfEmail($this->email));
     }
 
     /**
@@ -2424,10 +2372,7 @@ final class EventEditorTest extends TestCase
 
         $this->subject->sendAdditionalNotificationEmailToReviewer();
 
-        self::assertStringContainsString(
-            '02.04.1975',
-            $this->email->getBody()
-        );
+        self::assertStringContainsString('02.04.1975', $this->getTextBodyOfEmail($this->email));
     }
 
     ///////////////////////////////////////////

--- a/Tests/LegacyUnit/SchedulerTasks/MailNotifierTest.php
+++ b/Tests/LegacyUnit/SchedulerTasks/MailNotifierTest.php
@@ -541,7 +541,7 @@ final class MailNotifierTest extends TestCase
 
         self::assertContains(
             substr($message, 0, strpos($message, '%') - 1),
-            $this->email->getBody()
+            $this->getTextBodyOfEmail($this->email)
         );
     }
 
@@ -810,7 +810,7 @@ final class MailNotifierTest extends TestCase
 
         self::assertContains(
             substr($message, 0, strpos($message, '%') - 1),
-            $this->email->getBody()
+            $this->getTextBodyOfEmail($this->email)
         );
     }
 
@@ -1048,10 +1048,7 @@ final class MailNotifierTest extends TestCase
 
         $this->subject->sendEventTakesPlaceReminders();
 
-        self::assertArrayHasKey(
-            'MrTest@example.com',
-            $this->email->getTo()
-        );
+        self::assertArrayHasKey('MrTest@example.com', $this->getToOfEmail($this->email));
     }
 
     /**
@@ -1076,10 +1073,7 @@ final class MailNotifierTest extends TestCase
 
         $this->subject->sendEventTakesPlaceReminders();
 
-        self::assertArrayHasKey(
-            $defaultMailFromAddress,
-            $this->email->getFrom()
-        );
+        self::assertArrayHasKey($defaultMailFromAddress, $this->getFromOfEmail($this->email));
     }
 
     /**
@@ -1111,10 +1105,7 @@ final class MailNotifierTest extends TestCase
 
         $this->subject->sendEventTakesPlaceReminders();
 
-        self::assertArrayHasKey(
-            $defaultMailFromAddress,
-            $this->email->getFrom()
-        );
+        self::assertArrayHasKey($defaultMailFromAddress, $this->getFromOfEmail($this->email));
     }
 
     /**
@@ -1144,9 +1135,7 @@ final class MailNotifierTest extends TestCase
 
         $this->subject->sendEventTakesPlaceReminders();
 
-        /** @var array<string, string> $replyTo */
-        $replyTo = $this->email->getReplyTo();
-        self::assertSame(['MrTest@example.com' => 'Mr. Test'], $replyTo);
+        self::assertSame(['MrTest@example.com' => 'Mr. Test'], $this->getReplyToOfEmail($this->email));
     }
 
     /**
@@ -1169,10 +1158,7 @@ final class MailNotifierTest extends TestCase
 
         $this->subject->sendEventTakesPlaceReminders();
 
-        self::assertArrayHasKey(
-            'MrTest@example.com',
-            $this->email->getFrom()
-        );
+        self::assertArrayHasKey('MrTest@example.com', $this->getFromOfEmail($this->email));
     }
 
     /**
@@ -1202,10 +1188,7 @@ final class MailNotifierTest extends TestCase
 
         $this->subject->sendEventTakesPlaceReminders();
 
-        self::assertArrayHasKey(
-            'MrTest@example.com',
-            $this->email->getFrom()
-        );
+        self::assertArrayHasKey('MrTest@example.com', $this->getFromOfEmail($this->email));
     }
 
     // attached CSV
@@ -1522,10 +1505,7 @@ final class MailNotifierTest extends TestCase
 
         $this->subject->sendEventTakesPlaceReminders();
 
-        self::assertStringContainsString(
-            'Mr. Test',
-            $this->email->getBody()
-        );
+        self::assertStringContainsString('Mr. Test', $this->getTextBodyOfEmail($this->email));
     }
 
     /**
@@ -1546,10 +1526,7 @@ final class MailNotifierTest extends TestCase
 
         $this->subject->sendEventTakesPlaceReminders();
 
-        self::assertStringContainsString(
-            'test event',
-            $this->email->getBody()
-        );
+        self::assertStringContainsString('test event', $this->getTextBodyOfEmail($this->email));
     }
 
     /**
@@ -1569,10 +1546,7 @@ final class MailNotifierTest extends TestCase
 
         $this->subject->sendEventTakesPlaceReminders();
 
-        self::assertStringContainsString(
-            (string)$uid,
-            $this->email->getBody()
-        );
+        self::assertStringContainsString((string)$uid, $this->getTextBodyOfEmail($this->email));
     }
 
     /**
@@ -1592,10 +1566,7 @@ final class MailNotifierTest extends TestCase
 
         $this->subject->sendEventTakesPlaceReminders();
 
-        self::assertStringContainsString(
-            '2',
-            $this->email->getBody()
-        );
+        self::assertStringContainsString('2', $this->getTextBodyOfEmail($this->email));
     }
 
     /**
@@ -1622,7 +1593,7 @@ final class MailNotifierTest extends TestCase
                 $this->configuration->getAsString('dateFormatYMD'),
                 $GLOBALS['SIM_EXEC_TIME'] + Time::SECONDS_PER_DAY
             ),
-            $this->email->getBody()
+            $this->getTextBodyOfEmail($this->email)
         );
     }
 
@@ -1643,10 +1614,7 @@ final class MailNotifierTest extends TestCase
 
         $this->subject->sendEventTakesPlaceReminders();
 
-        self::assertStringContainsString(
-            '0',
-            $this->email->getBody()
-        );
+        self::assertStringContainsString('0', $this->getTextBodyOfEmail($this->email));
     }
 
     /**
@@ -1674,10 +1642,7 @@ final class MailNotifierTest extends TestCase
 
         $this->subject->sendEventTakesPlaceReminders();
 
-        self::assertStringContainsString(
-            '1',
-            $this->email->getBody()
-        );
+        self::assertStringContainsString('1', $this->getTextBodyOfEmail($this->email));
     }
 
     /**

--- a/Tests/LegacyUnit/Service/EmailServiceTest.php
+++ b/Tests/LegacyUnit/Service/EmailServiceTest.php
@@ -166,10 +166,7 @@ final class EmailServiceTest extends TestCase
 
         $this->subject->sendEmailToAttendees($this->event, 'Bonjour!', 'Hello!');
 
-        self::assertArrayHasKey(
-            $defaultMailFromAddress,
-            $this->email->getFrom()
-        );
+        self::assertArrayHasKey($defaultMailFromAddress, $this->getFromOfEmail($this->email));
     }
 
     /**
@@ -185,9 +182,7 @@ final class EmailServiceTest extends TestCase
 
         $this->subject->sendEmailToAttendees($this->event, 'Bonjour!', 'Hello!');
 
-        /** @var array<string, string> $replyTo */
-        $replyTo = $this->email->getReplyTo();
-        self::assertSame($this->organizer->getEmailAddress(), \key($replyTo));
+        self::assertArrayHasKey($this->organizer->getEmailAddress(), $this->getReplyToOfEmail($this->email));
     }
 
     /**
@@ -203,10 +198,7 @@ final class EmailServiceTest extends TestCase
 
         $this->subject->sendEmailToAttendees($this->event, 'Bonjour!', 'Hello!');
 
-        self::assertArrayHasKey(
-            $this->organizer->getEmailAddress(),
-            $this->email->getFrom()
-        );
+        self::assertArrayHasKey($this->organizer->getEmailAddress(), $this->getFromOfEmail($this->email));
     }
 
     /**
@@ -277,10 +269,7 @@ final class EmailServiceTest extends TestCase
         $this->email->expects(self::once())->method('send');
         $this->subject->sendEmailToAttendees($this->event, 'Bonjour!', $body);
 
-        self::assertStringContainsString(
-            $body,
-            $this->email->getBody()
-        );
+        self::assertStringContainsString($body, $this->getTextBodyOfEmail($this->email));
     }
 
     /**
@@ -295,7 +284,7 @@ final class EmailServiceTest extends TestCase
 
         self::assertSame(
             [$this->user->getEmailAddress() => $this->user->getName()],
-            $this->email->getTo()
+            $this->getToOfEmail($this->email)
         );
     }
 
@@ -362,10 +351,7 @@ final class EmailServiceTest extends TestCase
         $this->email->expects(self::once())->method('send');
         $this->subject->sendEmailToAttendees($this->event, 'Bonjour!', '%salutation (This was the salutation)');
 
-        self::assertStringContainsString(
-            $this->user->getName(),
-            $this->email->getBody()
-        );
+        self::assertStringContainsString($this->user->getName(), $this->getTextBodyOfEmail($this->email));
     }
 
     /**
@@ -380,7 +366,7 @@ final class EmailServiceTest extends TestCase
 
         self::assertStringContainsString(
             'Hello ' . $this->user->getName() . '!',
-            $this->email->getBody()
+            $this->getTextBodyOfEmail($this->email)
         );
     }
 
@@ -396,7 +382,7 @@ final class EmailServiceTest extends TestCase
 
         self::assertStringContainsString(
             'Event: ' . $this->event->getTitle(),
-            $this->email->getBody()
+            $this->getTextBodyOfEmail($this->email)
         );
     }
 
@@ -414,7 +400,7 @@ final class EmailServiceTest extends TestCase
 
         self::assertStringContainsString(
             'Date: ' . $formattedDate,
-            $this->email->getBody()
+            $this->getTextBodyOfEmail($this->email)
         );
     }
 
@@ -432,7 +418,7 @@ final class EmailServiceTest extends TestCase
 
         self::assertStringNotContainsString(
             '-- ',
-            $this->email->getBody()
+            $this->getTextBodyOfEmail($this->email)
         );
     }
 
@@ -448,7 +434,7 @@ final class EmailServiceTest extends TestCase
 
         self::assertStringContainsString(
             "\n-- \n" . $this->organizer->getEmailFooter(),
-            $this->email->getBody()
+            $this->getTextBodyOfEmail($this->email)
         );
     }
 }

--- a/Tests/LegacyUnit/Service/RegistrationManagerTest.php
+++ b/Tests/LegacyUnit/Service/RegistrationManagerTest.php
@@ -2082,10 +2082,7 @@ final class RegistrationManagerTest extends TestCase
         $registration = $this->createRegistration();
         $this->subject->notifyAttendee($registration, $pi1);
 
-        self::assertArrayHasKey(
-            'foo@bar.com',
-            $this->email->getTo()
-        );
+        self::assertArrayHasKey('foo@bar.com', $this->getToOfEmail($this->email));
     }
 
     /**
@@ -2221,10 +2218,7 @@ final class RegistrationManagerTest extends TestCase
         $registration = $this->createRegistration();
         $this->subject->notifyAttendee($registration, $pi1);
 
-        self::assertStringContainsString(
-            'test event',
-            $this->email->getBody()
-        );
+        self::assertStringContainsString('test event', $this->getTextBodyOfEmail($this->email));
     }
 
     /**
@@ -2239,9 +2233,7 @@ final class RegistrationManagerTest extends TestCase
         $registration = $this->createRegistration();
         $this->subject->notifyAttendee($registration, $pi1);
 
-        $this->assertNotContainsRawLabelKey(
-            $this->email->getBody()
-        );
+        $this->assertNotContainsRawLabelKey($this->getTextBodyOfEmail($this->email));
     }
 
     /**
@@ -2256,9 +2248,7 @@ final class RegistrationManagerTest extends TestCase
         $registration = $this->createRegistration();
         $this->subject->notifyAttendee($registration, $pi1);
 
-        $result = $this->email->getBody();
-
-        self::assertStringNotContainsString(' ,', $result);
+        self::assertStringNotContainsString(' ,', $this->getTextBodyOfEmail($this->email));
     }
 
     /**
@@ -2273,10 +2263,7 @@ final class RegistrationManagerTest extends TestCase
         $registration = $this->createRegistration();
         $this->subject->notifyAttendee($registration, $pi1);
 
-        self::assertStringContainsString(
-            'something nice to eat',
-            $this->email->getBody()
-        );
+        self::assertStringContainsString('something nice to eat', $this->getTextBodyOfEmail($this->email));
     }
 
     /**
@@ -2291,10 +2278,7 @@ final class RegistrationManagerTest extends TestCase
         $registration = $this->createRegistration();
         $this->subject->notifyAttendee($registration, $pi1);
 
-        self::assertStringContainsString(
-            'a nice, dry place',
-            $this->email->getBody()
-        );
+        self::assertStringContainsString('a nice, dry place', $this->getTextBodyOfEmail($this->email));
     }
 
     /**
@@ -2309,10 +2293,7 @@ final class RegistrationManagerTest extends TestCase
         $registration = $this->createRegistration();
         $this->subject->notifyAttendee($registration, $pi1);
 
-        self::assertStringContainsString(
-            'learning Ruby on Rails',
-            $this->email->getBody()
-        );
+        self::assertStringContainsString('learning Ruby on Rails', $this->getTextBodyOfEmail($this->email));
     }
 
     /**
@@ -2373,9 +2354,7 @@ final class RegistrationManagerTest extends TestCase
 
         $this->subject->notifyAttendee($registration, $pi1);
 
-        /** @var array<string, string> $replyTo */
-        $replyTo = $this->email->getReplyTo();
-        self::assertSame(['mail@example.com' => 'test organizer'], $replyTo);
+        self::assertSame(['mail@example.com' => 'test organizer'], $this->getReplyToOfEmail($this->email));
     }
 
     /**
@@ -2450,10 +2429,7 @@ final class RegistrationManagerTest extends TestCase
         $registration = $this->createRegistration();
         $this->subject->notifyAttendee($registration, $pi1);
 
-        self::assertStringNotContainsString(
-            '###',
-            $this->email->getBody()
-        );
+        self::assertStringNotContainsString('###', $this->getTextBodyOfEmail($this->email));
     }
 
     /**
@@ -2589,10 +2565,7 @@ final class RegistrationManagerTest extends TestCase
         $registration = $this->createRegistration();
         $this->subject->notifyAttendee($registration, $pi1);
 
-        self::assertStringContainsString(
-            "\n-- \norganizer footer",
-            $this->email->getBody()
-        );
+        self::assertStringContainsString("\n-- \norganizer footer", $this->getTextBodyOfEmail($this->email));
     }
 
     /**
@@ -2613,7 +2586,7 @@ final class RegistrationManagerTest extends TestCase
 
         self::assertStringNotContainsString(
             $this->getLanguageService()->getLL('label_planned_disclaimer'),
-            $this->email->getBody()
+            $this->getTextBodyOfEmail($this->email)
         );
     }
 
@@ -2635,7 +2608,7 @@ final class RegistrationManagerTest extends TestCase
 
         self::assertStringNotContainsString(
             $this->getLanguageService()->getLL('label_planned_disclaimer'),
-            $this->email->getBody()
+            $this->getTextBodyOfEmail($this->email)
         );
     }
 
@@ -2657,7 +2630,7 @@ final class RegistrationManagerTest extends TestCase
 
         self::assertStringContainsString(
             $this->getLanguageService()->getLL('label_planned_disclaimer'),
-            $this->email->getBody()
+            $this->getTextBodyOfEmail($this->email)
         );
     }
 
@@ -2680,7 +2653,7 @@ final class RegistrationManagerTest extends TestCase
 
         self::assertStringNotContainsString(
             $this->getLanguageService()->getLL('label_planned_disclaimer'),
-            $this->email->getBody()
+            $this->getTextBodyOfEmail($this->email)
         );
     }
 
@@ -2722,10 +2695,7 @@ final class RegistrationManagerTest extends TestCase
         $registration->setAttendeesNames('foo1 foo2');
         $this->subject->notifyAttendee($registration, $pi1);
 
-        self::assertStringContainsString(
-            'foo1 foo2',
-            $this->email->getBody()
-        );
+        self::assertStringContainsString('foo1 foo2', $this->getTextBodyOfEmail($this->email));
     }
 
     /**
@@ -2741,10 +2711,7 @@ final class RegistrationManagerTest extends TestCase
         $registration->setAttendeesNames("foo1\nfoo2");
         $this->subject->notifyAttendee($registration, $pi1);
 
-        self::assertStringContainsString(
-            "1. foo1\n2. foo2",
-            $this->email->getBody()
-        );
+        self::assertStringContainsString("1. foo1\n2. foo2", $this->getTextBodyOfEmail($this->email));
     }
 
     /**
@@ -2796,10 +2763,7 @@ final class RegistrationManagerTest extends TestCase
         $registration = $this->createRegistration();
         $this->subject->notifyAttendee($registration, $pi1);
 
-        self::assertStringContainsString(
-            'foo_place',
-            $this->email->getBody()
-        );
+        self::assertStringContainsString('foo_place', $this->getTextBodyOfEmail($this->email));
     }
 
     /**
@@ -2825,10 +2789,7 @@ final class RegistrationManagerTest extends TestCase
         $registration = $this->createRegistration();
         $this->subject->notifyAttendee($registration, $pi1);
 
-        self::assertStringContainsString(
-            'foo_street',
-            $this->email->getBody()
-        );
+        self::assertStringContainsString('foo_street', $this->getTextBodyOfEmail($this->email));
     }
 
     /**
@@ -2845,7 +2806,7 @@ final class RegistrationManagerTest extends TestCase
 
         self::assertStringContainsString(
             $this->getLanguageService()->getLL('message_willBeAnnounced'),
-            $this->email->getBody()
+            $this->getTextBodyOfEmail($this->email)
         );
     }
 
@@ -2874,7 +2835,7 @@ final class RegistrationManagerTest extends TestCase
 
         self::assertStringContainsString(
             "place_title\nplace_address",
-            $this->email->getBody()
+            $this->getTextBodyOfEmail($this->email)
         );
     }
 
@@ -2937,10 +2898,7 @@ final class RegistrationManagerTest extends TestCase
         $registration = $this->createRegistration();
         $this->subject->notifyAttendee($registration, $pi1);
 
-        self::assertStringContainsString(
-            "place_title\nplace_address",
-            $this->email->getBody()
-        );
+        self::assertStringContainsString("place_title\nplace_address", $this->getTextBodyOfEmail($this->email));
     }
 
     /**
@@ -2966,10 +2924,7 @@ final class RegistrationManagerTest extends TestCase
         $registration = $this->createRegistration();
         $this->subject->notifyAttendee($registration, $pi1);
 
-        self::assertStringContainsString(
-            'address1 address2',
-            $this->email->getBody()
-        );
+        self::assertStringContainsString('address1 address2', $this->getTextBodyOfEmail($this->email));
     }
 
     /**
@@ -2995,10 +2950,7 @@ final class RegistrationManagerTest extends TestCase
         $registration = $this->createRegistration();
         $this->subject->notifyAttendee($registration, $pi1);
 
-        self::assertStringContainsString(
-            'address1 address2',
-            $this->email->getBody()
-        );
+        self::assertStringContainsString('address1 address2', $this->getTextBodyOfEmail($this->email));
     }
 
     /**
@@ -3024,10 +2976,7 @@ final class RegistrationManagerTest extends TestCase
         $registration = $this->createRegistration();
         $this->subject->notifyAttendee($registration, $pi1);
 
-        self::assertStringContainsString(
-            'address1 address2',
-            $this->email->getBody()
-        );
+        self::assertStringContainsString('address1 address2', $this->getTextBodyOfEmail($this->email));
     }
 
     /**
@@ -3053,10 +3002,7 @@ final class RegistrationManagerTest extends TestCase
         $registration = $this->createRegistration();
         $this->subject->notifyAttendee($registration, $pi1);
 
-        self::assertStringContainsString(
-            'address1 address2',
-            $this->email->getBody()
-        );
+        self::assertStringContainsString('address1 address2', $this->getTextBodyOfEmail($this->email));
     }
 
     /**
@@ -3082,10 +3028,7 @@ final class RegistrationManagerTest extends TestCase
         $registration = $this->createRegistration();
         $this->subject->notifyAttendee($registration, $pi1);
 
-        self::assertStringContainsString(
-            'address1 address2',
-            $this->email->getBody()
-        );
+        self::assertStringContainsString('address1 address2', $this->getTextBodyOfEmail($this->email));
     }
 
     /**
@@ -3154,10 +3097,7 @@ final class RegistrationManagerTest extends TestCase
         $registration = $this->createRegistration();
         $this->subject->notifyAttendee($registration, $pi1);
 
-        self::assertStringContainsString(
-            'address1 address2 address3',
-            $this->email->getBody()
-        );
+        self::assertStringContainsString('address1 address2 address3', $this->getTextBodyOfEmail($this->email));
     }
 
     /**
@@ -3183,10 +3123,7 @@ final class RegistrationManagerTest extends TestCase
         $registration = $this->createRegistration();
         $this->subject->notifyAttendee($registration, $pi1);
 
-        self::assertStringContainsString(
-            'footown',
-            $this->email->getBody()
-        );
+        self::assertStringContainsString('footown', $this->getTextBodyOfEmail($this->email));
     }
 
     /**
@@ -3212,10 +3149,7 @@ final class RegistrationManagerTest extends TestCase
         $registration = $this->createRegistration();
         $this->subject->notifyAttendee($registration, $pi1);
 
-        self::assertStringContainsString(
-            '12345 footown',
-            $this->email->getBody()
-        );
+        self::assertStringContainsString('12345 footown', $this->getTextBodyOfEmail($this->email));
     }
 
     /**
@@ -3244,10 +3178,7 @@ final class RegistrationManagerTest extends TestCase
         $registration = $this->createRegistration();
         $this->subject->notifyAttendee($registration, $pi1);
 
-        self::assertContains(
-            $country->getLocalShortName(),
-            $this->email->getBody()
-        );
+        self::assertContains($country->getLocalShortName(), $this->getTextBodyOfEmail($this->email));
     }
 
     /**
@@ -3273,10 +3204,7 @@ final class RegistrationManagerTest extends TestCase
         $registration = $this->createRegistration();
         $this->subject->notifyAttendee($registration, $pi1);
 
-        self::assertStringContainsString(
-            "address\nfootown",
-            $this->email->getBody()
-        );
+        self::assertStringContainsString("address\nfootown", $this->getTextBodyOfEmail($this->email));
     }
 
     /**
@@ -3347,7 +3275,7 @@ final class RegistrationManagerTest extends TestCase
 
         self::assertStringContainsString(
             'footown, ' . $country->getLocalShortName(),
-            $this->email->getBody()
+            $this->getTextBodyOfEmail($this->email)
         );
     }
 
@@ -3374,10 +3302,7 @@ final class RegistrationManagerTest extends TestCase
         $registration = $this->createRegistration();
         $this->subject->notifyAttendee($registration, $pi1);
 
-        self::assertStringNotContainsString(
-            'footown,',
-            $this->email->getBody()
-        );
+        self::assertStringNotContainsString('footown,', $this->getTextBodyOfEmail($this->email));
     }
 
     /**
@@ -3804,7 +3729,7 @@ final class RegistrationManagerTest extends TestCase
 
         self::assertStringContainsString(
             $this->getLanguageService()->getLL('email_hello_informal'),
-            $this->email->getBody()
+            $this->getTextBodyOfEmail($this->email)
         );
     }
 
@@ -3832,7 +3757,7 @@ final class RegistrationManagerTest extends TestCase
 
         self::assertStringContainsString(
             $this->getLanguageService()->getLL('email_hello_formal_2'),
-            $this->email->getBody()
+            $this->getTextBodyOfEmail($this->email)
         );
     }
 
@@ -3860,7 +3785,7 @@ final class RegistrationManagerTest extends TestCase
 
         self::assertStringContainsString(
             $this->getLanguageService()->getLL('email_hello_formal_0'),
-            $this->email->getBody()
+            $this->getTextBodyOfEmail($this->email)
         );
     }
 
@@ -3888,7 +3813,7 @@ final class RegistrationManagerTest extends TestCase
 
         self::assertStringContainsString(
             $this->getLanguageService()->getLL('email_hello_formal_1'),
-            $this->email->getBody()
+            $this->getTextBodyOfEmail($this->email)
         );
     }
 
@@ -3915,7 +3840,7 @@ final class RegistrationManagerTest extends TestCase
                 $this->getLanguageService()->getLL('email_confirmationHello'),
                 $this->seminar->getTitle()
             ),
-            $this->email->getBody()
+            $this->getTextBodyOfEmail($this->email)
         );
     }
 
@@ -3942,7 +3867,7 @@ final class RegistrationManagerTest extends TestCase
                 $this->getLanguageService()->getLL('email_confirmationHello_informal'),
                 $this->seminar->getTitle()
             ),
-            $this->email->getBody()
+            $this->getTextBodyOfEmail($this->email)
         );
     }
 
@@ -3975,7 +3900,7 @@ final class RegistrationManagerTest extends TestCase
                 ),
                 $this->seminar->getTitle()
             ),
-            $this->email->getBody()
+            $this->getTextBodyOfEmail($this->email)
         );
     }
 
@@ -4008,7 +3933,7 @@ final class RegistrationManagerTest extends TestCase
                 ),
                 $this->seminar->getTitle()
             ),
-            $this->email->getBody()
+            $this->getTextBodyOfEmail($this->email)
         );
     }
 
@@ -4041,7 +3966,7 @@ final class RegistrationManagerTest extends TestCase
                 ),
                 $this->seminar->getTitle()
             ),
-            $this->email->getBody()
+            $this->getTextBodyOfEmail($this->email)
         );
     }
 
@@ -4074,7 +3999,7 @@ final class RegistrationManagerTest extends TestCase
                 ),
                 $this->seminar->getTitle()
             ),
-            $this->email->getBody()
+            $this->getTextBodyOfEmail($this->email)
         );
     }
 
@@ -4107,7 +4032,7 @@ final class RegistrationManagerTest extends TestCase
                 ),
                 $this->seminar->getTitle()
             ),
-            $this->email->getBody()
+            $this->getTextBodyOfEmail($this->email)
         );
     }
 
@@ -4140,7 +4065,7 @@ final class RegistrationManagerTest extends TestCase
                 ),
                 $this->seminar->getTitle()
             ),
-            $this->email->getBody()
+            $this->getTextBodyOfEmail($this->email)
         );
     }
 
@@ -4162,9 +4087,7 @@ final class RegistrationManagerTest extends TestCase
 
         $this->subject->notifyAttendee($registration, $pi1);
 
-        $this->assertNotContainsRawLabelKey(
-            $this->email->getBody()
-        );
+        $this->assertNotContainsRawLabelKey($this->getTextBodyOfEmail($this->email));
     }
 
     /**
@@ -4189,9 +4112,7 @@ final class RegistrationManagerTest extends TestCase
 
         $this->subject->notifyAttendee($registration, $pi1);
 
-        $this->assertNotContainsRawLabelKey(
-            $this->email->getBody()
-        );
+        $this->assertNotContainsRawLabelKey($this->getTextBodyOfEmail($this->email));
     }
 
     /**
@@ -4216,9 +4137,7 @@ final class RegistrationManagerTest extends TestCase
 
         $this->subject->notifyAttendee($registration, $pi1);
 
-        $this->assertNotContainsRawLabelKey(
-            $this->email->getBody()
-        );
+        $this->assertNotContainsRawLabelKey($this->getTextBodyOfEmail($this->email));
     }
 
     /**
@@ -4243,9 +4162,7 @@ final class RegistrationManagerTest extends TestCase
 
         $this->subject->notifyAttendee($registration, $pi1);
 
-        $this->assertNotContainsRawLabelKey(
-            $this->email->getBody()
-        );
+        $this->assertNotContainsRawLabelKey($this->getTextBodyOfEmail($this->email));
     }
 
     /**
@@ -4266,9 +4183,7 @@ final class RegistrationManagerTest extends TestCase
 
         $this->subject->notifyAttendee($registration, $pi1);
 
-        $this->assertNotContainsRawLabelKey(
-            $this->email->getBody()
-        );
+        $this->assertNotContainsRawLabelKey($this->getTextBodyOfEmail($this->email));
     }
 
     /**
@@ -4289,9 +4204,7 @@ final class RegistrationManagerTest extends TestCase
 
         $this->subject->notifyAttendee($registration, $pi1);
 
-        $this->assertNotContainsRawLabelKey(
-            $this->email->getBody()
-        );
+        $this->assertNotContainsRawLabelKey($this->getTextBodyOfEmail($this->email));
     }
 
     /**
@@ -4316,9 +4229,7 @@ final class RegistrationManagerTest extends TestCase
             'confirmationOnUnregistration'
         );
 
-        $this->assertNotContainsRawLabelKey(
-            $this->email->getBody()
-        );
+        $this->assertNotContainsRawLabelKey($this->getTextBodyOfEmail($this->email));
     }
 
     /**
@@ -4343,9 +4254,7 @@ final class RegistrationManagerTest extends TestCase
             'confirmationOnUnregistration'
         );
 
-        $this->assertNotContainsRawLabelKey(
-            $this->email->getBody()
-        );
+        $this->assertNotContainsRawLabelKey($this->getTextBodyOfEmail($this->email));
     }
 
     /**
@@ -4370,9 +4279,7 @@ final class RegistrationManagerTest extends TestCase
             'confirmationOnRegistrationForQueue'
         );
 
-        $this->assertNotContainsRawLabelKey(
-            $this->email->getBody()
-        );
+        $this->assertNotContainsRawLabelKey($this->getTextBodyOfEmail($this->email));
     }
 
     /**
@@ -4397,9 +4304,7 @@ final class RegistrationManagerTest extends TestCase
             'confirmationOnRegistrationForQueue'
         );
 
-        $this->assertNotContainsRawLabelKey(
-            $this->email->getBody()
-        );
+        $this->assertNotContainsRawLabelKey($this->getTextBodyOfEmail($this->email));
     }
 
     /**
@@ -4424,9 +4329,7 @@ final class RegistrationManagerTest extends TestCase
             'confirmationOnQueueUpdate'
         );
 
-        $this->assertNotContainsRawLabelKey(
-            $this->email->getBody()
-        );
+        $this->assertNotContainsRawLabelKey($this->getTextBodyOfEmail($this->email));
     }
 
     /**
@@ -4451,9 +4354,7 @@ final class RegistrationManagerTest extends TestCase
             'confirmationOnQueueUpdate'
         );
 
-        $this->assertNotContainsRawLabelKey(
-            $this->email->getBody()
-        );
+        $this->assertNotContainsRawLabelKey($this->getTextBodyOfEmail($this->email));
     }
 
     // Tests concerning the unregistration notice
@@ -4706,9 +4607,7 @@ final class RegistrationManagerTest extends TestCase
 
         $this->subject->notifyOrganizers($registration);
 
-        /** @var array<string, string> $replyTo */
-        $replyTo = $this->email->getReplyTo();
-        self::assertSame(['mail@example.com' => 'test organizer'], $replyTo);
+        self::assertSame(['mail@example.com' => 'test organizer'], $this->getReplyToOfEmail($this->email));
     }
 
     /**
@@ -4743,10 +4642,7 @@ final class RegistrationManagerTest extends TestCase
         $registration = $this->createRegistration();
         $this->subject->notifyOrganizers($registration);
 
-        self::assertArrayHasKey(
-            'mail@example.com',
-            $this->email->getTo()
-        );
+        self::assertArrayHasKey('mail@example.com', $this->getToOfEmail($this->email));
     }
 
     /**
@@ -4760,10 +4656,7 @@ final class RegistrationManagerTest extends TestCase
 
         $this->subject->notifyOrganizers($registration);
 
-        self::assertStringContainsString(
-            'Hello',
-            $this->email->getBody()
-        );
+        self::assertStringContainsString('Hello', $this->getTextBodyOfEmail($this->email));
     }
 
     /**
@@ -4784,7 +4677,7 @@ final class RegistrationManagerTest extends TestCase
 
         self::assertRegExp(
             '/' . $this->getLanguageService()->getLL('label_vacancies') . ': 1\\n*$/',
-            $this->email->getBody()
+            $this->getTextBodyOfEmail($this->email)
         );
     }
 
@@ -4807,7 +4700,7 @@ final class RegistrationManagerTest extends TestCase
         self::assertStringContainsString(
             $this->getLanguageService()->getLL('label_vacancies') . ': ' .
             $this->getLanguageService()->getLL('label_unlimited'),
-            $this->email->getBody()
+            $this->getTextBodyOfEmail($this->email)
         );
     }
 
@@ -4833,7 +4726,7 @@ final class RegistrationManagerTest extends TestCase
 
         self::assertStringContainsString(
             $this->getLanguageService()->getLL('label_company'),
-            $this->email->getBody()
+            $this->getTextBodyOfEmail($this->email)
         );
     }
 
@@ -4857,10 +4750,7 @@ final class RegistrationManagerTest extends TestCase
         $registration = new LegacyRegistration($registrationUid);
         $this->subject->notifyOrganizers($registration);
 
-        self::assertStringContainsString(
-            'foo inc.',
-            $this->email->getBody()
-        );
+        self::assertStringContainsString('foo inc.', $this->getTextBodyOfEmail($this->email));
     }
 
     /**
@@ -4927,10 +4817,7 @@ final class RegistrationManagerTest extends TestCase
         $registration = $this->createRegistration();
         $this->subject->sendAdditionalNotification($registration);
 
-        self::assertArrayHasKey(
-            'mail@example.com',
-            $this->email->getTo()
-        );
+        self::assertArrayHasKey('mail@example.com', $this->getToOfEmail($this->email));
     }
 
     /**
@@ -4975,8 +4862,8 @@ final class RegistrationManagerTest extends TestCase
         $registration = $this->createRegistration();
         $this->subject->sendAdditionalNotification($registration);
 
-        self::assertArrayHasKey('mail@example.com', $this->email->getTo());
-        self::assertArrayHasKey('mail2@example.com', $this->email->getTo());
+        self::assertArrayHasKey('mail@example.com', $this->getToOfEmail($this->email));
+        self::assertArrayHasKey('mail2@example.com', $this->getToOfEmail($this->email));
     }
 
     /**
@@ -5047,9 +4934,7 @@ final class RegistrationManagerTest extends TestCase
 
         $this->subject->sendAdditionalNotification($registration);
 
-        /** @var array<array-key, string> $replyTosOfFirstEmail */
-        $replyTosOfFirstEmail = $this->email->getReplyTo();
-        self::assertArrayHasKey('mail@example.com', $replyTosOfFirstEmail);
+        self::assertArrayHasKey('mail@example.com', $this->getReplyToOfEmail($this->email));
     }
 
     /**
@@ -5346,7 +5231,7 @@ final class RegistrationManagerTest extends TestCase
 
         self::assertStringContainsString(
             $this->getLanguageService()->getLL('email_additionalNotificationIsFull'),
-            $this->email->getBody()
+            $this->getTextBodyOfEmail($this->email)
         );
     }
 
@@ -5412,7 +5297,7 @@ final class RegistrationManagerTest extends TestCase
 
         self::assertRegExp(
             '/' . $this->getLanguageService()->getLL('label_vacancies') . ': 1\\n*$/',
-            $this->email->getBody()
+            $this->getTextBodyOfEmail($this->email)
         );
     }
 
@@ -5438,7 +5323,7 @@ final class RegistrationManagerTest extends TestCase
         self::assertStringContainsString(
             $this->getLanguageService()->getLL('label_vacancies') . ': '
             . $this->getLanguageService()->getLL('label_unlimited'),
-            $this->email->getBody()
+            $this->getTextBodyOfEmail($this->email)
         );
     }
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -591,16 +591,6 @@ parameters:
 			path: Tests/LegacyUnit/FrontEnd/EventEditorTest.php
 
 		-
-			message: "#^Parameter \\#2 \\$haystack of static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertStringContainsString\\(\\) expects string, Symfony\\\\Component\\\\Mime\\\\Part\\\\AbstractPart given\\.$#"
-			count: 8
-			path: Tests/LegacyUnit/FrontEnd/EventEditorTest.php
-
-		-
-			message: "#^Parameter \\#2 \\$haystack of static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertStringNotContainsString\\(\\) expects string, Symfony\\\\Component\\\\Mime\\\\Part\\\\AbstractPart given\\.$#"
-			count: 4
-			path: Tests/LegacyUnit/FrontEnd/EventEditorTest.php
-
-		-
 			message: "#^Method OliverKlee\\\\Seminars\\\\Tests\\\\LegacyUnit\\\\OldModel\\\\LegacyEventTest\\:\\:addCategoryRelation\\(\\) has parameter \\$categoryData with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: Tests/LegacyUnit/OldModel/LegacyEventTest.php
@@ -676,32 +666,12 @@ parameters:
 			path: Tests/LegacyUnit/SchedulerTasks/MailNotifierTest.php
 
 		-
-			message: "#^Parameter \\#2 \\$haystack of static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertStringContainsString\\(\\) expects string, Symfony\\\\Component\\\\Mime\\\\Part\\\\AbstractPart given\\.$#"
-			count: 6
-			path: Tests/LegacyUnit/SchedulerTasks/MailNotifierTest.php
-
-		-
 			message: "#^PHPDoc tag @var for variable \\$objectManager contains generic class TYPO3\\\\CMS\\\\Extbase\\\\Object\\\\ObjectManager but does not specify its types\\: T$#"
 			count: 1
 			path: Tests/LegacyUnit/SchedulerTasks/RegistrationDigestTest.php
 
 		-
-			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertSame\\(\\) with array\\<string, string\\>&nonEmpty and array\\<Symfony\\\\Component\\\\Mime\\\\Address\\> will always evaluate to false\\.$#"
-			count: 1
-			path: Tests/LegacyUnit/Service/EmailServiceTest.php
-
-		-
 			message: "#^Class TYPO3\\\\CMS\\\\Core\\\\Localization\\\\LanguageService constructor invoked with 0 parameters, 2 required\\.$#"
-			count: 1
-			path: Tests/LegacyUnit/Service/EmailServiceTest.php
-
-		-
-			message: "#^Parameter \\#2 \\$haystack of static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertStringContainsString\\(\\) expects string, Symfony\\\\Component\\\\Mime\\\\Part\\\\AbstractPart given\\.$#"
-			count: 6
-			path: Tests/LegacyUnit/Service/EmailServiceTest.php
-
-		-
-			message: "#^Parameter \\#2 \\$haystack of static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertStringNotContainsString\\(\\) expects string, Symfony\\\\Component\\\\Mime\\\\Part\\\\AbstractPart given\\.$#"
 			count: 1
 			path: Tests/LegacyUnit/Service/EmailServiceTest.php
 
@@ -723,26 +693,6 @@ parameters:
 		-
 			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertSame\\(\\) with array\\('system\\-foo@example\\.com' \\=\\> 'Mr\\. Default'\\) and array\\<Symfony\\\\Component\\\\Mime\\\\Address\\> will always evaluate to false\\.$#"
 			count: 3
-			path: Tests/LegacyUnit/Service/RegistrationManagerTest.php
-
-		-
-			message: "#^Parameter \\#1 \\$string of method OliverKlee\\\\Seminars\\\\Tests\\\\LegacyUnit\\\\Service\\\\RegistrationManagerTest\\:\\:assertNotContainsRawLabelKey\\(\\) expects string, Symfony\\\\Component\\\\Mime\\\\Part\\\\AbstractPart given\\.$#"
-			count: 13
-			path: Tests/LegacyUnit/Service/RegistrationManagerTest.php
-
-		-
-			message: "#^Parameter \\#2 \\$haystack of static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertStringContainsString\\(\\) expects string, Symfony\\\\Component\\\\Mime\\\\Part\\\\AbstractPart given\\.$#"
-			count: 41
-			path: Tests/LegacyUnit/Service/RegistrationManagerTest.php
-
-		-
-			message: "#^Parameter \\#2 \\$haystack of static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertStringNotContainsString\\(\\) expects string, Symfony\\\\Component\\\\Mime\\\\Part\\\\AbstractPart given\\.$#"
-			count: 6
-			path: Tests/LegacyUnit/Service/RegistrationManagerTest.php
-
-		-
-			message: "#^Parameter \\#2 \\$string of static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertRegExp\\(\\) expects string, Symfony\\\\Component\\\\Mime\\\\Part\\\\AbstractPart given\\.$#"
-			count: 2
 			path: Tests/LegacyUnit/Service/RegistrationManagerTest.php
 
 		-


### PR DESCRIPTION
This fixes those email tests in the legacy tests in V10.

Part of #1109