### PR TITLE
[BUGFIX] Explicitly allow the needed Composer plugins

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -86,7 +86,12 @@
 		},
 		"sort-packages": true,
 		"process-timeout": 1000,
-		"vendor-dir": ".Build/vendor"
+		"vendor-dir": ".Build/vendor",
+		"allow-plugins": {
+			"typo3/class-alias-loader": true,
+			"typo3/cms-composer-installers": true,
+			"phpstan/extension-installer": true
+		}
 	},
 	"scripts": {
 		"php:fix": ".Build/vendor/bin/php-cs-fixer --config=Configuration/php-cs-fixer.php fix Classes Tests && .Build/vendor/bin/phpcbf Classes Configuration Tests",


### PR DESCRIPTION
This is required for Composer 2.2.