### PR TITLE
[BUGFIX] Downgrade the unit and functional tests on CI to Composer 1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           php-version: "${{ matrix.php-version }}"
-          tools: composer:v2
+          tools: composer:v1
           extensions: dom, json, libxml, zip
           coverage: none
       - name: "Show Composer version"
@@ -136,7 +136,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           php-version: "${{ matrix.php-version }}"
-          tools: composer:v2
+          tools: composer:v1
           extensions: dom, json, libxml, mysqli, zip
           coverage: none
       - name: "Show Composer version"


### PR DESCRIPTION
This fixes a crash during `composer install` with TYPO3 8.7 on PHP 7.2
due to an imcompatibility in `class_alias_loader`.