### PR TITLE
[BUGFIX] Configure the PHP platform for Dependabot

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -92,6 +92,9 @@
 	},
 	"prefer-stable": true,
 	"config": {
+		"platform": {
+			"php": "7.2.9"
+		},
 		"preferred-install": {
 			"*": "dist"
 		},


### PR DESCRIPTION
Without a PHP version set via `platform` in `composer.json`,
Dependabot will try to update to a version of `php-cs-fixer` that
our current PHP version does not support, which causes Dependabot
to choke.