### PR TITLE
[BUGFIX] Call `GeneralUtility::purgeInstances` in the tests less

### DIFF
--- a/Tests/Functional/BackEnd/CancelEventMailFormTest.php
+++ b/Tests/Functional/BackEnd/CancelEventMailFormTest.php
@@ -39,7 +39,9 @@ final class CancelEventMailFormTest extends FunctionalTestCase
 
     protected function tearDown(): void
     {
-        GeneralUtility::purgeInstances();
+        // Manually purge the TYPO3 FIFO queue
+        GeneralUtility::makeInstance(MailMessage::class);
+        GeneralUtility::makeInstance(MailMessage::class);
         unset($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['seminars']['backEndModule']);
     }
 

--- a/Tests/Functional/BackEnd/ConfirmEventMailFormTest.php
+++ b/Tests/Functional/BackEnd/ConfirmEventMailFormTest.php
@@ -40,7 +40,9 @@ final class ConfirmEventMailFormTest extends FunctionalTestCase
 
     protected function tearDown(): void
     {
-        GeneralUtility::purgeInstances();
+        // Manually purge the TYPO3 FIFO queue
+        GeneralUtility::makeInstance(MailMessage::class);
+        GeneralUtility::makeInstance(MailMessage::class);
         unset($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['seminars']['backEndModule']);
 
         parent::tearDown();

--- a/Tests/Functional/BackEnd/GeneralEventMailFormTest.php
+++ b/Tests/Functional/BackEnd/GeneralEventMailFormTest.php
@@ -37,7 +37,9 @@ final class GeneralEventMailFormTest extends FunctionalTestCase
 
     protected function tearDown(): void
     {
-        GeneralUtility::purgeInstances();
+        // Manually purge the TYPO3 FIFO queue
+        GeneralUtility::makeInstance(MailMessage::class);
+        GeneralUtility::makeInstance(MailMessage::class);
         unset($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['seminars']['backEndModule']);
 
         parent::tearDown();

--- a/Tests/LegacyUnit/BackEnd/ControllerTest.php
+++ b/Tests/LegacyUnit/BackEnd/ControllerTest.php
@@ -32,6 +32,8 @@ final class ControllerTest extends TestCase
 
     protected function tearDown(): void
     {
+        // Manually purge the TYPO3 FIFO queue
+        GeneralUtility::makeInstance(CsvDownloader::class);
         $this->restoreOriginalEnvironment();
     }
 

--- a/Tests/LegacyUnit/SchedulerTasks/RegistrationDigestTest.php
+++ b/Tests/LegacyUnit/SchedulerTasks/RegistrationDigestTest.php
@@ -94,7 +94,9 @@ final class RegistrationDigestTest extends TestCase
 
     protected function tearDown(): void
     {
-        GeneralUtility::purgeInstances();
+        // Manually purge the TYPO3 FIFO queue
+        GeneralUtility::makeInstance(MailMessage::class);
+        GeneralUtility::makeInstance(MailMessage::class);
     }
 
     /**


### PR DESCRIPTION
This call affectds performance and messes with caches and other
system-wide things.

Fixes #1174