### PR TITLE
[BUGFIX] Add missing import in the FE form base class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Removed
 
 ### Fixed
+- Add missing import in the FE form base class (#1367)
 
 ## 3.4.2
 

--- a/Classes/FrontEnd/Editor.php
+++ b/Classes/FrontEnd/Editor.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Sys25\RnBase\Configuration\Processor as ConfigurationProcessor;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
  * This class is the base class for any kind of front-end editor, for example the event editor or the registration editor.


### PR DESCRIPTION
This fixes a potential crash in the FE event editor and registration
form.

Fixes #1366