### PR TITLE
[BUGFIX] Use Composer 1 for the legacy tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,7 +197,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           php-version: "${{ matrix.php-version }}"
-          tools: composer:v2
+          tools: composer:v1
           extensions: dom, json, libxml, mysqli, zip
           coverage: none
       - name: "Show Composer version"


### PR DESCRIPTION
This avoids a problem with the sr_feuser_register dev dependency,
fixing the recent build breakage.

(We will be able to switch back to Composer 2 once we are using
feuserextrafields instead.)