### PR TITLE
[BUGFIX] Use proper slugs for pages in more legacy tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Removed
 
 ### Fixed
-- Improve the fake frontend in the tests (#1299)
+- Improve the fake frontend in the tests (#1299, #1300, #1301)
 - Harden some queries (#1297)
 - Use `intExplode` where applicable (#1296)
 - Make the Composer dependencies explicit (#1283)

--- a/Tests/LegacyUnit/FrontEnd/CategoryListTest.php
+++ b/Tests/LegacyUnit/FrontEnd/CategoryListTest.php
@@ -35,14 +35,19 @@ final class CategoryListTest extends TestCase
      */
     private $systemFolderPid = 0;
 
+    /**
+     * @var int
+     */
+    private $rootPageUid;
+
     protected function setUp(): void
     {
         $GLOBALS['SIM_EXEC_TIME'] = 1524751343;
 
         $this->testingFramework = new TestingFramework('tx_seminars');
-        $rootPageUid = $this->testingFramework->createFrontEndPage();
-        $this->testingFramework->changeRecord('pages', $rootPageUid, ['slug' => '/home']);
-        $this->testingFramework->createFakeFrontEnd($rootPageUid);
+        $this->rootPageUid = $this->testingFramework->createFrontEndPage();
+        $this->testingFramework->changeRecord('pages', $this->rootPageUid, ['slug' => '/home']);
+        $this->testingFramework->createFakeFrontEnd($this->rootPageUid);
 
         $this->systemFolderPid = $this->testingFramework->createSystemFolder();
         $this->subject = new CategoryList(
@@ -388,10 +393,9 @@ final class CategoryListTest extends TestCase
      */
     public function renderCreatesCategoryListContainingLinksToListPageLimitedToCategory(): void
     {
-        $this->subject->setConfigurationValue(
-            'listPID',
-            $this->testingFramework->createFrontEndPage()
-        );
+        $listPageUid = $this->testingFramework->createFrontEndPage($this->rootPageUid);
+        $this->testingFramework->changeRecord('pages', $listPageUid, ['slug' => '/eventList']);
+        $this->subject->setConfigurationValue('listPID', $listPageUid);
 
         $categoryUid = $this->testingFramework->createRecord(
             'tx_seminars_categories',

--- a/Tests/LegacyUnit/FrontEnd/DefaultControllerTest.php
+++ b/Tests/LegacyUnit/FrontEnd/DefaultControllerTest.php
@@ -119,6 +119,11 @@ final class DefaultControllerTest extends TestCase
      */
     private $pluginConfiguration;
 
+    /**
+     * @var int
+     */
+    private $rootPageUid;
+
     protected function setUp(): void
     {
         $GLOBALS['SIM_EXEC_TIME'] = 1524751343;
@@ -127,9 +132,9 @@ final class DefaultControllerTest extends TestCase
         $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['seminars'] = [];
 
         $this->testingFramework = new TestingFramework('tx_seminars');
-        $rootPageUid = $this->testingFramework->createFrontEndPage();
-        $this->testingFramework->changeRecord('pages', $rootPageUid, ['slug' => '/home']);
-        $this->testingFramework->createFakeFrontEnd($rootPageUid);
+        $this->rootPageUid = $this->testingFramework->createFrontEndPage();
+        $this->testingFramework->changeRecord('pages', $this->rootPageUid, ['slug' => '/home']);
+        $this->testingFramework->createFakeFrontEnd($this->rootPageUid);
         HeaderProxyFactory::getInstance()->enableTestMode();
         $headerCollector = HeaderProxyFactory::getInstance()->getHeaderCollector();
         $this->headerCollector = $headerCollector;

--- a/Tests/LegacyUnit/FrontEnd/RequirementsListTest.php
+++ b/Tests/LegacyUnit/FrontEnd/RequirementsListTest.php
@@ -37,14 +37,19 @@ final class RequirementsListTest extends TestCase
     /**
      * @var DummyConfiguration
      */
-    private $configuration;
+    private $pluginConfiguration;
+
+    /**
+     * @var int
+     */
+    private $rootPageUid;
 
     protected function setUp(): void
     {
         $this->testingFramework = new TestingFramework('tx_seminars');
-        $rootPageUid = $this->testingFramework->createFrontEndPage();
-        $this->testingFramework->changeRecord('pages', $rootPageUid, ['slug' => '/home']);
-        $this->testingFramework->createFakeFrontEnd($rootPageUid);
+        $this->rootPageUid = $this->testingFramework->createFrontEndPage();
+        $this->testingFramework->changeRecord('pages', $this->rootPageUid, ['slug' => '/home']);
+        $this->testingFramework->createFakeFrontEnd($this->rootPageUid);
 
         $systemFolderPid = $this->testingFramework->createSystemFolder();
 
@@ -56,8 +61,8 @@ final class RequirementsListTest extends TestCase
             ]
         );
 
-        $this->configuration = new DummyConfiguration();
-        ConfigurationRegistry::getInstance()->set('plugin.tx_seminars_pi1', $this->configuration);
+        $this->pluginConfiguration = new DummyConfiguration();
+        ConfigurationRegistry::getInstance()->set('plugin.tx_seminars_pi1', $this->pluginConfiguration);
 
         $this->subject = new RequirementsList(
             ['templateFile' => 'EXT:seminars/Resources/Private/Templates/FrontEnd/FrontEnd.html'],
@@ -131,7 +136,9 @@ final class RequirementsListTest extends TestCase
      */
     public function renderLinksOneRequirementToTheSingleView(): void
     {
-        $this->configuration->setAsInteger('detailPID', $this->testingFramework->createFrontEndPage());
+        $detailPageUid = $this->testingFramework->createFrontEndPage($this->rootPageUid);
+        $this->testingFramework->changeRecord('pages', $detailPageUid, ['slug' => '/eventDetail']);
+        $this->pluginConfiguration->setAsInteger('detailPID', $detailPageUid);
         $this->testingFramework->changeRecord(
             'tx_seminars_seminars',
             $this->seminarUid,

--- a/Tests/LegacyUnit/OldModel/LegacyEventTest.php
+++ b/Tests/LegacyUnit/OldModel/LegacyEventTest.php
@@ -115,7 +115,7 @@ final class LegacyEventTest extends TestCase
     /**
      * Creates a fake front end and a pi1 instance in `$this->pi1`.
      */
-    private function createPi1(int $detailPageUid = 0): void
+    private function createPi1(): void
     {
         $rootPageUid = $this->testingFramework->createFrontEndPage();
         $this->testingFramework->changeRecord('pages', $rootPageUid, ['slug' => '/home']);
@@ -126,7 +126,6 @@ final class LegacyEventTest extends TestCase
             [
                 'isStaticTemplateLoaded' => 1,
                 'templateFile' => 'EXT:seminars/Resources/Private/Templates/FrontEnd/FrontEnd.html',
-                'detailPID' => $detailPageUid,
             ]
         );
         $this->pi1->getTemplateCode();
@@ -4970,7 +4969,10 @@ final class LegacyEventTest extends TestCase
      */
     public function hasSeparateDetailsPageReturnsTrueForInternalSeparateDetailsPage(): void
     {
-        $detailsPageUid = $this->testingFramework->createFrontEndPage();
+        $rootPageUid = $this->testingFramework->createFrontEndPage();
+        $this->testingFramework->changeRecord('pages', $rootPageUid, ['slug' => '/home']);
+        $detailsPageUid = $this->testingFramework->createFrontEndPage($rootPageUid);
+        $this->testingFramework->changeRecord('pages', $detailsPageUid, ['slug' => '/eventDetail']);
         $eventUid = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
             [
@@ -5022,7 +5024,10 @@ final class LegacyEventTest extends TestCase
      */
     public function getDetailsPageForInternalSeparateDetailsPageSetReturnsThisPage(): void
     {
-        $detailsPageUid = $this->testingFramework->createFrontEndPage();
+        $rootPageUid = $this->testingFramework->createFrontEndPage();
+        $this->testingFramework->changeRecord('pages', $rootPageUid, ['slug' => '/home']);
+        $detailsPageUid = $this->testingFramework->createFrontEndPage($rootPageUid);
+        $this->testingFramework->changeRecord('pages', $detailsPageUid, ['slug' => '/eventDetail']);
         $eventUid = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
             [

--- a/Tests/LegacyUnit/Service/RegistrationManagerTest.php
+++ b/Tests/LegacyUnit/Service/RegistrationManagerTest.php
@@ -138,6 +138,11 @@ final class RegistrationManagerTest extends TestCase
      */
     private $extensionConfiguration;
 
+    /**
+     * @var int
+     */
+    private $rootPageUid;
+
     protected function setUp(): void
     {
         $GLOBALS['SIM_EXEC_TIME'] = 1524751343;
@@ -145,9 +150,9 @@ final class RegistrationManagerTest extends TestCase
         $this->extConfBackup = $GLOBALS['TYPO3_CONF_VARS']['EXTCONF'];
 
         $this->testingFramework = new TestingFramework('tx_seminars');
-        $rootPageUid = $this->testingFramework->createFrontEndPage();
-        $this->testingFramework->changeRecord('pages', $rootPageUid, ['slug' => '/home']);
-        $this->testingFramework->createFakeFrontEnd($rootPageUid);
+        $this->rootPageUid = $this->testingFramework->createFrontEndPage();
+        $this->testingFramework->changeRecord('pages', $this->rootPageUid, ['slug' => '/home']);
+        $this->testingFramework->createFakeFrontEnd($this->rootPageUid);
 
         $this->email = $this->createEmailMock();
         $this->secondEmail = $this->createEmailMock();
@@ -232,15 +237,14 @@ final class RegistrationManagerTest extends TestCase
 
     /**
      * Creates a dummy login page and registration page and stores their UIDs
-     * in $this->loginPageUid and $this->registrationPageUid.
+     * in `$this->loginPageUid` and `$this->registrationPageUid`.
      *
      * In addition, it provides the fixture's configuration with the UIDs.
      */
     private function createFrontEndPages(): void
     {
         $this->loginPageUid = $this->testingFramework->createFrontEndPage();
-        $this->registrationPageUid
-            = $this->testingFramework->createFrontEndPage();
+        $this->registrationPageUid = $this->testingFramework->createFrontEndPage();
 
         $this->pi1 = new DefaultController();
 


### PR DESCRIPTION
Also make all pages subpages of the root page.

This gets more links in the legacy tests to run in V10.

Part of #1285