### PR TITLE
[BUGFIX] Fix PHPUnit warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Removed
 
 ### Fixed
+- Fix PHPUnit warnings (#1262)
 - Dev-require and suggest the install tool (#1261)
 
 ## 4.1.2

--- a/Tests/LegacyUnit/FrontEnd/DefaultControllerTest.php
+++ b/Tests/LegacyUnit/FrontEnd/DefaultControllerTest.php
@@ -179,7 +179,7 @@ final class DefaultControllerTest extends TestCase
         $this->subject->injectLinkBuilder($linkBuilder);
 
         /** @var ContentObjectRenderer&MockObject $contentObject */
-        $contentObject = $this->createPartialMock(ContentObjectRenderer::class, ['IMAGE', 'cObjGetSingle']);
+        $contentObject = $this->createPartialMock(ContentObjectRenderer::class, ['cObjGetSingle']);
         $contentObject->setLogger(new NullLogger());
         $contentObject->method('cObjGetSingle')->willReturn('<img src="foo.jpg" alt="bar"/>');
         $this->subject->cObj = $contentObject;

--- a/Tests/LegacyUnit/Model/EventTest.php
+++ b/Tests/LegacyUnit/Model/EventTest.php
@@ -1074,7 +1074,7 @@ final class EventTest extends TestCase
             ['getCombinedSingleViewPage']
         );
         $subject->expects(self::atLeastOnce())
-            ->method('getCombinedSingleViewPage')->willReturn(42);
+            ->method('getCombinedSingleViewPage')->willReturn('42');
 
         self::assertTrue(
             $subject->hasCombinedSingleViewPage()

--- a/Tests/LegacyUnit/Service/EmailServiceTest.php
+++ b/Tests/LegacyUnit/Service/EmailServiceTest.php
@@ -304,7 +304,7 @@ final class EmailServiceTest extends TestCase
         $this->email
             ->expects(self::exactly(2))
             ->method('send')
-            ->willReturn(2);
+            ->willReturn(true);
         $this->addMockedInstance(MailMessage::class, $this->email);
         $this->addMockedInstance(MailMessage::class, $this->email);
 

--- a/Tests/LegacyUnit/Service/SingleViewLinkBuilderTest.php
+++ b/Tests/LegacyUnit/Service/SingleViewLinkBuilderTest.php
@@ -360,7 +360,7 @@ final class SingleViewLinkBuilderTest extends TestCase
             ->willReturn($contentObject);
         $subject
             ->method('getSingleViewPageForEvent')
-            ->willReturn($singleViewPageUid);
+            ->willReturn((string)$singleViewPageUid);
 
         $subject->createRelativeUrlForEvent($event);
     }

--- a/Tests/Unit/FrontEnd/DefaultControllerTest.php
+++ b/Tests/Unit/FrontEnd/DefaultControllerTest.php
@@ -29,9 +29,7 @@ final class DefaultControllerTest extends UnitTestCase
                 'pi_initPIflexForm',
                 'getTemplateCode',
                 'setLabels',
-                'setCSS',
                 'createHelperObjects',
-                'setErrorMessage',
             ]
         );
         $controller->expects(self::once())->method('createSingleView');
@@ -56,9 +54,7 @@ final class DefaultControllerTest extends UnitTestCase
                 'pi_initPIflexForm',
                 'getTemplateCode',
                 'setLabels',
-                'setCSS',
                 'createHelperObjects',
-                'setErrorMessage',
             ]
         );
         $controller->expects(self::once())->method('createSingleView');
@@ -83,9 +79,7 @@ final class DefaultControllerTest extends UnitTestCase
                 'pi_initPIflexForm',
                 'getTemplateCode',
                 'setLabels',
-                'setCSS',
                 'createHelperObjects',
-                'setErrorMessage',
             ]
         );
         $controller->expects(self::once())->method('createSingleView');
@@ -112,9 +106,7 @@ final class DefaultControllerTest extends UnitTestCase
                 'pi_initPIflexForm',
                 'getTemplateCode',
                 'setLabels',
-                'setCSS',
                 'createHelperObjects',
-                'setErrorMessage',
             ]
         );
         $controller->expects(self::once())->method('createListView')->with('seminar_list');
@@ -139,9 +131,7 @@ final class DefaultControllerTest extends UnitTestCase
                 'pi_initPIflexForm',
                 'getTemplateCode',
                 'setLabels',
-                'setCSS',
                 'createHelperObjects',
-                'setErrorMessage',
             ]
         );
         $controller->expects(self::once())->method('createListView')->with('seminar_list');


### PR DESCRIPTION
- remove methods from partial mocks that do not exist
- fix the return types of mocked method calls