### PR TITLE
[BUGFIX] Allow Composer plugins from `helhum/typo3-console-plugin`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Removed
 
 ### Fixed
+- Allow Composer plugins from `helhum/typo3-console-plugin` (#1264)
 - Fix PHPUnit warnings (#1262)
 - Dev-require and suggest the install tool (#1261)
 

--- a/composer.json
+++ b/composer.json
@@ -65,6 +65,9 @@
 		"typo3/cms-install": "^9.5 || ^10.4",
 		"typo3/cms-scheduler": "^9.5 || ^10.4"
 	},
+	"conflict": {
+		"helhum/typo3-console-plugin": "< 2.0.7"
+	},
 	"suggest": {
 		"in2code/femanager": "^6.0",
 		"oliverklee/onetimeaccount": "^4.2",
@@ -95,7 +98,8 @@
 		"allow-plugins": {
 			"typo3/class-alias-loader": true,
 			"typo3/cms-composer-installers": true,
-			"phpstan/extension-installer": true
+			"phpstan/extension-installer": true,
+			"helhum/typo3-console-plugin": true
 		}
 	},
 	"scripts": {


### PR DESCRIPTION
This is required for V9 installations.