### PR TITLE
[BUGFIX] Always use a page UID for the fake FE in the tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Removed
 
 ### Fixed
+- Fix the link generation in the tests in TYPO3 V10 (#1217)
 
 ## 4.1.0
 

--- a/Tests/Functional/FrontEnd/RegistrationFormTest.php
+++ b/Tests/Functional/FrontEnd/RegistrationFormTest.php
@@ -48,7 +48,8 @@ final class RegistrationFormTest extends FunctionalTestCase
         parent::setUp();
 
         $this->testingFramework = new TestingFramework('tx_seminars');
-        $this->testingFramework->createFakeFrontEnd();
+        $rootPageUid = $this->testingFramework->createFrontEndPage();
+        $this->testingFramework->createFakeFrontEnd($rootPageUid);
         $this->contentObject = new ContentObjectRenderer();
         $this->initializeBackEndLanguage();
 

--- a/Tests/LegacyUnit/Csv/CsvDownloaderTest.php
+++ b/Tests/LegacyUnit/Csv/CsvDownloaderTest.php
@@ -49,7 +49,8 @@ final class CsvDownloaderTest extends TestCase
         $this->unifyTestingEnvironment();
 
         $this->testingFramework = new TestingFramework('tx_seminars');
-        $this->testingFramework->createFakeFrontEnd();
+        $rootPageUid = $this->testingFramework->createFrontEndPage();
+        $this->testingFramework->createFakeFrontEnd($rootPageUid);
 
         $this->pid = $this->testingFramework->createSystemFolder();
         $this->eventUid = $this->testingFramework->createRecord(

--- a/Tests/LegacyUnit/FrontEnd/AbstractEditorTest.php
+++ b/Tests/LegacyUnit/FrontEnd/AbstractEditorTest.php
@@ -28,7 +28,8 @@ final class AbstractEditorTest extends TestCase
     protected function setUp(): void
     {
         $this->testingFramework = new TestingFramework('tx_seminars');
-        $this->testingFramework->createFakeFrontEnd();
+        $rootPageUid = $this->testingFramework->createFrontEndPage();
+        $this->testingFramework->createFakeFrontEnd($rootPageUid);
 
         $this->subject = new TestingEditor([], $this->getFrontEndController()->cObj);
         $this->subject->setTestMode();

--- a/Tests/LegacyUnit/FrontEnd/AbstractViewTest.php
+++ b/Tests/LegacyUnit/FrontEnd/AbstractViewTest.php
@@ -27,7 +27,8 @@ final class AbstractViewTest extends TestCase
     protected function setUp(): void
     {
         $this->testingFramework = new TestingFramework('tx_seminars');
-        $this->testingFramework->createFakeFrontEnd();
+        $rootPageUid = $this->testingFramework->createFrontEndPage();
+        $this->testingFramework->createFakeFrontEnd($rootPageUid);
         $this->subject = new TestingView(
             ['templateFile' => 'EXT:seminars/Resources/Private/Templates/FrontEnd/FrontEnd.html'],
             $this->getFrontEndController()->cObj

--- a/Tests/LegacyUnit/FrontEnd/CountdownTest.php
+++ b/Tests/LegacyUnit/FrontEnd/CountdownTest.php
@@ -45,7 +45,8 @@ final class CountdownTest extends TestCase
         $configurationRegistry->set('plugin.tx_seminars._LOCAL_LANG.default', new DummyConfiguration());
 
         $this->testingFramework = new TestingFramework('tx_seminars');
-        $this->testingFramework->createFakeFrontEnd();
+        $rootPageUid = $this->testingFramework->createFrontEndPage();
+        $this->testingFramework->createFakeFrontEnd($rootPageUid);
 
         /** @var EventMapper&MockObject $mapper */
         $mapper = $this->getMockBuilder(EventMapper::class)->setMethods(['findNextUpcoming'])->getMock();

--- a/Tests/LegacyUnit/FrontEnd/EventPublicationTest.php
+++ b/Tests/LegacyUnit/FrontEnd/EventPublicationTest.php
@@ -32,7 +32,8 @@ final class EventPublicationTest extends TestCase
     protected function setUp(): void
     {
         $this->testingFramework = new TestingFramework('tx_seminars');
-        $this->testingFramework->createFakeFrontEnd();
+        $rootPageUid = $this->testingFramework->createFrontEndPage();
+        $this->testingFramework->createFakeFrontEnd($rootPageUid);
         $this->subject = new EventPublication();
     }
 

--- a/Tests/LegacyUnit/FrontEnd/SelectorWidgetTest.php
+++ b/Tests/LegacyUnit/FrontEnd/SelectorWidgetTest.php
@@ -40,7 +40,8 @@ final class SelectorWidgetTest extends TestCase
     protected function setUp(): void
     {
         $this->testingFramework = new TestingFramework('tx_seminars');
-        $this->testingFramework->createFakeFrontEnd();
+        $rootPageUid = $this->testingFramework->createFrontEndPage();
+        $this->testingFramework->createFakeFrontEnd($rootPageUid);
 
         $this->subject = new SelectorWidget(
             [

--- a/Tests/LegacyUnit/OldModel/LegacyRegistrationTest.php
+++ b/Tests/LegacyUnit/OldModel/LegacyRegistrationTest.php
@@ -57,7 +57,8 @@ final class LegacyRegistrationTest extends TestCase
         LegacyRegistration::purgeCachedSeminars();
 
         $this->testingFramework = new TestingFramework('tx_seminars');
-        $this->testingFramework->createFakeFrontEnd();
+        $rootPageUid = $this->testingFramework->createFrontEndPage();
+        $this->testingFramework->createFakeFrontEnd($rootPageUid);
 
         $this->configuration = new DummyConfiguration();
         $this->configuration->setAsString('templateFile', 'EXT:seminars/Resources/Private/Templates/Mail/e-mail.html');

--- a/Tests/LegacyUnit/Service/SingleViewLinkBuilderTest.php
+++ b/Tests/LegacyUnit/Service/SingleViewLinkBuilderTest.php
@@ -435,7 +435,8 @@ final class SingleViewLinkBuilderTest extends TestCase
      */
     public function getContentObjectForAvailableFrontEndReturnsFrontEndContentObject(): void
     {
-        $this->testingFramework->createFakeFrontEnd();
+        $rootPageUid = $this->testingFramework->createFrontEndPage();
+        $this->testingFramework->createFakeFrontEnd($rootPageUid);
 
         $subject = new TestingSingleViewLinkBuilder();
 


### PR DESCRIPTION
This helps fix link creation in the tests in V10.

Fixes #1210