### PR TITLE
[BUGFIX] Remove a stray `backupGlobals` from a legacy test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Removed
 
 ### Fixed
+- Remove a stray `backupGlobals` from a legacy test (#1274)
 - Allow Composer plugins from `helhum/typo3-console-plugin` (#1264)
 - Fix PHPUnit warnings (#1262)
 - Dev-require and suggest the install tool (#1261)

--- a/Tests/LegacyUnit/Csv/CsvDownloaderTest.php
+++ b/Tests/LegacyUnit/Csv/CsvDownloaderTest.php
@@ -19,11 +19,6 @@ final class CsvDownloaderTest extends TestCase
     use BackEndTestsTrait;
 
     /**
-     * @var bool
-     */
-    protected $backupGlobals = true;
-
-    /**
      * @var CsvDownloader
      */
     private $subject = null;


### PR DESCRIPTION
This broken the fake FE in the affected testcase (and all subsequent tests)
on GitHub Actions.