### PR TITLE
[BUGFIX] Remove the HTML template file settings from the flexforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Removed
 
 ### Fixed
+- Remove the HTML template file settings from the Flexforms (#1221)
 - Fix the link generation in the tests in TYPO3 V10 (#1217)
 
 ## 4.1.0

--- a/Configuration/FlexForms/flexforms_pi1.xml
+++ b/Configuration/FlexForms/flexforms_pi1.xml
@@ -518,19 +518,6 @@
 				</TCEforms>
 				<type>array</type>
 				<el>
-					<templateFile>
-						<TCEforms>
-							<label>LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:seminars.pi_flexform.templateFile</label>
-							<config>
-								<type>group</type>
-								<internal_type>file</internal_type>
-								<allowed>tmpl,html,htm</allowed>
-								<max_size>100</max_size>
-								<maxitems>1</maxitems>
-								<size>1</size>
-							</config>
-						</TCEforms>
-					</templateFile>
 					<showSingleEvent>
 						<TCEforms>
 							<exclude>1</exclude>

--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -1118,10 +1118,6 @@ Wir konnten dieser Veranstaltung nun fest zusagen.</target>
 				<source>Recursion:</source>
 				<target>Rekursion:</target>
 			</trans-unit>
-			<trans-unit id="seminars.pi_flexform.templateFile" xml:space="preserve">
-				<source>File name of the HTML template:</source>
-				<target>Dateiname des HTML-Templates:</target>
-			</trans-unit>
 			<trans-unit id="seminars.pi_flexform.showSingleEvent" xml:space="preserve">
 				<source>Which event should be shown in a detailed view?</source>
 				<target>Welche Veranstaltung soll als Detailansicht angezeigt werden?</target>

--- a/Resources/Private/Language/dk.locallang.xlf
+++ b/Resources/Private/Language/dk.locallang.xlf
@@ -1062,10 +1062,6 @@ This event now has been confirmed.</source>
 				<source>Show attached files list only to attendees:</source>
 				<target></target>
 			</trans-unit>
-			<trans-unit id="seminars.pi_flexform.templateFile" xml:space="preserve">
-				<source>File name of the HTML template:</source>
-				<target>Filnavnet på HTML-skabelonen:</target>
-			</trans-unit>
 			<trans-unit id="seminars.pi_flexform.showSingleEvent" xml:space="preserve">
 				<source>Which event should be shown in a detailed view?</source>
 				<target>Hvilket arrangement skal vises på enkeltvisningssiden?</target>

--- a/Resources/Private/Language/fr.locallang.xlf
+++ b/Resources/Private/Language/fr.locallang.xlf
@@ -1072,10 +1072,6 @@ This event now has been confirmed.</source>
 				<source>Show attached files list only to attendees:</source>
 				<target>Montrer la liste des fichiers attachés uniquement aux participants :</target>
 			</trans-unit>
-			<trans-unit id="seminars.pi_flexform.templateFile" xml:space="preserve">
-				<source>File name of the HTML template:</source>
-				<target>Nom du modèle HTML :</target>
-			</trans-unit>
 			<trans-unit id="seminars.pi_flexform.showSingleEvent" xml:space="preserve">
 				<source>Which event should be shown in a detailed view?</source>
 				<target>Quel événement devrait être montré en détail ?</target>

--- a/Resources/Private/Language/it.locallang.xlf
+++ b/Resources/Private/Language/it.locallang.xlf
@@ -1064,10 +1064,6 @@ This event now has been confirmed.</source>
 				<source>Show attached files list only to attendees:</source>
 				<target></target>
 			</trans-unit>
-			<trans-unit id="seminars.pi_flexform.templateFile" xml:space="preserve">
-				<source>File name of the HTML template:</source>
-				<target>Nome del file del template HTML:</target>
-			</trans-unit>
 			<trans-unit id="seminars.pi_flexform.showSingleEvent" xml:space="preserve">
 				<source>Which event should be shown in a detailed view?</source>
 				<target>Che evento deve essere visualizzato in modo dettaglio?</target>

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -828,9 +828,6 @@ This event now has been confirmed.</source>
 			<trans-unit id="seminars.pi_flexform.recursive">
 				<source>Recursion:</source>
 			</trans-unit>
-			<trans-unit id="seminars.pi_flexform.templateFile" xml:space="preserve">
-				<source>File name of the HTML template:</source>
-			</trans-unit>
 			<trans-unit id="seminars.pi_flexform.showSingleEvent" xml:space="preserve">
 				<source>Which event should be shown in a detailed view?</source>
 			</trans-unit>

--- a/Resources/Private/Language/nl.locallang.xlf
+++ b/Resources/Private/Language/nl.locallang.xlf
@@ -1052,10 +1052,6 @@ This event now has been confirmed.</source>
 				<source>Show attached files list only to attendees:</source>
 				<target></target>
 			</trans-unit>
-			<trans-unit id="seminars.pi_flexform.templateFile" xml:space="preserve">
-				<source>File name of the HTML template:</source>
-				<target>Bestandsnaam van het HTML-sjabloon:</target>
-			</trans-unit>
 			<trans-unit id="seminars.pi_flexform.showSingleEvent" xml:space="preserve">
 				<source>Which event should be shown in a detailed view?</source>
 				<target>Welke evenement moet in de detailweergave getoond worden</target>

--- a/Resources/Private/Language/ru.locallang.xlf
+++ b/Resources/Private/Language/ru.locallang.xlf
@@ -792,10 +792,6 @@ This event now has been confirmed.</source>
 				<source>Show attached files list only to attendees:</source>
 				<target></target>
 			</trans-unit>
-			<trans-unit id="seminars.pi_flexform.templateFile" xml:space="preserve">
-				<source>File name of the HTML template:</source>
-				<target>Файл HTML-шаблона:</target>
-			</trans-unit>
 			<trans-unit id="seminars.pi_flexform.showSingleEvent" xml:space="preserve">
 				<source>Which event should be shown in a detailed view?</source>
 				<target>Какое событие показывать в детализированном виде?</target>


### PR DESCRIPTION
In TYPO3 10LTS and higher, file uploads without FAL are not supported
in the TCA or flexforms anymore and will lead to an exception.

Fixes #1220