### PR TITLE
[BUGFIX] Require `typo3/class-alias-loader` >= 1.1.0 for development

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Removed
 
 ### Fixed
+- Require `typo3/class-alias-loader` >= 1.1.0 for development (#1245)
 - Keep development-only files out of the TER releases (#1241)
 
 ## 4.1.1

--- a/composer.json
+++ b/composer.json
@@ -59,6 +59,7 @@
 		"saschaegerer/phpstan-typo3": "^1.1.2",
 		"sjbr/sr-feuser-register": "^7.0.5",
 		"squizlabs/php_codesniffer": "^3.6.2",
+		"typo3/class-alias-loader": "^1.1.0",
 		"typo3/cms-scheduler": "^9.5 || ^10.4"
 	},
 	"suggest": {


### PR DESCRIPTION
This avoids a crash when installing the Composer packages (including
the development packages) with Composer 1 with the lowest
dependencies.