### PR TITLE
[BUGFIX] Require `typo3/class-alias-loader` >= 1.1.0 for development

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Removed
 
 ### Fixed
+- Require `typo3/class-alias-loader` >= 1.1.0 for development (#1245, #1351)
 - Keep development-only files out of the TER releases (#1241, #1348)
 - Create mkforms-related directories on the fly (#1211)
 

--- a/composer.json
+++ b/composer.json
@@ -51,6 +51,7 @@
 		"phpspec/prophecy": "^1.10.3",
 		"phpunit/phpunit": "^6.5.14",
 		"squizlabs/php_codesniffer": "^3.6.0",
+		"typo3/class-alias-loader": "^1.1.0",
 		"typo3/cms-scheduler": "^8.7 || ^9.5"
 	},
 	"suggest": {


### PR DESCRIPTION
This avoids a crash when installing the Composer packages (including
the development packages) with Composer 1 with the lowest
dependencies.