### PR TITLE
[CLEANUP] Avoid unnecessarily broad method visibility in tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Add a convenience function for localized labels in tests (#1268)
 
 ### Changed
+- Clean up the test (#1267)
 - Move more legacy tests to the new testing framework (#1267)
 - Use the new configuration classes for the single view link builder (#1265, #1266)
 - Upgrade to PHPUnit 8 (#1223)

--- a/Tests/LegacyUnit/Csv/EventListViewTest.php
+++ b/Tests/LegacyUnit/Csv/EventListViewTest.php
@@ -82,7 +82,7 @@ final class EventListViewTest extends TestCase
      *
      * @return int the UID of the created event record
      */
-    protected function createEventInFolderAndSetPageUid(array $eventData = []): int
+    private function createEventInFolderAndSetPageUid(array $eventData = []): int
     {
         $this->pageUid = $this->testingFramework->createSystemFolder();
         $this->subject->setPageUid($this->pageUid);

--- a/Tests/LegacyUnit/Email/SalutationTest.php
+++ b/Tests/LegacyUnit/Email/SalutationTest.php
@@ -111,7 +111,7 @@ final class SalutationTest extends TestCase
      * Checks whether the FrontEndUser.gender fields exists and
      * marks the test as skipped if that extension is not installed.
      */
-    protected function skipWithoutGenderField(): void
+    private function skipWithoutGenderField(): void
     {
         if (!OelibFrontEndUser::hasGenderField()) {
             self::markTestSkipped(


### PR DESCRIPTION
Testscases are not expected to be extended. So methods should be
`private` whenever possible.