### PR TITLE
[BUGFIX] Add felogin as a development dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -59,6 +59,7 @@
 		"saschaegerer/phpstan-typo3": "^1.1.2",
 		"sjbr/sr-feuser-register": "^7.0.5",
 		"squizlabs/php_codesniffer": "^3.6.2",
+		"typo3/cms-felogin": "^9.5 || ^10.4",
 		"typo3/cms-scheduler": "^9.5 || ^10.4"
 	},
 	"suggest": {


### PR DESCRIPTION
This is required so we can run the legacy tests.