### PR TITLE
[BUGFIX] Always set a slug for the fake homepage in the tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Removed
 
 ### Fixed
+- Improve the fake frontend in the tests (#1299)
 - Harden some queries (#1297)
 - Use `intExplode` where applicable (#1296)
 - Make the Composer dependencies explicit (#1283)

--- a/Tests/Functional/OldModel/Fixtures/SingleRootPage.xml
+++ b/Tests/Functional/OldModel/Fixtures/SingleRootPage.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<dataset>
+    <pages>
+        <uid>1</uid>
+        <slug>/home</slug>
+    </pages>
+</dataset>

--- a/Tests/Functional/OldModel/LegacyEventTest.php
+++ b/Tests/Functional/OldModel/LegacyEventTest.php
@@ -78,7 +78,8 @@ final class LegacyEventTest extends FunctionalTestCase
 
     private function buildFrontEndAndPlugin(): DefaultController
     {
-        $this->testingFramework->createFakeFrontEnd();
+        $this->importDataSet(__DIR__ . '/Fixtures/SingleRootPage.xml');
+        $this->testingFramework->createFakeFrontEnd(1);
         $this->initializeBackEndLanguage();
 
         $plugin = new DefaultController();

--- a/Tests/LegacyUnit/FrontEnd/AbstractEditorTest.php
+++ b/Tests/LegacyUnit/FrontEnd/AbstractEditorTest.php
@@ -29,6 +29,7 @@ final class AbstractEditorTest extends TestCase
     {
         $this->testingFramework = new TestingFramework('tx_seminars');
         $rootPageUid = $this->testingFramework->createFrontEndPage();
+        $this->testingFramework->changeRecord('pages', $rootPageUid, ['slug' => '/home']);
         $this->testingFramework->createFakeFrontEnd($rootPageUid);
 
         $this->subject = new TestingEditor([], $this->getFrontEndController()->cObj);

--- a/Tests/LegacyUnit/FrontEnd/AbstractViewTest.php
+++ b/Tests/LegacyUnit/FrontEnd/AbstractViewTest.php
@@ -28,6 +28,7 @@ final class AbstractViewTest extends TestCase
     {
         $this->testingFramework = new TestingFramework('tx_seminars');
         $rootPageUid = $this->testingFramework->createFrontEndPage();
+        $this->testingFramework->changeRecord('pages', $rootPageUid, ['slug' => '/home']);
         $this->testingFramework->createFakeFrontEnd($rootPageUid);
         $this->subject = new TestingView(
             ['templateFile' => 'EXT:seminars/Resources/Private/Templates/FrontEnd/FrontEnd.html'],

--- a/Tests/LegacyUnit/FrontEnd/CategoryListTest.php
+++ b/Tests/LegacyUnit/FrontEnd/CategoryListTest.php
@@ -40,8 +40,9 @@ final class CategoryListTest extends TestCase
         $GLOBALS['SIM_EXEC_TIME'] = 1524751343;
 
         $this->testingFramework = new TestingFramework('tx_seminars');
-        $pageUid = $this->testingFramework->createFrontEndPage();
-        $this->testingFramework->createFakeFrontEnd($pageUid);
+        $rootPageUid = $this->testingFramework->createFrontEndPage();
+        $this->testingFramework->changeRecord('pages', $rootPageUid, ['slug' => '/home']);
+        $this->testingFramework->createFakeFrontEnd($rootPageUid);
 
         $this->systemFolderPid = $this->testingFramework->createSystemFolder();
         $this->subject = new CategoryList(

--- a/Tests/LegacyUnit/FrontEnd/CountdownTest.php
+++ b/Tests/LegacyUnit/FrontEnd/CountdownTest.php
@@ -46,6 +46,7 @@ final class CountdownTest extends TestCase
 
         $this->testingFramework = new TestingFramework('tx_seminars');
         $rootPageUid = $this->testingFramework->createFrontEndPage();
+        $this->testingFramework->changeRecord('pages', $rootPageUid, ['slug' => '/home']);
         $this->testingFramework->createFakeFrontEnd($rootPageUid);
 
         /** @var EventMapper&MockObject $mapper */

--- a/Tests/LegacyUnit/FrontEnd/DefaultControllerTest.php
+++ b/Tests/LegacyUnit/FrontEnd/DefaultControllerTest.php
@@ -127,8 +127,9 @@ final class DefaultControllerTest extends TestCase
         $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['seminars'] = [];
 
         $this->testingFramework = new TestingFramework('tx_seminars');
-        $pageUid = $this->testingFramework->createFrontEndPage();
-        $this->testingFramework->createFakeFrontEnd($pageUid);
+        $rootPageUid = $this->testingFramework->createFrontEndPage();
+        $this->testingFramework->changeRecord('pages', $rootPageUid, ['slug' => '/home']);
+        $this->testingFramework->createFakeFrontEnd($rootPageUid);
         HeaderProxyFactory::getInstance()->enableTestMode();
         $headerCollector = HeaderProxyFactory::getInstance()->getHeaderCollector();
         $this->headerCollector = $headerCollector;

--- a/Tests/LegacyUnit/FrontEnd/EventEditorTest.php
+++ b/Tests/LegacyUnit/FrontEnd/EventEditorTest.php
@@ -68,8 +68,9 @@ final class EventEditorTest extends TestCase
 
         $this->testingFramework = new TestingFramework('tx_seminars');
         MapperRegistry::getInstance()->activateTestingMode($this->testingFramework);
-        $pageUid = $this->testingFramework->createFrontEndPage();
-        $this->testingFramework->createFakeFrontEnd($pageUid);
+        $rootPageUid = $this->testingFramework->createFrontEndPage();
+        $this->testingFramework->changeRecord('pages', $rootPageUid, ['slug' => '/home']);
+        $this->testingFramework->createFakeFrontEnd($rootPageUid);
 
         $sharedConfiguration = new DummyConfiguration(self::CONFIGURATION);
         ConfigurationRegistry::getInstance()->set('plugin.tx_seminars', $sharedConfiguration);

--- a/Tests/LegacyUnit/FrontEnd/EventPublicationTest.php
+++ b/Tests/LegacyUnit/FrontEnd/EventPublicationTest.php
@@ -33,6 +33,7 @@ final class EventPublicationTest extends TestCase
     {
         $this->testingFramework = new TestingFramework('tx_seminars');
         $rootPageUid = $this->testingFramework->createFrontEndPage();
+        $this->testingFramework->changeRecord('pages', $rootPageUid, ['slug' => '/home']);
         $this->testingFramework->createFakeFrontEnd($rootPageUid);
         $this->subject = new EventPublication();
     }

--- a/Tests/LegacyUnit/FrontEnd/RegistrationFormTest.php
+++ b/Tests/LegacyUnit/FrontEnd/RegistrationFormTest.php
@@ -59,8 +59,9 @@ final class RegistrationFormTest extends TestCase
     protected function setUp(): void
     {
         $this->testingFramework = new TestingFramework('tx_seminars');
-        $frontEndPageUid = $this->testingFramework->createFrontEndPage();
-        $this->testingFramework->createFakeFrontEnd($frontEndPageUid);
+        $rootPageUid = $this->testingFramework->createFrontEndPage();
+        $this->testingFramework->changeRecord('pages', $rootPageUid, ['slug' => '/home']);
+        $this->testingFramework->createFakeFrontEnd($rootPageUid);
 
         $this->session = new FakeSession();
         Session::setInstance(Session::TYPE_USER, $this->session);
@@ -82,9 +83,9 @@ final class RegistrationFormTest extends TestCase
 
         $this->subject = new RegistrationForm(
             [
-                'pageToShowAfterUnregistrationPID' => $frontEndPageUid,
+                'pageToShowAfterUnregistrationPID' => $rootPageUid,
                 'sendParametersToThankYouAfterRegistrationPageUrl' => 1,
-                'thankYouAfterRegistrationPID' => $frontEndPageUid,
+                'thankYouAfterRegistrationPID' => $rootPageUid,
                 'sendParametersToPageToShowAfterUnregistrationUrl' => 1,
                 'templateFile' => 'EXT:seminars/Resources/Private/Templates/FrontEnd/FrontEnd.html',
                 'logOutOneTimeAccountsAfterRegistration' => 1,

--- a/Tests/LegacyUnit/FrontEnd/RegistrationsListTest.php
+++ b/Tests/LegacyUnit/FrontEnd/RegistrationsListTest.php
@@ -54,8 +54,9 @@ final class RegistrationsListTest extends TestCase
         HeaderProxyFactory::getInstance()->enableTestMode();
 
         $this->testingFramework = new TestingFramework('tx_seminars');
-        $pageUid = $this->testingFramework->createFrontEndPage();
-        $this->testingFramework->createFakeFrontEnd($pageUid);
+        $rootPageUid = $this->testingFramework->createFrontEndPage();
+        $this->testingFramework->changeRecord('pages', $rootPageUid, ['slug' => '/home']);
+        $this->testingFramework->createFakeFrontEnd($rootPageUid);
 
         $this->seminarUid = $this->testingFramework->createRecord(
             'tx_seminars_seminars',

--- a/Tests/LegacyUnit/FrontEnd/RequirementsListTest.php
+++ b/Tests/LegacyUnit/FrontEnd/RequirementsListTest.php
@@ -42,8 +42,9 @@ final class RequirementsListTest extends TestCase
     protected function setUp(): void
     {
         $this->testingFramework = new TestingFramework('tx_seminars');
-        $pageUid = $this->testingFramework->createFrontEndPage();
-        $this->testingFramework->createFakeFrontEnd($pageUid);
+        $rootPageUid = $this->testingFramework->createFrontEndPage();
+        $this->testingFramework->changeRecord('pages', $rootPageUid, ['slug' => '/home']);
+        $this->testingFramework->createFakeFrontEnd($rootPageUid);
 
         $systemFolderPid = $this->testingFramework->createSystemFolder();
 

--- a/Tests/LegacyUnit/FrontEnd/SelectorWidgetTest.php
+++ b/Tests/LegacyUnit/FrontEnd/SelectorWidgetTest.php
@@ -41,6 +41,7 @@ final class SelectorWidgetTest extends TestCase
     {
         $this->testingFramework = new TestingFramework('tx_seminars');
         $rootPageUid = $this->testingFramework->createFrontEndPage();
+        $this->testingFramework->changeRecord('pages', $rootPageUid, ['slug' => '/home']);
         $this->testingFramework->createFakeFrontEnd($rootPageUid);
 
         $this->subject = new SelectorWidget(

--- a/Tests/LegacyUnit/OldModel/LegacyEventTest.php
+++ b/Tests/LegacyUnit/OldModel/LegacyEventTest.php
@@ -117,8 +117,9 @@ final class LegacyEventTest extends TestCase
      */
     private function createPi1(int $detailPageUid = 0): void
     {
-        $pageUid = $this->testingFramework->createFrontEndPage();
-        $this->testingFramework->createFakeFrontEnd($pageUid);
+        $rootPageUid = $this->testingFramework->createFrontEndPage();
+        $this->testingFramework->changeRecord('pages', $rootPageUid, ['slug' => '/home']);
+        $this->testingFramework->createFakeFrontEnd($rootPageUid);
 
         $this->pi1 = new DefaultController();
         $this->pi1->init(
@@ -5075,8 +5076,9 @@ final class LegacyEventTest extends TestCase
      */
     public function isOwnerFeUserForLoggedInUserOtherThanOwnerReturnsFalse(): void
     {
-        $pageUid = $this->testingFramework->createFrontEndPage();
-        $this->testingFramework->createFakeFrontEnd($pageUid);
+        $rootPageUid = $this->testingFramework->createFrontEndPage();
+        $this->testingFramework->changeRecord('pages', $rootPageUid, ['slug' => '/home']);
+        $this->testingFramework->createFakeFrontEnd($rootPageUid);
         $userUid = $this->testingFramework->createAndLoginFrontEndUser();
 
         $this->subject->setOwnerUid($userUid + 1);
@@ -5091,8 +5093,9 @@ final class LegacyEventTest extends TestCase
      */
     public function isOwnerFeUserForLoggedInUserOtherThanOwnerReturnsTrue(): void
     {
-        $pageUid = $this->testingFramework->createFrontEndPage();
-        $this->testingFramework->createFakeFrontEnd($pageUid);
+        $rootPageUid = $this->testingFramework->createFrontEndPage();
+        $this->testingFramework->changeRecord('pages', $rootPageUid, ['slug' => '/home']);
+        $this->testingFramework->createFakeFrontEnd($rootPageUid);
         $ownerUid = $this->testingFramework->createAndLoginFrontEndUser();
         $this->subject->setOwnerUid($ownerUid);
 
@@ -5108,8 +5111,9 @@ final class LegacyEventTest extends TestCase
      */
     public function getOwnerForExistingOwnerReturnsFrontEndUserInstance(): void
     {
-        $pageUid = $this->testingFramework->createFrontEndPage();
-        $this->testingFramework->createFakeFrontEnd($pageUid);
+        $rootPageUid = $this->testingFramework->createFrontEndPage();
+        $this->testingFramework->changeRecord('pages', $rootPageUid, ['slug' => '/home']);
+        $this->testingFramework->createFakeFrontEnd($rootPageUid);
         $ownerUid = $this->testingFramework->createAndLoginFrontEndUser();
         $this->subject->setOwnerUid($ownerUid);
 
@@ -5121,8 +5125,9 @@ final class LegacyEventTest extends TestCase
      */
     public function getOwnerForExistingOwnerReturnsUserWithOwnersUid(): void
     {
-        $pageUid = $this->testingFramework->createFrontEndPage();
-        $this->testingFramework->createFakeFrontEnd($pageUid);
+        $rootPageUid = $this->testingFramework->createFrontEndPage();
+        $this->testingFramework->changeRecord('pages', $rootPageUid, ['slug' => '/home']);
+        $this->testingFramework->createFakeFrontEnd($rootPageUid);
         $ownerUid = $this->testingFramework->createAndLoginFrontEndUser();
         $this->subject->setOwnerUid($ownerUid);
 
@@ -5149,8 +5154,9 @@ final class LegacyEventTest extends TestCase
      */
     public function hasOwnerForExistingOwnerReturnsTrue(): void
     {
-        $pageUid = $this->testingFramework->createFrontEndPage();
-        $this->testingFramework->createFakeFrontEnd($pageUid);
+        $rootPageUid = $this->testingFramework->createFrontEndPage();
+        $this->testingFramework->changeRecord('pages', $rootPageUid, ['slug' => '/home']);
+        $this->testingFramework->createFakeFrontEnd($rootPageUid);
         $ownerUid = $this->testingFramework->createAndLoginFrontEndUser();
         $this->subject->setOwnerUid($ownerUid);
 
@@ -7485,8 +7491,9 @@ final class LegacyEventTest extends TestCase
             ->willReturn($isVip);
 
         if ($loggedIn) {
-            $pageUid = $this->testingFramework->createFrontEndPage();
-            $this->testingFramework->createFakeFrontEnd($pageUid);
+            $rootPageUid = $this->testingFramework->createFrontEndPage();
+            $this->testingFramework->changeRecord('pages', $rootPageUid, ['slug' => '/home']);
+            $this->testingFramework->createFakeFrontEnd($rootPageUid);
             $this->testingFramework->createAndLoginFrontEndUser();
         }
 
@@ -7527,8 +7534,9 @@ final class LegacyEventTest extends TestCase
             ->willReturn($isVip);
 
         if ($loggedIn) {
-            $pageUid = $this->testingFramework->createFrontEndPage();
-            $this->testingFramework->createFakeFrontEnd($pageUid);
+            $rootPageUid = $this->testingFramework->createFrontEndPage();
+            $this->testingFramework->changeRecord('pages', $rootPageUid, ['slug' => '/home']);
+            $this->testingFramework->createFakeFrontEnd($rootPageUid);
             $this->testingFramework->createAndLoginFrontEndUser();
         }
 
@@ -7599,8 +7607,9 @@ final class LegacyEventTest extends TestCase
             ->willReturn($isVip);
 
         if ($loggedIn) {
-            $pageUid = $this->testingFramework->createFrontEndPage();
-            $this->testingFramework->createFakeFrontEnd($pageUid);
+            $rootPageUid = $this->testingFramework->createFrontEndPage();
+            $this->testingFramework->changeRecord('pages', $rootPageUid, ['slug' => '/home']);
+            $this->testingFramework->createFakeFrontEnd($rootPageUid);
             $this->testingFramework->createAndLoginFrontEndUser();
         }
 
@@ -7794,8 +7803,9 @@ final class LegacyEventTest extends TestCase
             ->willReturn($isVip);
 
         if ($loggedIn) {
-            $pageUid = $this->testingFramework->createFrontEndPage();
-            $this->testingFramework->createFakeFrontEnd($pageUid);
+            $rootPageUid = $this->testingFramework->createFrontEndPage();
+            $this->testingFramework->changeRecord('pages', $rootPageUid, ['slug' => '/home']);
+            $this->testingFramework->createFakeFrontEnd($rootPageUid);
             $this->testingFramework->createAndLoginFrontEndUser();
         }
 
@@ -7995,8 +8005,9 @@ final class LegacyEventTest extends TestCase
             ->willReturn($isVip);
 
         if ($loggedIn) {
-            $pageUid = $this->testingFramework->createFrontEndPage();
-            $this->testingFramework->createFakeFrontEnd($pageUid);
+            $rootPageUid = $this->testingFramework->createFrontEndPage();
+            $this->testingFramework->changeRecord('pages', $rootPageUid, ['slug' => '/home']);
+            $this->testingFramework->createFakeFrontEnd($rootPageUid);
             $this->testingFramework->createAndLoginFrontEndUser();
         }
 
@@ -8160,8 +8171,9 @@ final class LegacyEventTest extends TestCase
             ->with($whichPlugin, 0, 0, 0, $accessLevel)
             ->willReturn(true);
 
-        $pageUid = $this->testingFramework->createFrontEndPage();
-        $this->testingFramework->createFakeFrontEnd($pageUid);
+        $rootPageUid = $this->testingFramework->createFrontEndPage();
+        $this->testingFramework->changeRecord('pages', $rootPageUid, ['slug' => '/home']);
+        $this->testingFramework->createFakeFrontEnd($rootPageUid);
         $this->testingFramework->createAndLoginFrontEndUser();
 
         $subject->canViewRegistrationsListMessage($whichPlugin, $accessLevel);
@@ -8180,8 +8192,9 @@ final class LegacyEventTest extends TestCase
         $subject->method('needsRegistration')->willReturn(true);
         $subject->method('canViewRegistrationsList')->willReturn(true);
 
-        $pageUid = $this->testingFramework->createFrontEndPage();
-        $this->testingFramework->createFakeFrontEnd($pageUid);
+        $rootPageUid = $this->testingFramework->createFrontEndPage();
+        $this->testingFramework->changeRecord('pages', $rootPageUid, ['slug' => '/home']);
+        $this->testingFramework->createFakeFrontEnd($rootPageUid);
         $this->testingFramework->createAndLoginFrontEndUser();
 
         self::assertSame(
@@ -8203,8 +8216,9 @@ final class LegacyEventTest extends TestCase
         $subject->method('needsRegistration')->willReturn(true);
         $subject->method('canViewRegistrationsList')->willReturn(false);
 
-        $pageUid = $this->testingFramework->createFrontEndPage();
-        $this->testingFramework->createFakeFrontEnd($pageUid);
+        $rootPageUid = $this->testingFramework->createFrontEndPage();
+        $this->testingFramework->changeRecord('pages', $rootPageUid, ['slug' => '/home']);
+        $this->testingFramework->createFakeFrontEnd($rootPageUid);
         $this->testingFramework->createAndLoginFrontEndUser();
 
         self::assertSame(

--- a/Tests/LegacyUnit/OldModel/LegacyRegistrationTest.php
+++ b/Tests/LegacyUnit/OldModel/LegacyRegistrationTest.php
@@ -58,6 +58,7 @@ final class LegacyRegistrationTest extends TestCase
 
         $this->testingFramework = new TestingFramework('tx_seminars');
         $rootPageUid = $this->testingFramework->createFrontEndPage();
+        $this->testingFramework->changeRecord('pages', $rootPageUid, ['slug' => '/home']);
         $this->testingFramework->createFakeFrontEnd($rootPageUid);
 
         $this->configuration = new DummyConfiguration();

--- a/Tests/LegacyUnit/Service/RegistrationManagerTest.php
+++ b/Tests/LegacyUnit/Service/RegistrationManagerTest.php
@@ -145,8 +145,9 @@ final class RegistrationManagerTest extends TestCase
         $this->extConfBackup = $GLOBALS['TYPO3_CONF_VARS']['EXTCONF'];
 
         $this->testingFramework = new TestingFramework('tx_seminars');
-        $pageUid = $this->testingFramework->createFrontEndPage();
-        $this->testingFramework->createFakeFrontEnd($pageUid);
+        $rootPageUid = $this->testingFramework->createFrontEndPage();
+        $this->testingFramework->changeRecord('pages', $rootPageUid, ['slug' => '/home']);
+        $this->testingFramework->createFakeFrontEnd($rootPageUid);
 
         $this->email = $this->createEmailMock();
         $this->secondEmail = $this->createEmailMock();


### PR DESCRIPTION
This helps with link creation in the functional and legacy tests.