### PR TITLE
[BUGFIX] Use the email abstractions in the legacy tests (part 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 - Improve the type annotations and fix PHPStan warnings (#1165)
-- Use the new mailer in TYPO3 10LTS (#1153, #1157, #1158, #1161, #1163)
+- Use the new mailer in TYPO3 10LTS (#1153, #1157, #1158, #1161, #1163, #1169, #1170)
 - Properly disable the Core cache in V10 in the tests (#1148)
 - Provide the `ContentObjectRenderer` with a logger in the tests (#1145)
 - Fix the test setup (#1139, #1162, #1164, #1168)

--- a/Tests/LegacyUnit/Service/RegistrationManagerTest.php
+++ b/Tests/LegacyUnit/Service/RegistrationManagerTest.php
@@ -2300,10 +2300,7 @@ final class RegistrationManagerTest extends TestCase
 
         $this->subject->notifyAttendee($registration, $pi1);
 
-        self::assertSame(
-            [$defaultMailFromAddress => $defaultMailFromName],
-            $this->email->getFrom()
-        );
+        self::assertSame([$defaultMailFromAddress => $defaultMailFromName], $this->getFromOfEmail($this->email));
     }
 
     /**
@@ -2341,10 +2338,7 @@ final class RegistrationManagerTest extends TestCase
 
         $this->subject->notifyAttendee($registration, $pi1);
 
-        self::assertSame(
-            ['mail@example.com' => 'test organizer'],
-            $this->email->getFrom()
-        );
+        self::assertSame(['mail@example.com' => 'test organizer'], $this->getFromOfEmail($this->email));
     }
 
     /**
@@ -4522,10 +4516,7 @@ final class RegistrationManagerTest extends TestCase
 
         $this->subject->notifyOrganizers($registration);
 
-        self::assertSame(
-            [$defaultMailFromAddress => $defaultMailFromName],
-            $this->email->getFrom()
-        );
+        self::assertSame([$defaultMailFromAddress => $defaultMailFromName], $this->getFromOfEmail($this->email));
     }
 
     /**
@@ -4561,10 +4552,7 @@ final class RegistrationManagerTest extends TestCase
 
         $this->subject->notifyOrganizers($registration);
 
-        self::assertSame(
-            [$defaultMailFromAddress => $defaultMailFromName],
-            $this->email->getFrom()
-        );
+        self::assertSame([$defaultMailFromAddress => $defaultMailFromName], $this->getFromOfEmail($this->email));
     }
 
     /**
@@ -4833,10 +4821,7 @@ final class RegistrationManagerTest extends TestCase
 
         $this->subject->sendAdditionalNotification($registration);
 
-        self::assertArrayHasKey(
-            $defaultMailFromAddress,
-            $this->email->getFrom()
-        );
+        self::assertArrayHasKey($defaultMailFromAddress, $this->getFromOfEmail($this->email));
     }
 
     /**
@@ -4902,10 +4887,7 @@ final class RegistrationManagerTest extends TestCase
 
         $this->subject->sendAdditionalNotification($registration);
 
-        self::assertArrayHasKey(
-            'mail@example.com',
-            $this->email->getFrom()
-        );
+        self::assertArrayHasKey('mail@example.com', $this->getFromOfEmail($this->email));
     }
 
     /**

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -671,16 +671,6 @@ parameters:
 			path: Tests/LegacyUnit/Service/Fixtures/TestingRegistrationManager.php
 
 		-
-			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertSame\\(\\) with array\\('mail@example\\.com' \\=\\> 'test organizer'\\) and array\\<Symfony\\\\Component\\\\Mime\\\\Address\\> will always evaluate to false\\.$#"
-			count: 1
-			path: Tests/LegacyUnit/Service/RegistrationManagerTest.php
-
-		-
-			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertSame\\(\\) with array\\('system\\-foo@example\\.com' \\=\\> 'Mr\\. Default'\\) and array\\<Symfony\\\\Component\\\\Mime\\\\Address\\> will always evaluate to false\\.$#"
-			count: 3
-			path: Tests/LegacyUnit/Service/RegistrationManagerTest.php
-
-		-
 			message: "#^Parameter \\#1 \\$email of method OliverKlee\\\\Seminars\\\\Tests\\\\LegacyUnit\\\\Service\\\\RegistrationManagerTest\\:\\:filterSwiftEmailAttachmentsByType\\(\\) expects Swift_Message, \\(PHPUnit\\\\Framework\\\\MockObject\\\\MockObject&TYPO3\\\\CMS\\\\Core\\\\Mail\\\\MailMessage\\)\\|null given\\.$#"
 			count: 17
 			path: Tests/LegacyUnit/Service/RegistrationManagerTest.php


### PR DESCRIPTION
This fixes those email tests in the legacy tests in V10.

Part of #1109