### PR TITLE
[BUGFIX] Dev-require and suggest the install tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Removed
 
 ### Fixed
+- Dev-require and suggest the install tool (#1261)
 
 ## 4.1.2
 

--- a/composer.json
+++ b/composer.json
@@ -62,12 +62,14 @@
 		"sjbr/sr-feuser-register": "^7.0.5",
 		"squizlabs/php_codesniffer": "^3.6.2",
 		"typo3/class-alias-loader": "^1.1.3",
+		"typo3/cms-install": "^9.5 || ^10.4",
 		"typo3/cms-scheduler": "^9.5 || ^10.4"
 	},
 	"suggest": {
 		"in2code/femanager": "^6.0",
 		"oliverklee/onetimeaccount": "^4.2",
-		"sjbr/sr-feuser-register": "^6.0 || ^7.0"
+		"sjbr/sr-feuser-register": "^6.0 || ^7.0",
+		"typo3/cms-install": "^9.5 || ^10.4"
 	},
 	"replace": {
 		"typo3-ter/seminars": "self.version"


### PR DESCRIPTION
The install tool is optional for running the extension (as long
as the upgrade wizards do not get used). So add it as a suggestion
to the `composer.json`.

Also dev-require it to allow rector to parse the upgrade wizards.