### PR TITLE
[BUGFIX] Create mkforms-related directories on the fly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Drop the RealURL auto-configuration (#1189)
 
 ### Fixed
+- Create mkforms-related directories on the fly (#1211)
 - Get the BE CSV export to work in TYPO3 V10 (#1198, #1206, #1207)
 - Avoid calls to the removed `buildUriFromModule` (#1204)
 - Fix crash in the BE module in V10 (#1199)

--- a/Classes/FrontEnd/AbstractEditor.php
+++ b/Classes/FrontEnd/AbstractEditor.php
@@ -103,7 +103,22 @@ abstract class AbstractEditor extends AbstractView
      */
     public function render(): string
     {
+        $this->createTemporaryDirectories();
+
         return $this->getFormCreator()->render();
+    }
+
+    /**
+     * Creates the assets and cache directories for mkforms if they are missing
+     * (which can happen due to a bug in mkforms).
+     */
+    private function createTemporaryDirectories(): void
+    {
+        foreach (['typo3temp/assets/mkforms/', 'typo3temp/mkforms/cache/'] as $directory) {
+            if (!\is_dir($directory)) {
+                GeneralUtility::mkdir_deep($directory);
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
This fixes a crash in the registration form and event editor
in TYPO3 V10.

Fixes #1188