### PR TITLE
[BUGFIX] Make the Composer dependencies explicit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Removed
 
 ### Fixed
+- Make the Composer dependencies explicit (#1283)
 - Avoid spilling over the request in the legacy tests (#1278, #1279)
 - Improve the type annotations (#1277, #1280)
 - Remove a stray `backupGlobals` from a legacy test (#1274)

--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,7 @@
 		"ext-pdo": "*",
 		"digedag/rn-base": "~1.13.15 || ~1.14.0",
 		"dmk/mkforms": "^10.0.2",
+		"doctrine/dbal": "^2.10",
 		"oliverklee/oelib": "^4.1.4",
 		"pelago/emogrifier": "^4.0.0 || ^5.0.1 || ^6.0.0",
 		"psr/http-message": "^1.0",


### PR DESCRIPTION
We should not depend on transitive dependencies.