### PR TITLE
[CLEANUP] Drop redundant type annotations for mocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 - Fix a flaky test (#1403, #1408)
-- Drop redundant type annotations (#1401)
+- Improve the type annotations (#1401, #1417)
 
 ## 4.1.5
 

--- a/Tests/Functional/SchedulerTasks/MailNotifierConfigurationTest.php
+++ b/Tests/Functional/SchedulerTasks/MailNotifierConfigurationTest.php
@@ -48,7 +48,6 @@ final class MailNotifierConfigurationTest extends FunctionalTestCase
         $this->setUpBackendUserFromFixture(1);
         $this->initializeBackEndLanguage();
 
-        /** @var SchedulerModuleController&MockObject $moduleController */
         $moduleController = $this->createMock(SchedulerModuleController::class);
         $this->moduleController = $moduleController;
         // We can remove this line once we have moved to PHPUnit 7.5.
@@ -200,7 +199,6 @@ final class MailNotifierConfigurationTest extends FunctionalTestCase
         $pageUid = 1;
         $submittedData = ['seminars_configurationPageUid' => (string)$pageUid];
 
-        /** @var MailNotifier&MockObject $task */
         $task = $this->createMock(MailNotifier::class);
         $task->expects(self::once())->method('setConfigurationPageUid')->with($pageUid);
 

--- a/Tests/Functional/SchedulerTasks/MailNotifierTest.php
+++ b/Tests/Functional/SchedulerTasks/MailNotifierTest.php
@@ -13,7 +13,6 @@ use OliverKlee\Oelib\Model\BackEndUser;
 use OliverKlee\Seminars\SchedulerTasks\MailNotifier;
 use OliverKlee\Seminars\SchedulerTasks\RegistrationDigest;
 use OliverKlee\Seminars\Tests\Functional\Traits\LanguageHelper;
-use PHPUnit\Framework\MockObject\MockObject;
 use Prophecy\Prophecy\ObjectProphecy;
 use TYPO3\CMS\Core\Localization\LanguageService;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -152,7 +151,6 @@ final class MailNotifierTest extends FunctionalTestCase
     public function executeWithPageConfigurationCallsAllSeparateSteps(): void
     {
         $this->importDataSet(__DIR__ . '/Fixtures/MailNotifierConfiguration.xml');
-        /** @var MailNotifier&MockObject $subject */
         $subject = $this->createPartialMock(
             MailNotifier::class,
             ['sendEventTakesPlaceReminders', 'sendCancellationDeadlineReminders', 'automaticallyChangeEventStatuses']
@@ -171,7 +169,6 @@ final class MailNotifierTest extends FunctionalTestCase
      */
     public function executeWithoutPageConfigurationNotCallsAnySeparateStep(): void
     {
-        /** @var MailNotifier&MockObject $subject */
         $subject = $this->createPartialMock(
             MailNotifier::class,
             ['sendEventTakesPlaceReminders', 'sendCancellationDeadlineReminders', 'automaticallyChangeEventStatuses']
@@ -191,7 +188,6 @@ final class MailNotifierTest extends FunctionalTestCase
     public function executeWithPageConfigurationExecutesRegistrationDigest(): void
     {
         $this->importDataSet(__DIR__ . '/Fixtures/MailNotifierConfiguration.xml');
-        /** @var MailNotifier&MockObject $subject */
         $subject = $this->createPartialMock(
             MailNotifier::class,
             ['sendEventTakesPlaceReminders', 'sendCancellationDeadlineReminders', 'automaticallyChangeEventStatuses']

--- a/Tests/LegacyUnit/Csv/AbstractRegistrationListViewTest.php
+++ b/Tests/LegacyUnit/Csv/AbstractRegistrationListViewTest.php
@@ -100,7 +100,6 @@ final class AbstractRegistrationListViewTest extends TestCase
             ]
         );
 
-        /** @var AbstractRegistrationListView&MockObject $subject */
         $subject = $this->getMockForAbstractClass(AbstractRegistrationListView::class);
         $subject->method('shouldAlsoContainRegistrationsOnQueue')->willReturn(true);
 
@@ -311,7 +310,6 @@ final class AbstractRegistrationListViewTest extends TestCase
     {
         $this->expectException(\BadMethodCallException::class);
 
-        /** @var AbstractRegistrationListView&MockObject $subject */
         $subject = $this->getMockForAbstractClass(AbstractRegistrationListView::class);
 
         self::assertSame(
@@ -327,7 +325,6 @@ final class AbstractRegistrationListViewTest extends TestCase
     {
         $this->expectException(\BadMethodCallException::class);
 
-        /** @var AbstractRegistrationListView&MockObject $subject */
         $subject = $this->getMockForAbstractClass(AbstractRegistrationListView::class);
         $subject->setEventUid($this->eventUid);
         $subject->setPageUid($this->pageUid);

--- a/Tests/LegacyUnit/Csv/BackEndEventAccessCheckTest.php
+++ b/Tests/LegacyUnit/Csv/BackEndEventAccessCheckTest.php
@@ -32,7 +32,6 @@ final class BackEndEventAccessCheckTest extends TestCase
     protected function setUp(): void
     {
         $this->backEndUserBackup = $GLOBALS['BE_USER'];
-        /** @var BackendUserAuthentication&MockObject $backEndUser */
         $backEndUser = $this->createMock(BackendUserAuthentication::class);
         $this->backEndUser = $backEndUser;
         $GLOBALS['BE_USER'] = $backEndUser;

--- a/Tests/LegacyUnit/Csv/BackEndRegistrationAccessCheckTest.php
+++ b/Tests/LegacyUnit/Csv/BackEndRegistrationAccessCheckTest.php
@@ -38,7 +38,6 @@ final class BackEndRegistrationAccessCheckTest extends TestCase
     protected function setUp(): void
     {
         $this->backEndUserBackup = $GLOBALS['BE_USER'];
-        /** @var BackendUserAuthentication&MockObject $backEndUser */
         $backEndUser = $this->createMock(BackendUserAuthentication::class);
         $this->backEndUser = $backEndUser;
         $GLOBALS['BE_USER'] = $backEndUser;

--- a/Tests/LegacyUnit/Csv/FrontEndRegistrationAccessCheckTest.php
+++ b/Tests/LegacyUnit/Csv/FrontEndRegistrationAccessCheckTest.php
@@ -11,7 +11,6 @@ use OliverKlee\Seminars\Csv\FrontEndRegistrationAccessCheck;
 use OliverKlee\Seminars\Csv\Interfaces\CsvAccessCheck;
 use OliverKlee\Seminars\Model\FrontEndUser;
 use OliverKlee\Seminars\OldModel\LegacyEvent;
-use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 final class FrontEndRegistrationAccessCheckTest extends TestCase
@@ -67,7 +66,6 @@ final class FrontEndRegistrationAccessCheckTest extends TestCase
     {
         FrontEndLoginManager::getInstance()->logInUser();
 
-        /** @var LegacyEvent&MockObject $event */
         $event = $this->createMock(LegacyEvent::class);
         $this->subject->setEvent($event);
 
@@ -83,13 +81,11 @@ final class FrontEndRegistrationAccessCheckTest extends TestCase
     {
         $this->seminarsPluginConfiguration->setAsBoolean('allowCsvExportOfRegistrationsInMyVipEventsView', false);
 
-        /** @var FrontEndUser&MockObject $user */
         $user = $this->createMock(FrontEndUser::class);
         $userUid = 42;
         $user->method('getUid')->willReturn($userUid);
         FrontEndLoginManager::getInstance()->logInUser($user);
 
-        /** @var LegacyEvent&MockObject $event */
         $event = $this->createMock(LegacyEvent::class);
         $event->method('isUserVip')->with(
             $userUid,
@@ -109,13 +105,11 @@ final class FrontEndRegistrationAccessCheckTest extends TestCase
     {
         $this->seminarsPluginConfiguration->setAsBoolean('allowCsvExportOfRegistrationsInMyVipEventsView', false);
 
-        /** @var FrontEndUser&MockObject $user */
         $user = $this->createMock(FrontEndUser::class);
         $userUid = 42;
         $user->method('getUid')->willReturn($userUid);
         FrontEndLoginManager::getInstance()->logInUser($user);
 
-        /** @var LegacyEvent&MockObject $event */
         $event = $this->createMock(LegacyEvent::class);
         $event->method('isUserVip')->with(
             $userUid,
@@ -135,13 +129,11 @@ final class FrontEndRegistrationAccessCheckTest extends TestCase
     {
         $this->seminarsPluginConfiguration->setAsBoolean('allowCsvExportOfRegistrationsInMyVipEventsView', true);
 
-        /** @var FrontEndUser&MockObject $user */
         $user = $this->createMock(FrontEndUser::class);
         $userUid = 42;
         $user->method('getUid')->willReturn($userUid);
         FrontEndLoginManager::getInstance()->logInUser($user);
 
-        /** @var LegacyEvent&MockObject $event */
         $event = $this->createMock(LegacyEvent::class);
         $event->method('isUserVip')->with(
             $userUid,
@@ -161,13 +153,11 @@ final class FrontEndRegistrationAccessCheckTest extends TestCase
     {
         $this->seminarsPluginConfiguration->setAsBoolean('allowCsvExportOfRegistrationsInMyVipEventsView', true);
 
-        /** @var FrontEndUser&MockObject $user */
         $user = $this->createMock(FrontEndUser::class);
         $userUid = 42;
         $user->method('getUid')->willReturn($userUid);
         FrontEndLoginManager::getInstance()->logInUser($user);
 
-        /** @var LegacyEvent&MockObject $event */
         $event = $this->createMock(LegacyEvent::class);
         $event->method('isUserVip')->with($userUid, $this->vipsGroupUid)
             ->willReturn(true);

--- a/Tests/LegacyUnit/FrontEnd/CountdownTest.php
+++ b/Tests/LegacyUnit/FrontEnd/CountdownTest.php
@@ -49,7 +49,6 @@ final class CountdownTest extends TestCase
         $this->testingFramework->changeRecord('pages', $rootPageUid, ['slug' => '/home']);
         $this->testingFramework->createFakeFrontEnd($rootPageUid);
 
-        /** @var EventMapper&MockObject $mapper */
         $mapper = $this->getMockBuilder(EventMapper::class)->setMethods(['findNextUpcoming'])->getMock();
         $this->mapper = $mapper;
 
@@ -137,7 +136,6 @@ final class CountdownTest extends TestCase
             ->method('findNextUpcoming')
             ->willReturn($event);
 
-        /** @var CountdownViewHelper&MockObject $viewHelper */
         $viewHelper = $this->createPartialMock(CountdownViewHelper::class, ['render']);
         $viewHelper->expects(self::once())
             ->method('render')

--- a/Tests/LegacyUnit/FrontEnd/DefaultControllerTest.php
+++ b/Tests/LegacyUnit/FrontEnd/DefaultControllerTest.php
@@ -28,7 +28,6 @@ use OliverKlee\Seminars\Service\RegistrationManager;
 use OliverKlee\Seminars\Tests\Functional\FrontEnd\Fixtures\TestingDefaultController;
 use OliverKlee\Seminars\Tests\Functional\Traits\LanguageHelper;
 use OliverKlee\Seminars\Tests\LegacyUnit\Fixtures\OldModel\TestingLegacyEvent;
-use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
 use TYPO3\CMS\Core\Database\ConnectionPool;
@@ -182,7 +181,6 @@ final class DefaultControllerTest extends TestCase
         $this->subject->setLabels();
         $this->subject->createHelperObjects();
 
-        /** @var ContentObjectRenderer&MockObject $contentObject */
         $contentObject = $this->createPartialMock(ContentObjectRenderer::class, ['cObjGetSingle']);
         $contentObject->setLogger(new NullLogger());
         $contentObject->method('cObjGetSingle')->willReturn('<img src="foo.jpg" alt="bar"/>');
@@ -6525,7 +6523,6 @@ final class DefaultControllerTest extends TestCase
         $subject = new TestingDefaultController();
         $subject->cObj = $this->getFrontEndController()->cObj;
         $subject->conf = [];
-        /** @var LegacyEvent&MockObject $event */
         $event = $this->createPartialMock(LegacyEvent::class, ['getUid', 'isUserVip', 'isOwnerFeUser']);
         $event->method('isUserVip')
             ->willReturn(false);
@@ -6547,7 +6544,6 @@ final class DefaultControllerTest extends TestCase
 
         $subject->cObj = $this->getFrontEndController()->cObj;
         $subject->conf = ['mayManagersEditTheirEvents' => true];
-        /** @var LegacyEvent&MockObject $event */
         $event = $this->createPartialMock(LegacyEvent::class, ['getUid', 'isUserVip', 'isOwnerFeUser']);
         $event->method('isUserVip')
             ->willReturn(true);
@@ -6569,7 +6565,6 @@ final class DefaultControllerTest extends TestCase
 
         $subject->cObj = $this->getFrontEndController()->cObj;
         $subject->conf = ['mayManagersEditTheirEvents' => false];
-        /** @var LegacyEvent&MockObject $event */
         $event = $this->createPartialMock(LegacyEvent::class, ['getUid', 'isUserVip', 'isOwnerFeUser']);
         $event->method('isUserVip')
             ->willReturn(true);
@@ -6598,7 +6593,6 @@ final class DefaultControllerTest extends TestCase
             'eventEditorPID' => $editorPageUid,
             'mayManagersEditTheirEvents' => true,
         ];
-        /** @var LegacyEvent&MockObject $event */
         $event = $this->createPartialMock(LegacyEvent::class, ['getUid', 'isUserVip', 'isOwnerFeUser']);
         $event->method('getUid')
             ->willReturn(91);
@@ -6624,14 +6618,12 @@ final class DefaultControllerTest extends TestCase
         $editorPageSlug = '/eventEditor';
         $this->testingFramework->changeRecord('pages', $editorPageUid, ['slug' => $editorPageSlug]);
 
-        /** @var TestingDefaultController&MockObject $subject */
         $subject = $this->createPartialMock(TestingDefaultController::class, ['mayCurrentUserEditCurrentEvent']);
         $subject->cObj = $this->getFrontEndController()->cObj;
         $subject->conf = ['eventEditorPID' => $editorPageUid];
         $subject->expects(self::once())->method('mayCurrentUserEditCurrentEvent')
             ->willReturn(false);
 
-        /** @var LegacyEvent&MockObject $event */
         $event = $this->createPartialMock(LegacyEvent::class, ['getUid', 'isPublished', 'isHidden']);
         $event->method('getUid')->willReturn(91);
         $subject->setSeminar($event);
@@ -6655,14 +6647,12 @@ final class DefaultControllerTest extends TestCase
         $editorPageSlug = '/eventEditor';
         $this->testingFramework->changeRecord('pages', $editorPageUid, ['slug' => $editorPageSlug]);
 
-        /** @var TestingDefaultController&MockObject $subject */
         $subject = $this->createPartialMock(TestingDefaultController::class, ['mayCurrentUserEditCurrentEvent']);
         $subject->cObj = $this->getFrontEndController()->cObj;
         $subject->conf = ['eventEditorPID' => $editorPageUid];
         $subject->expects(self::once())->method('mayCurrentUserEditCurrentEvent')
             ->willReturn(true);
 
-        /** @var LegacyEvent&MockObject $event */
         $event = $this->createPartialMock(LegacyEvent::class, ['getUid', 'isPublished', 'isHidden']);
         $event->method('getUid')->willReturn(91);
         $subject->setSeminar($event);
@@ -6684,14 +6674,12 @@ final class DefaultControllerTest extends TestCase
             self::markTestSkipped('This test is flaky in V10 and needs to be rewritten as a functional test.');
         }
 
-        /** @var TestingDefaultController&MockObject $subject */
         $subject = $this->createPartialMock(TestingDefaultController::class, ['mayCurrentUserEditCurrentEvent']);
         $subject->cObj = $this->getFrontEndController()->cObj;
         $subject->conf = [];
         $subject->expects(self::once())->method('mayCurrentUserEditCurrentEvent')
             ->willReturn(true);
 
-        /** @var LegacyEvent&MockObject $event */
         $event = $this->createPartialMock(LegacyEvent::class, ['getUid', 'isPublished', 'isHidden']);
         $event->method('getUid')->willReturn(91);
         $event->method('isPublished')->willReturn(true);
@@ -6715,14 +6703,12 @@ final class DefaultControllerTest extends TestCase
             self::markTestSkipped('This test is flaky in V10 and needs to be rewritten as a functional test.');
         }
 
-        /** @var TestingDefaultController&MockObject $subject */
         $subject = $this->createPartialMock(TestingDefaultController::class, ['mayCurrentUserEditCurrentEvent']);
         $subject->cObj = $this->getFrontEndController()->cObj;
         $subject->conf = [];
         $subject->expects(self::once())->method('mayCurrentUserEditCurrentEvent')
             ->willReturn(true);
 
-        /** @var LegacyEvent&MockObject $event */
         $event = $this->createPartialMock(LegacyEvent::class, ['getUid', 'isPublished', 'isHidden']);
         $event->method('getUid')->willReturn(91);
         $event->method('isPublished')->willReturn(true);
@@ -6742,14 +6728,12 @@ final class DefaultControllerTest extends TestCase
      */
     public function createAllEditorLinksForEditAccessGrantedAndUnpublishedVisibleEventNotCreatesHideLink(): void
     {
-        /** @var TestingDefaultController&MockObject $subject */
         $subject = $this->createPartialMock(TestingDefaultController::class, ['mayCurrentUserEditCurrentEvent']);
         $subject->cObj = $this->getFrontEndController()->cObj;
         $subject->conf = [];
         $subject->expects(self::once())->method('mayCurrentUserEditCurrentEvent')
             ->willReturn(true);
 
-        /** @var LegacyEvent&MockObject $event */
         $event = $this->createPartialMock(LegacyEvent::class, ['getUid', 'isPublished', 'isHidden']);
         $event->method('getUid')->willReturn(91);
         $event->method('isPublished')->willReturn(false);
@@ -6764,14 +6748,12 @@ final class DefaultControllerTest extends TestCase
      */
     public function createAllEditorLinksForEditAccessGrantedAndUnpublishedHiddenEventNotCreatesUnhideLink(): void
     {
-        /** @var TestingDefaultController&MockObject $subject */
         $subject = $this->createPartialMock(TestingDefaultController::class, ['mayCurrentUserEditCurrentEvent']);
         $subject->cObj = $this->getFrontEndController()->cObj;
         $subject->conf = [];
         $subject->expects(self::once())->method('mayCurrentUserEditCurrentEvent')
             ->willReturn(true);
 
-        /** @var LegacyEvent&MockObject $event */
         $event = $this->createPartialMock(LegacyEvent::class, ['getUid', 'isPublished', 'isHidden']);
         $event->method('getUid')->willReturn(91);
         $event->method('isPublished')->willReturn(false);
@@ -6786,14 +6768,12 @@ final class DefaultControllerTest extends TestCase
      */
     public function createAllEditorLinksForEditAccessGrantedAndUnpublishedHiddenEventNotCreatesCopyLink(): void
     {
-        /** @var TestingDefaultController&MockObject $subject */
         $subject = $this->createPartialMock(TestingDefaultController::class, ['mayCurrentUserEditCurrentEvent']);
         $subject->cObj = $this->getFrontEndController()->cObj;
         $subject->conf = [];
         $subject->expects(self::once())->method('mayCurrentUserEditCurrentEvent')
             ->willReturn(true);
 
-        /** @var LegacyEvent&MockObject $event */
         $event = $this->createPartialMock(LegacyEvent::class, ['getUid', 'isPublished', 'isHidden']);
         $event->method('getUid')->willReturn(91);
         $event->method('isPublished')->willReturn(false);
@@ -6808,14 +6788,12 @@ final class DefaultControllerTest extends TestCase
      */
     public function createAllEditorLinksForEditAccessGrantedAndUnpublishedVisibleEventNotCreatesCopyLink(): void
     {
-        /** @var TestingDefaultController&MockObject $subject */
         $subject = $this->createPartialMock(TestingDefaultController::class, ['mayCurrentUserEditCurrentEvent']);
         $subject->cObj = $this->getFrontEndController()->cObj;
         $subject->conf = [];
         $subject->expects(self::once())->method('mayCurrentUserEditCurrentEvent')
             ->willReturn(true);
 
-        /** @var LegacyEvent&MockObject $event */
         $event = $this->createPartialMock(LegacyEvent::class, ['getUid', 'isPublished', 'isHidden']);
         $event->method('getUid')->willReturn(91);
         $event->method('isPublished')->willReturn(false);
@@ -6834,14 +6812,12 @@ final class DefaultControllerTest extends TestCase
             self::markTestSkipped('This test is flaky in V10 and needs to be rewritten as a functional test.');
         }
 
-        /** @var TestingDefaultController&MockObject $subject */
         $subject = $this->createPartialMock(TestingDefaultController::class, ['mayCurrentUserEditCurrentEvent']);
         $subject->cObj = $this->getFrontEndController()->cObj;
         $subject->conf = [];
         $subject->expects(self::once())->method('mayCurrentUserEditCurrentEvent')
             ->willReturn(true);
 
-        /** @var LegacyEvent&MockObject $event */
         $event = $this->createPartialMock(LegacyEvent::class, ['getUid', 'isPublished', 'isHidden']);
         $event->method('getUid')->willReturn(91);
         $event->method('isPublished')->willReturn(true);
@@ -6863,7 +6839,6 @@ final class DefaultControllerTest extends TestCase
      */
     public function eventsListNotCallsProcessEventEditorActions(): void
     {
-        /** @var TestingDefaultController&MockObject $subject */
         $subject = $this->createPartialMock(
             TestingDefaultController::class,
             ['processEventEditorActions']
@@ -6886,7 +6861,6 @@ final class DefaultControllerTest extends TestCase
     {
         $this->testingFramework->createAndLoginFrontEndUser();
 
-        /** @var TestingDefaultController&MockObject $subject */
         $subject = $this->createPartialMock(
             TestingDefaultController::class,
             ['processEventEditorActions']
@@ -6907,7 +6881,6 @@ final class DefaultControllerTest extends TestCase
      */
     public function myManagedEventsListCallsProcessEventEditorActions(): void
     {
-        /** @var TestingDefaultController&MockObject $subject */
         $subject = $this->createPartialMock(
             TestingDefaultController::class,
             ['processEventEditorActions']
@@ -6928,7 +6901,6 @@ final class DefaultControllerTest extends TestCase
      */
     public function processEventEditorActionsIntvalsSeminarPivar(): void
     {
-        /** @var TestingDefaultController&MockObject $subject */
         $subject = $this->createPartialMock(
             TestingDefaultController::class,
             ['ensureIntegerPiVars', 'createEventEditorInstance', 'hideEvent', 'unhideEvent']
@@ -6944,7 +6916,6 @@ final class DefaultControllerTest extends TestCase
      */
     public function processEventEditorActionsWithZeroSeminarPivarNotCreatesEventEditor(): void
     {
-        /** @var TestingDefaultController&MockObject $subject */
         $subject = $this->createPartialMock(
             TestingDefaultController::class,
             ['createEventEditorInstance', 'hideEvent', 'unhideEvent']
@@ -6960,7 +6931,6 @@ final class DefaultControllerTest extends TestCase
      */
     public function processEventEditorActionsWithNegativeSeminarPivarNotCreatesEventEditor(): void
     {
-        /** @var TestingDefaultController&MockObject $subject */
         $subject = $this->createPartialMock(
             TestingDefaultController::class,
             ['createEventEditorInstance', 'hideEvent', 'unhideEvent']
@@ -6978,10 +6948,8 @@ final class DefaultControllerTest extends TestCase
     {
         $uid = $this->testingFramework->createRecord('tx_seminars_seminars');
 
-        /** @var EventEditor&MockObject $eventEditor */
         $eventEditor = $this->createPartialMock(EventEditor::class, ['hasAccessMessage']);
 
-        /** @var TestingDefaultController&MockObject $subject */
         $subject = $this->createPartialMock(
             TestingDefaultController::class,
             ['createEventEditorInstance', 'hideEvent', 'unhideEvent']
@@ -6999,11 +6967,9 @@ final class DefaultControllerTest extends TestCase
     {
         $uid = $this->testingFramework->createRecord('tx_seminars_seminars');
 
-        /** @var EventEditor&MockObject $eventEditor */
         $eventEditor = $this->createPartialMock(EventEditor::class, ['hasAccessMessage']);
         $eventEditor->expects(self::once())->method('hasAccessMessage');
 
-        /** @var TestingDefaultController&MockObject $subject */
         $subject = $this->createPartialMock(
             TestingDefaultController::class,
             ['createEventEditorInstance', 'hideEvent', 'unhideEvent']
@@ -7022,13 +6988,11 @@ final class DefaultControllerTest extends TestCase
      */
     public function processEventEditorActionsForHideActionWithAccessGrantedCallsHideEvent(): void
     {
-        /** @var EventEditor&MockObject $eventEditor */
         $eventEditor = $this->createPartialMock(EventEditor::class, ['hasAccessMessage']);
         $eventEditor->expects(self::atLeastOnce())->method('hasAccessMessage')->willReturn('');
 
         $event = MapperRegistry::get(EventMapper::class)->getLoadedTestingModel([]);
 
-        /** @var TestingDefaultController&MockObject $subject */
         $subject = $this->createPartialMock(
             TestingDefaultController::class,
             ['createEventEditorInstance', 'hideEvent', 'unhideEvent']
@@ -7049,14 +7013,12 @@ final class DefaultControllerTest extends TestCase
      */
     public function processEventEditorActionsForHideActionWithUnpublishedEventAndAccessGrantedNotCallsHideEvent(): void
     {
-        /** @var EventEditor&MockObject $eventEditor */
         $eventEditor = $this->createPartialMock(EventEditor::class, ['hasAccessMessage']);
         $eventEditor->expects(self::atLeastOnce())->method('hasAccessMessage')->willReturn('');
 
         $event = MapperRegistry::get(EventMapper::class)
             ->getLoadedTestingModel(['publication_hash' => 'foo']);
 
-        /** @var TestingDefaultController&MockObject $subject */
         $subject = $this->createPartialMock(
             TestingDefaultController::class,
             ['createEventEditorInstance', 'hideEvent', 'unhideEvent']
@@ -7077,7 +7039,6 @@ final class DefaultControllerTest extends TestCase
      */
     public function processEventEditorActionsForHideActionWithAccessDeniedNotCallsHideEvent(): void
     {
-        /** @var EventEditor&MockObject $eventEditor */
         $eventEditor = $this->createPartialMock(EventEditor::class, ['hasAccessMessage']);
         $eventEditor->expects(self::atLeastOnce())->method('hasAccessMessage')->willReturn(
             'access denied'
@@ -7085,7 +7046,6 @@ final class DefaultControllerTest extends TestCase
 
         $event = MapperRegistry::get(EventMapper::class)->getLoadedTestingModel([]);
 
-        /** @var TestingDefaultController&MockObject $subject */
         $subject = $this->createPartialMock(
             TestingDefaultController::class,
             ['createEventEditorInstance', 'hideEvent', 'unhideEvent']
@@ -7106,13 +7066,11 @@ final class DefaultControllerTest extends TestCase
      */
     public function processEventEditorActionsForUnhideActionWithAccessGrantedCallsUnhideEvent(): void
     {
-        /** @var EventEditor&MockObject $eventEditor */
         $eventEditor = $this->createPartialMock(EventEditor::class, ['hasAccessMessage']);
         $eventEditor->expects(self::once())->method('hasAccessMessage')->willReturn('');
 
         $event = MapperRegistry::get(EventMapper::class)->getLoadedTestingModel([]);
 
-        /** @var TestingDefaultController&MockObject $subject */
         $subject = $this->createPartialMock(
             TestingDefaultController::class,
             ['createEventEditorInstance', 'hideEvent', 'unhideEvent']
@@ -7131,14 +7089,12 @@ final class DefaultControllerTest extends TestCase
      */
     public function processEventEditorActionsForUnhideActionWithUnpublishedEventAccessGrantedNotCallsUnhideEvent(): void
     {
-        /** @var EventEditor&MockObject $eventEditor */
         $eventEditor = $this->createPartialMock(EventEditor::class, ['hasAccessMessage']);
         $eventEditor->expects(self::once())->method('hasAccessMessage')->willReturn('');
 
         $event = MapperRegistry::get(EventMapper::class)
             ->getLoadedTestingModel(['publication_hash' => 'foo']);
 
-        /** @var TestingDefaultController&MockObject $subject */
         $subject = $this->createPartialMock(
             TestingDefaultController::class,
             ['createEventEditorInstance', 'hideEvent', 'unhideEvent']
@@ -7157,13 +7113,11 @@ final class DefaultControllerTest extends TestCase
      */
     public function processEventEditorActionsForUnhideActionWithAccessDeniedNotCallsUnhideEvent(): void
     {
-        /** @var EventEditor&MockObject $eventEditor */
         $eventEditor = $this->createPartialMock(EventEditor::class, ['hasAccessMessage']);
         $eventEditor->expects(self::once())->method('hasAccessMessage')->willReturn('access denied');
 
         $event = MapperRegistry::get(EventMapper::class)->getLoadedTestingModel([]);
 
-        /** @var TestingDefaultController&MockObject $subject */
         $subject = $this->createPartialMock(
             TestingDefaultController::class,
             ['createEventEditorInstance', 'hideEvent', 'unhideEvent']
@@ -7182,13 +7136,11 @@ final class DefaultControllerTest extends TestCase
      */
     public function processEventEditorActionsForCopyActionWithAccessGrantedCallsCopyEvent(): void
     {
-        /** @var EventEditor&MockObject $eventEditor */
         $eventEditor = $this->createPartialMock(EventEditor::class, ['hasAccessMessage']);
         $eventEditor->expects(self::atLeastOnce())->method('hasAccessMessage')->willReturn('');
 
         $event = MapperRegistry::get(EventMapper::class)->getLoadedTestingModel([]);
 
-        /** @var TestingDefaultController&MockObject $subject */
         $subject = $this->createPartialMock(
             TestingDefaultController::class,
             ['createEventEditorInstance', 'hideEvent', 'unhideEvent', 'copyEvent']
@@ -7209,14 +7161,12 @@ final class DefaultControllerTest extends TestCase
      */
     public function processEventEditorActionsForCopyActionWithUnpublishedEventAndAccessGrantedNotCallsCopyEvent(): void
     {
-        /** @var EventEditor&MockObject $eventEditor */
         $eventEditor = $this->createPartialMock(EventEditor::class, ['hasAccessMessage']);
         $eventEditor->expects(self::atLeastOnce())->method('hasAccessMessage')->willReturn('');
 
         $event = MapperRegistry::get(EventMapper::class)
             ->getLoadedTestingModel(['publication_hash' => 'foo']);
 
-        /** @var TestingDefaultController&MockObject $subject */
         $subject = $this->createPartialMock(
             TestingDefaultController::class,
             ['createEventEditorInstance', 'hideEvent', 'unhideEvent', 'copyEvent']
@@ -7237,7 +7187,6 @@ final class DefaultControllerTest extends TestCase
      */
     public function processEventEditorActionsForCopyActionWithAccessDeniedNotCallsCopyEvent(): void
     {
-        /** @var EventEditor&MockObject $eventEditor */
         $eventEditor = $this->createPartialMock(EventEditor::class, ['hasAccessMessage']);
         $eventEditor->expects(self::atLeastOnce())->method('hasAccessMessage')->willReturn(
             'access denied'
@@ -7245,7 +7194,6 @@ final class DefaultControllerTest extends TestCase
 
         $event = MapperRegistry::get(EventMapper::class)->getLoadedTestingModel([]);
 
-        /** @var TestingDefaultController&MockObject $subject */
         $subject = $this->createPartialMock(
             TestingDefaultController::class,
             ['createEventEditorInstance', 'hideEvent', 'unhideEvent', 'copyEvent']
@@ -7266,13 +7214,11 @@ final class DefaultControllerTest extends TestCase
      */
     public function processEventEditorActionsForEmptyActionWithPublishedEventAndAccessGrantedNotCallsHideEventOrUnhideEvent(): void
     {
-        /** @var EventEditor&MockObject $eventEditor */
         $eventEditor = $this->createPartialMock(EventEditor::class, ['hasAccessMessage']);
         $eventEditor->expects(self::once())->method('hasAccessMessage')->willReturn('');
 
         $event = MapperRegistry::get(EventMapper::class)->getLoadedTestingModel([]);
 
-        /** @var TestingDefaultController&MockObject $subject */
         $subject = $this->createPartialMock(
             TestingDefaultController::class,
             ['createEventEditorInstance', 'hideEvent', 'unhideEvent']
@@ -7292,13 +7238,11 @@ final class DefaultControllerTest extends TestCase
      */
     public function processEventEditorActionsForInvalidActionWithPublishedEventAndAccessGrantedNotCallsHideEventOrUnhideEvent(): void
     {
-        /** @var EventEditor&MockObject $eventEditor */
         $eventEditor = $this->createPartialMock(EventEditor::class, ['hasAccessMessage']);
         $eventEditor->expects(self::once())->method('hasAccessMessage')->willReturn('');
 
         $event = MapperRegistry::get(EventMapper::class)->getLoadedTestingModel([]);
 
-        /** @var TestingDefaultController&MockObject $subject */
         $subject = $this->createPartialMock(
             TestingDefaultController::class,
             ['createEventEditorInstance', 'hideEvent', 'unhideEvent']
@@ -7318,7 +7262,6 @@ final class DefaultControllerTest extends TestCase
      */
     public function hideEventMarksVisibleEventAsHidden(): void
     {
-        /** @var EventMapper&MockObject $mapper */
         $mapper = $this->getMockBuilder(EventMapper::class)->setMethods(['save'])->getMock();
         MapperRegistry::set(EventMapper::class, $mapper);
 
@@ -7338,7 +7281,6 @@ final class DefaultControllerTest extends TestCase
      */
     public function hideEventKeepsHiddenEventAsHidden(): void
     {
-        /** @var EventMapper&MockObject $mapper */
         $mapper = $this->getMockBuilder(EventMapper::class)->setMethods(['save'])->getMock();
         MapperRegistry::set(EventMapper::class, $mapper);
 
@@ -7358,7 +7300,6 @@ final class DefaultControllerTest extends TestCase
      */
     public function hideEventSavesEvent(): void
     {
-        /** @var EventMapper&MockObject $mapper */
         $mapper = $this->getMockBuilder(EventMapper::class)->setMethods(['save'])->getMock();
         MapperRegistry::set(EventMapper::class, $mapper);
 
@@ -7375,7 +7316,6 @@ final class DefaultControllerTest extends TestCase
      */
     public function hideEventRedirectsToRequestUrl(): void
     {
-        /** @var EventMapper&MockObject $mapper */
         $mapper = $this->getMockBuilder(EventMapper::class)->setMethods(['save'])->getMock();
         MapperRegistry::set(EventMapper::class, $mapper);
 
@@ -7397,7 +7337,6 @@ final class DefaultControllerTest extends TestCase
      */
     public function unhideEventMarksHiddenEventAsVisible(): void
     {
-        /** @var EventMapper&MockObject $mapper */
         $mapper = $this->getMockBuilder(EventMapper::class)->setMethods(['save'])->getMock();
         MapperRegistry::set(EventMapper::class, $mapper);
 
@@ -7417,7 +7356,6 @@ final class DefaultControllerTest extends TestCase
      */
     public function unhideEventKeepsVisibleEventAsVisible(): void
     {
-        /** @var EventMapper&MockObject $mapper */
         $mapper = $this->getMockBuilder(EventMapper::class)->setMethods(['save'])->getMock();
         MapperRegistry::set(EventMapper::class, $mapper);
 
@@ -7437,7 +7375,6 @@ final class DefaultControllerTest extends TestCase
      */
     public function unhideEventSavesEvent(): void
     {
-        /** @var EventMapper&MockObject $mapper */
         $mapper = $this->getMockBuilder(EventMapper::class)->setMethods(['save'])->getMock();
         MapperRegistry::set(EventMapper::class, $mapper);
 
@@ -7454,7 +7391,6 @@ final class DefaultControllerTest extends TestCase
      */
     public function unhideEventRedirectsToRequestUrl(): void
     {
-        /** @var EventMapper&MockObject $mapper */
         $mapper = $this->getMockBuilder(EventMapper::class)->setMethods(['save'])->getMock();
         MapperRegistry::set(EventMapper::class, $mapper);
 
@@ -7476,7 +7412,6 @@ final class DefaultControllerTest extends TestCase
      */
     public function copySavesHiddenCloneOfEvent(): void
     {
-        /** @var EventMapper&MockObject $mapper */
         $mapper = $this->getMockBuilder(EventMapper::class)->setMethods(['save'])->getMock();
         MapperRegistry::set(EventMapper::class, $mapper);
 
@@ -7496,7 +7431,6 @@ final class DefaultControllerTest extends TestCase
      */
     public function copyRemovesRegistrationsFromEvent(): void
     {
-        /** @var EventMapper&MockObject $mapper */
         $mapper = $this->getMockBuilder(EventMapper::class)->setMethods(['save'])->getMock();
         MapperRegistry::set(EventMapper::class, $mapper);
 
@@ -7523,7 +7457,6 @@ final class DefaultControllerTest extends TestCase
      */
     public function copyEventRedirectsToRequestUrl(): void
     {
-        /** @var EventMapper&MockObject $mapper */
         $mapper = $this->getMockBuilder(EventMapper::class)->setMethods(['save'])->getMock();
         MapperRegistry::set(EventMapper::class, $mapper);
 
@@ -7549,7 +7482,6 @@ final class DefaultControllerTest extends TestCase
      */
     public function initListViewForDefaultListLimitsListByAdditionalParameters(): void
     {
-        /** @var TestingDefaultController&MockObject $subject */
         $subject = $this->createPartialMock(
             TestingDefaultController::class,
             ['limitForAdditionalParameters']
@@ -7564,7 +7496,6 @@ final class DefaultControllerTest extends TestCase
      */
     public function initListViewForTopicListLimitsListByAdditionalParameters(): void
     {
-        /** @var TestingDefaultController&MockObject $subject */
         $subject = $this->createPartialMock(
             TestingDefaultController::class,
             ['limitForAdditionalParameters']
@@ -7579,7 +7510,6 @@ final class DefaultControllerTest extends TestCase
      */
     public function initListViewForMyEventsListNotLimitsListByAdditionalParameters(): void
     {
-        /** @var TestingDefaultController&MockObject $subject */
         $subject = $this->createPartialMock(
             TestingDefaultController::class,
             ['limitForAdditionalParameters']
@@ -7717,7 +7647,6 @@ final class DefaultControllerTest extends TestCase
         int $listPid,
         int $vipListPid
     ): void {
-        /** @var TestingDefaultController&MockObject $subject */
         $subject = $this->createPartialMock(
             TestingDefaultController::class,
             ['isRegistrationEnabled', 'isLoggedIn', 'hideColumns']
@@ -7760,7 +7689,6 @@ final class DefaultControllerTest extends TestCase
         int $listPid,
         int $vipListPid
     ): void {
-        /** @var TestingDefaultController&MockObject $subject */
         $subject = $this->createPartialMock(
             TestingDefaultController::class,
             ['isRegistrationEnabled', 'isLoggedIn', 'hideColumns']
@@ -7799,7 +7727,6 @@ final class DefaultControllerTest extends TestCase
         int $listPid,
         int $vipListPid
     ): void {
-        /** @var TestingDefaultController&MockObject $subject */
         $subject = $this->createPartialMock(
             TestingDefaultController::class,
             ['isRegistrationEnabled', 'isLoggedIn', 'hideColumns']

--- a/Tests/LegacyUnit/FrontEnd/RegistrationFormTest.php
+++ b/Tests/LegacyUnit/FrontEnd/RegistrationFormTest.php
@@ -14,7 +14,6 @@ use OliverKlee\Seminars\Model\Event;
 use OliverKlee\Seminars\OldModel\LegacyEvent;
 use OliverKlee\Seminars\Service\RegistrationManager;
 use OliverKlee\Seminars\Tests\Functional\Traits\LanguageHelper;
-use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
@@ -711,7 +710,6 @@ final class RegistrationFormTest extends TestCase
             $this->getFrontEndController()->cObj
         );
 
-        /** @var LegacyEvent&MockObject $event */
         $event = $this->createMock(LegacyEvent::class);
         $subject->setSeminar($event);
 
@@ -738,7 +736,6 @@ final class RegistrationFormTest extends TestCase
             ['showRegistrationFields' => $key],
             $this->getFrontEndController()->cObj
         );
-        /** @var LegacyEvent&MockObject $event */
         $event = $this->createMock(LegacyEvent::class);
         $subject->setSeminar($event);
 
@@ -1027,7 +1024,6 @@ final class RegistrationFormTest extends TestCase
      */
     public function validateNumberOfRegisteredPersonsForOnePersonAndOneSeatReturnsTrue(): void
     {
-        /** @var RegistrationForm&MockObject $subject */
         $subject = $this->createPartialMock(
             RegistrationForm::class,
             ['getNumberOfEnteredPersons', 'isFormFieldEnabled']
@@ -1050,7 +1046,6 @@ final class RegistrationFormTest extends TestCase
      */
     public function validateNumberOfRegisteredPersonsForOnePersonAndTwoSeatsReturnsFalse(): void
     {
-        /** @var RegistrationForm&MockObject $subject */
         $subject = $this->createPartialMock(
             RegistrationForm::class,
             ['getNumberOfEnteredPersons', 'isFormFieldEnabled']
@@ -1073,7 +1068,6 @@ final class RegistrationFormTest extends TestCase
      */
     public function validateNumberOfRegisteredPersonsForTwoPersonsAndOneSeatReturnsFalse(): void
     {
-        /** @var RegistrationForm&MockObject $subject */
         $subject = $this->createPartialMock(
             RegistrationForm::class,
             ['getNumberOfEnteredPersons', 'isFormFieldEnabled']
@@ -1096,7 +1090,6 @@ final class RegistrationFormTest extends TestCase
      */
     public function validateNumberOfRegisteredPersonsForTwoPersonsAndTwoSeatsReturnsTrue(): void
     {
-        /** @var RegistrationForm&MockObject $subject */
         $subject = $this->createPartialMock(
             RegistrationForm::class,
             ['getNumberOfEnteredPersons', 'isFormFieldEnabled']
@@ -1202,7 +1195,6 @@ final class RegistrationFormTest extends TestCase
      */
     public function validateAdditionalPersonsEmailAddressesForDisabledFrontEndUserCreationReturnsTrue(): void
     {
-        /** @var RegistrationForm&MockObject $subject */
         $subject = $this->createPartialMock(
             RegistrationForm::class,
             ['getAdditionalRegisteredPersonsData', 'isFormFieldEnabled']
@@ -1227,7 +1219,6 @@ final class RegistrationFormTest extends TestCase
      */
     public function validateAdditionalPersonsEmailAddressesForDisabledFormFieldReturnsTrue(): void
     {
-        /** @var RegistrationForm&MockObject $subject */
         $subject = $this->createPartialMock(
             RegistrationForm::class,
             ['getAdditionalRegisteredPersonsData', 'isFormFieldEnabled']
@@ -1252,7 +1243,6 @@ final class RegistrationFormTest extends TestCase
      */
     public function validateAdditionalPersonsEmailAddressesForNoPersonsReturnsTrue(): void
     {
-        /** @var RegistrationForm&MockObject $subject */
         $subject = $this->createPartialMock(
             RegistrationForm::class,
             ['getAdditionalRegisteredPersonsData', 'isFormFieldEnabled']
@@ -1277,7 +1267,6 @@ final class RegistrationFormTest extends TestCase
      */
     public function validateAdditionalPersonsEmailAddressesForOneValidEmailAddressReturnsTrue(): void
     {
-        /** @var RegistrationForm&MockObject $subject */
         $subject = $this->createPartialMock(
             RegistrationForm::class,
             ['getAdditionalRegisteredPersonsData', 'isFormFieldEnabled']
@@ -1304,7 +1293,6 @@ final class RegistrationFormTest extends TestCase
      */
     public function validateAdditionalPersonsEmailAddressesForOneInvalidEmailAddressReturnsFalse(): void
     {
-        /** @var RegistrationForm&MockObject $subject */
         $subject = $this->createPartialMock(
             RegistrationForm::class,
             ['getAdditionalRegisteredPersonsData', 'isFormFieldEnabled']
@@ -1331,7 +1319,6 @@ final class RegistrationFormTest extends TestCase
      */
     public function validateAdditionalPersonsEmailAddressesForOneEmptyAddressReturnsFalse(): void
     {
-        /** @var RegistrationForm&MockObject $subject */
         $subject = $this->createPartialMock(
             RegistrationForm::class,
             ['getAdditionalRegisteredPersonsData', 'isFormFieldEnabled']
@@ -1358,7 +1345,6 @@ final class RegistrationFormTest extends TestCase
      */
     public function validateAdditionalPersonsEmailAddressesForOneMissingAddressReturnsFalse(): void
     {
-        /** @var RegistrationForm&MockObject $subject */
         $subject = $this->createPartialMock(
             RegistrationForm::class,
             ['getAdditionalRegisteredPersonsData', 'isFormFieldEnabled']
@@ -1385,7 +1371,6 @@ final class RegistrationFormTest extends TestCase
      */
     public function validateAdditionalPersonsEmailAddressesForOneValidAndOneInvalidEmailAddressReturnsFalse(): void
     {
-        /** @var RegistrationForm&MockObject $subject */
         $subject = $this->createPartialMock(
             RegistrationForm::class,
             ['getAdditionalRegisteredPersonsData', 'isFormFieldEnabled']

--- a/Tests/LegacyUnit/FrontEnd/SelectorWidgetTest.php
+++ b/Tests/LegacyUnit/FrontEnd/SelectorWidgetTest.php
@@ -9,7 +9,6 @@ use OliverKlee\Seminars\FrontEnd\SelectorWidget;
 use OliverKlee\Seminars\Hooks\Interfaces\SeminarSelectorWidget;
 use OliverKlee\Seminars\Service\RegistrationManager;
 use OliverKlee\Seminars\Tests\Functional\Traits\LanguageHelper;
-use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use SJBR\StaticInfoTables\PiBaseApi;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -469,7 +468,6 @@ final class SelectorWidgetTest extends TestCase
      */
     public function itemsInSearchBoxAreSortedAlphabetically(): void
     {
-        /** @var SelectorWidget&MockObject $subject */
         $subject = $this->getMockBuilder(SelectorWidget::class)
             ->setMethods(
                 [

--- a/Tests/LegacyUnit/Model/AbstractTimeSpanTest.php
+++ b/Tests/LegacyUnit/Model/AbstractTimeSpanTest.php
@@ -17,9 +17,7 @@ final class AbstractTimeSpanTest extends TestCase
 
     protected function setUp(): void
     {
-        /** @var AbstractTimeSpan&MockObject $subject */
-        $subject = $this->getMockForAbstractClass(AbstractTimeSpan::class);
-        $this->subject = $subject;
+        $this->subject = $this->getMockForAbstractClass(AbstractTimeSpan::class);
     }
 
     // Tests regarding the begin date.

--- a/Tests/LegacyUnit/Model/EventTest.php
+++ b/Tests/LegacyUnit/Model/EventTest.php
@@ -17,7 +17,6 @@ use OliverKlee\Seminars\Model\FrontEndUser;
 use OliverKlee\Seminars\Model\Organizer;
 use OliverKlee\Seminars\Model\PaymentMethod;
 use OliverKlee\Seminars\Model\Registration;
-use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -1050,7 +1049,6 @@ final class EventTest extends TestCase
      */
     public function hasCombinedSingleViewPageForEmptySingleViewPageReturnsFalse(): void
     {
-        /** @var Event&MockObject $subject */
         $subject = $this->createPartialMock(
             Event::class,
             ['getCombinedSingleViewPage']
@@ -1068,7 +1066,6 @@ final class EventTest extends TestCase
      */
     public function hasCombinedSingleViewPageForNonEmptySingleViewPageReturnsTrue(): void
     {
-        /** @var Event&MockObject $subject */
         $subject = $this->createPartialMock(
             Event::class,
             ['getCombinedSingleViewPage']
@@ -2170,7 +2167,6 @@ final class EventTest extends TestCase
         $registration = MapperRegistry::get(RegistrationMapper::class)
             ->getLoadedTestingModel(['registration_queue' => 1]);
         $registrations->add($registration);
-        /** @var Event&MockObject $event */
         $event = $this->createPartialMock(
             Event::class,
             ['getQueueRegistrations']
@@ -2239,7 +2235,6 @@ final class EventTest extends TestCase
      */
     public function hasQueueRegistrationsForNoQueueRegistrationReturnsFalse(): void
     {
-        /** @var Event&MockObject $event */
         $event = $this->createPartialMock(
             Event::class,
             ['getQueueRegistrations']
@@ -2289,7 +2284,6 @@ final class EventTest extends TestCase
      */
     public function getRegisteredSeatsForNoRegularRegistrationsReturnsZero(): void
     {
-        /** @var Event&MockObject $event */
         $event = $this->createPartialMock(
             Event::class,
             ['getRegularRegistrations']
@@ -2313,7 +2307,6 @@ final class EventTest extends TestCase
         $registration = MapperRegistry::get(RegistrationMapper::class)
             ->getLoadedTestingModel(['seats' => 1]);
         $registrations->add($registration);
-        /** @var Event&MockObject $event */
         $event = $this->createPartialMock(
             Event::class,
             ['getRegularRegistrations']
@@ -2337,7 +2330,6 @@ final class EventTest extends TestCase
         $registration = MapperRegistry::get(RegistrationMapper::class)
             ->getLoadedTestingModel(['seats' => 2]);
         $registrations->add($registration);
-        /** @var Event&MockObject $event */
         $event = $this->createPartialMock(
             Event::class,
             ['getRegularRegistrations']
@@ -2361,7 +2353,6 @@ final class EventTest extends TestCase
         $registration = MapperRegistry::get(RegistrationMapper::class)
             ->getLoadedTestingModel(['seats' => 1]);
         $queueRegistrations->add($registration);
-        /** @var Event&MockObject $event */
         $event = $this->createPartialMock(
             Event::class,
             ['getRegularRegistrations', 'getQueueRegistrations']
@@ -2383,7 +2374,6 @@ final class EventTest extends TestCase
      */
     public function getRegisteredSeatsCountsOfflineRegistrations(): void
     {
-        /** @var Event&MockObject $event */
         $event = $this->createPartialMock(
             Event::class,
             ['getRegularRegistrations']
@@ -2407,7 +2397,6 @@ final class EventTest extends TestCase
      */
     public function hasEnoughRegistrationsForZeroSeatsAndZeroNeededReturnsTrue(): void
     {
-        /** @var Event&MockObject $event */
         $event = $this->createPartialMock(
             Event::class,
             ['getRegisteredSeats']
@@ -2426,7 +2415,6 @@ final class EventTest extends TestCase
      */
     public function hasEnoughRegistrationsForLessSeatsThanNeededReturnsFalse(): void
     {
-        /** @var Event&MockObject $event */
         $event = $this->createPartialMock(
             Event::class,
             ['getRegisteredSeats']
@@ -2445,7 +2433,6 @@ final class EventTest extends TestCase
      */
     public function hasEnoughRegistrationsForAsManySeatsAsNeededReturnsTrue(): void
     {
-        /** @var Event&MockObject $event */
         $event = $this->createPartialMock(
             Event::class,
             ['getRegisteredSeats']
@@ -2464,7 +2451,6 @@ final class EventTest extends TestCase
      */
     public function hasEnoughRegistrationsForMoreSeatsThanNeededReturnsTrue(): void
     {
-        /** @var Event&MockObject $event */
         $event = $this->createPartialMock(
             Event::class,
             ['getRegisteredSeats']
@@ -2487,7 +2473,6 @@ final class EventTest extends TestCase
      */
     public function getVacanciesForOneRegisteredAndTwoMaximumReturnsOne(): void
     {
-        /** @var Event&MockObject $event */
         $event = $this->createPartialMock(
             Event::class,
             ['getRegisteredSeats']
@@ -2507,7 +2492,6 @@ final class EventTest extends TestCase
      */
     public function getVacanciesForAsManySeatsRegisteredAsMaximumReturnsZero(): void
     {
-        /** @var Event&MockObject $event */
         $event = $this->createPartialMock(
             Event::class,
             ['getRegisteredSeats']
@@ -2527,7 +2511,6 @@ final class EventTest extends TestCase
      */
     public function getVacanciesForAsMoreSeatsRegisteredThanMaximumReturnsZero(): void
     {
-        /** @var Event&MockObject $event */
         $event = $this->createPartialMock(
             Event::class,
             ['getRegisteredSeats']
@@ -2547,7 +2530,6 @@ final class EventTest extends TestCase
      */
     public function getVacanciesForNonZeroSeatsRegisteredAndUnlimitedVacanciesReturnsZero(): void
     {
-        /** @var Event&MockObject $event */
         $event = $this->createPartialMock(
             Event::class,
             ['getRegisteredSeats']
@@ -2571,7 +2553,6 @@ final class EventTest extends TestCase
      */
     public function hasVacanciesForOneRegisteredAndTwoMaximumReturnsTrue(): void
     {
-        /** @var Event&MockObject $event */
         $event = $this->createPartialMock(
             Event::class,
             ['getRegisteredSeats']
@@ -2590,7 +2571,6 @@ final class EventTest extends TestCase
      */
     public function hasVacanciesForAsManySeatsRegisteredAsMaximumReturnsFalse(): void
     {
-        /** @var Event&MockObject $event */
         $event = $this->createPartialMock(
             Event::class,
             ['getRegisteredSeats']
@@ -2609,7 +2589,6 @@ final class EventTest extends TestCase
      */
     public function hasVacanciesForAsMoreSeatsRegisteredThanMaximumReturnsFalse(): void
     {
-        /** @var Event&MockObject $event */
         $event = $this->createPartialMock(
             Event::class,
             ['getRegisteredSeats']
@@ -2628,7 +2607,6 @@ final class EventTest extends TestCase
      */
     public function hasVacanciesForNonZeroSeatsRegisteredAndUnlimitedVacanciesReturnsTrue(): void
     {
-        /** @var Event&MockObject $event */
         $event = $this->createPartialMock(
             Event::class,
             ['getRegisteredSeats']
@@ -2651,7 +2629,6 @@ final class EventTest extends TestCase
      */
     public function isFullForLessSeatsThanMaximumReturnsFalse(): void
     {
-        /** @var Event&MockObject $event */
         $event = $this->createPartialMock(
             Event::class,
             ['getRegisteredSeats']
@@ -2670,7 +2647,6 @@ final class EventTest extends TestCase
      */
     public function isFullForAsManySeatsAsMaximumReturnsTrue(): void
     {
-        /** @var Event&MockObject $event */
         $event = $this->createPartialMock(
             Event::class,
             ['getRegisteredSeats']
@@ -2689,7 +2665,6 @@ final class EventTest extends TestCase
      */
     public function isFullForMoreSeatsThanMaximumReturnsTrue(): void
     {
-        /** @var Event&MockObject $event */
         $event = $this->createPartialMock(
             Event::class,
             ['getRegisteredSeats']
@@ -2708,7 +2683,6 @@ final class EventTest extends TestCase
      */
     public function isFullForZeroSeatsAndUnlimitedMaximumReturnsFalse(): void
     {
-        /** @var Event&MockObject $event */
         $event = $this->createPartialMock(
             Event::class,
             ['getRegisteredSeats']
@@ -2727,7 +2701,6 @@ final class EventTest extends TestCase
      */
     public function isFullForPositiveSeatsAndUnlimitedMaximumReturnsFalse(): void
     {
-        /** @var Event&MockObject $event */
         $event = $this->createPartialMock(
             Event::class,
             ['getRegisteredSeats']

--- a/Tests/LegacyUnit/Model/EventTopicTest.php
+++ b/Tests/LegacyUnit/Model/EventTopicTest.php
@@ -7,7 +7,6 @@ namespace OliverKlee\Seminars\Tests\LegacyUnit\Model;
 use OliverKlee\Oelib\DataStructures\Collection;
 use OliverKlee\Seminars\Model\Event;
 use OliverKlee\Seminars\Model\PaymentMethod;
-use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -1443,7 +1442,6 @@ final class EventTopicTest extends TestCase
      */
     public function earlyBirdAppliesForNoEarlyBirdPriceAndDeadlineOverReturnsFalse(): void
     {
-        /** @var Event&MockObject $subject */
         $subject = $this->createPartialMock(
             Event::class,
             ['hasEarlyBirdPrice', 'isEarlyBirdDeadlineOver']
@@ -1463,7 +1461,6 @@ final class EventTopicTest extends TestCase
      */
     public function earlyBirdAppliesForEarlyBirdPriceAndDeadlineOverReturnsFalse(): void
     {
-        /** @var Event&MockObject $subject */
         $subject = $this->createPartialMock(
             Event::class,
             ['hasEarlyBirdPrice', 'isEarlyBirdDeadlineOver']
@@ -1483,7 +1480,6 @@ final class EventTopicTest extends TestCase
      */
     public function earlyBirdAppliesForEarlyBirdPriceAndDeadlineNotOverReturnsTrue(): void
     {
-        /** @var Event&MockObject $subject */
         $subject = $this->createPartialMock(
             Event::class,
             ['hasEarlyBirdPrice', 'isEarlyBirdDeadlineOver']
@@ -1507,7 +1503,6 @@ final class EventTopicTest extends TestCase
      */
     public function getAvailablePricesForNoPricesSetAndNoEarlyBirdReturnsZeroRegularPrice(): void
     {
-        /** @var Event&MockObject $subject */
         $subject = $this->createPartialMock(
             Event::class,
             ['earlyBirdApplies']
@@ -1527,7 +1522,6 @@ final class EventTopicTest extends TestCase
      */
     public function getAvailablePricesForRegularPriceSetAndNoEarlyBirdReturnsRegularPrice(): void
     {
-        /** @var Event&MockObject $subject */
         $subject = $this->createPartialMock(
             Event::class,
             ['earlyBirdApplies']
@@ -1547,7 +1541,6 @@ final class EventTopicTest extends TestCase
      */
     public function getAvailablePricesForRegularEarlyBirdPriceSetAndEarlyBirdReturnsEarlyBirdPrice(): void
     {
-        /** @var Event&MockObject $subject */
         $subject = $this->createPartialMock(
             Event::class,
             ['earlyBirdApplies']
@@ -1572,7 +1565,6 @@ final class EventTopicTest extends TestCase
      */
     public function getAvailablePricesForRegularEarlyBirdPriceSetAndNoEarlyBirdReturnsRegularPrice(): void
     {
-        /** @var Event&MockObject $subject */
         $subject = $this->createPartialMock(
             Event::class,
             ['earlyBirdApplies']
@@ -1597,7 +1589,6 @@ final class EventTopicTest extends TestCase
      */
     public function getAvailablePricesForRegularBoardPriceSetAndNoEarlyBirdReturnsRegularBoardPrice(): void
     {
-        /** @var Event&MockObject $subject */
         $subject = $this->createPartialMock(
             Event::class,
             ['earlyBirdApplies']
@@ -1624,7 +1615,6 @@ final class EventTopicTest extends TestCase
      */
     public function getAvailablePricesForSpecialBoardPriceSetAndNoEarlyBirdReturnsSpecialBoardPrice(): void
     {
-        /** @var Event&MockObject $subject */
         $subject = $this->createPartialMock(
             Event::class,
             ['earlyBirdApplies']
@@ -1651,7 +1641,6 @@ final class EventTopicTest extends TestCase
      */
     public function getAvailablePricesForSpecialPriceSetAndNoEarlyBirdReturnsSpecialPrice(): void
     {
-        /** @var Event&MockObject $subject */
         $subject = $this->createPartialMock(
             Event::class,
             ['earlyBirdApplies']
@@ -1674,7 +1663,6 @@ final class EventTopicTest extends TestCase
      */
     public function getAvailablePricesForSpecialPriceSetAndSpecialEarlyBirdPriceSetAndEarlyBirdReturnsSpecialEarlyBirdPrice(): void
     {
-        /** @var Event&MockObject $subject */
         $subject = $this->createPartialMock(
             Event::class,
             ['earlyBirdApplies']
@@ -1702,7 +1690,6 @@ final class EventTopicTest extends TestCase
      */
     public function getAvailablePricesForNoSpecialPriceSetAndSpecialEarlyBirdPriceSetAndEarlyBirdNotReturnsSpecialEarlyBirdPrice(): void
     {
-        /** @var Event&MockObject $subject */
         $subject = $this->createPartialMock(
             Event::class,
             ['earlyBirdApplies']
@@ -1727,7 +1714,6 @@ final class EventTopicTest extends TestCase
      */
     public function getAvailablePricesForSpecialPriceSetAndSpecialEarlyBirdPriceSetAndNoEarlyBirdReturnsSpecialPrice(): void
     {
-        /** @var Event&MockObject $subject */
         $subject = $this->createPartialMock(
             Event::class,
             ['earlyBirdApplies']

--- a/Tests/LegacyUnit/Model/FrontEndUserTest.php
+++ b/Tests/LegacyUnit/Model/FrontEndUserTest.php
@@ -14,7 +14,6 @@ use OliverKlee\Seminars\Mapper\OrganizerMapper;
 use OliverKlee\Seminars\Model\FrontEndUser;
 use OliverKlee\Seminars\Model\FrontEndUserGroup;
 use OliverKlee\Seminars\Model\Registration;
-use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 final class FrontEndUserTest extends TestCase
@@ -859,7 +858,6 @@ final class FrontEndUserTest extends TestCase
      */
     public function hasDefaultOrganizersForEmptyDefaultOrganizersReturnsFalse(): void
     {
-        /** @var FrontEndUser&MockObject $subject */
         $subject = $this->createPartialMock(
             FrontEndUser::class,
             ['getDefaultOrganizers']
@@ -881,7 +879,6 @@ final class FrontEndUserTest extends TestCase
         $organizers = new Collection();
         $organizers->add($organizer);
 
-        /** @var FrontEndUser&MockObject $subject */
         $subject = $this->createPartialMock(
             FrontEndUser::class,
             ['getDefaultOrganizers']

--- a/Tests/LegacyUnit/OldModel/LegacyEventTest.php
+++ b/Tests/LegacyUnit/OldModel/LegacyEventTest.php
@@ -18,7 +18,6 @@ use OliverKlee\Seminars\OldModel\LegacySpeaker;
 use OliverKlee\Seminars\Service\RegistrationManager;
 use OliverKlee\Seminars\Tests\Functional\Traits\LanguageHelper;
 use OliverKlee\Seminars\Tests\LegacyUnit\Fixtures\OldModel\TestingLegacyEvent;
-use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -6560,7 +6559,6 @@ final class LegacyEventTest extends TestCase
             'directions' => '',
         ];
 
-        /** @var LegacyEvent&MockObject $subject */
         $subject = $this->createPartialMock(LegacyEvent::class, ['getPlacesAsArray', 'hasPlace']);
         $subject->method('getPlacesAsArray')->willReturn([$place]);
         $subject->method('hasPlace')->willReturn(true);
@@ -6593,7 +6591,6 @@ final class LegacyEventTest extends TestCase
             'directions' => '',
         ];
 
-        /** @var LegacyEvent&MockObject $subject */
         $subject = $this->createPartialMock(LegacyEvent::class, ['getPlacesAsArray', 'hasPlace']);
         $subject->method('getPlacesAsArray')->willReturn([$place1, $place2]);
         $subject->method('hasPlace')->willReturn(true);
@@ -6616,7 +6613,6 @@ final class LegacyEventTest extends TestCase
             'city' => 'Bonn',
         ];
 
-        /** @var LegacyEvent&MockObject $subject */
         $subject = $this->createPartialMock(LegacyEvent::class, ['getPlacesAsArray', 'hasPlace']);
         $subject->method('getPlacesAsArray')->willReturn([$place]);
         $subject->method('hasPlace')->willReturn(true);
@@ -6639,7 +6635,6 @@ final class LegacyEventTest extends TestCase
             'city' => 'Bonn',
         ];
 
-        /** @var LegacyEvent&MockObject $subject */
         $subject = $this->createPartialMock(LegacyEvent::class, ['getPlacesAsArray', 'hasPlace']);
         $subject->method('getPlacesAsArray')->willReturn([$place]);
         $subject->method('hasPlace')->willReturn(true);
@@ -7483,7 +7478,6 @@ final class LegacyEventTest extends TestCase
         int $registrationsListPID,
         int $registrationsVipListPID
     ): void {
-        /** @var LegacyEvent&MockObject $subject */
         $subject = $this->createPartialMock(
             LegacyEvent::class,
             ['needsRegistration', 'isUserRegistered', 'isUserVip']
@@ -7526,7 +7520,6 @@ final class LegacyEventTest extends TestCase
         int $registrationsListPID,
         int $registrationsVipListPID
     ): void {
-        /** @var LegacyEvent&MockObject $subject */
         $subject = $this->createPartialMock(
             LegacyEvent::class,
             ['needsRegistration', 'isUserRegistered', 'isUserVip']
@@ -7604,7 +7597,6 @@ final class LegacyEventTest extends TestCase
     ): void {
         $this->configuration->setAsBoolean('allowCsvExportForVips', $allowCsvExportForVips);
 
-        /** @var LegacyEvent&MockObject $subject */
         $subject = $this->createPartialMock(LegacyEvent::class, ['needsRegistration', 'isUserVip']);
         $subject->method('needsRegistration')
             ->willReturn(true);
@@ -7795,7 +7787,6 @@ final class LegacyEventTest extends TestCase
         int $registrationsListPID,
         int $registrationsVipListPID
     ): void {
-        /** @var LegacyEvent&MockObject $subject */
         $subject = $this->createPartialMock(
             LegacyEvent::class,
             ['needsRegistration', 'isUserRegistered', 'isUserVip']
@@ -7997,7 +7988,6 @@ final class LegacyEventTest extends TestCase
         int $registrationsListPID,
         int $registrationsVipListPID
     ): void {
-        /** @var LegacyEvent&MockObject $subject */
         $subject = $this->createPartialMock(
             LegacyEvent::class,
             ['needsRegistration', 'isUserRegistered', 'isUserVip']
@@ -8035,7 +8025,6 @@ final class LegacyEventTest extends TestCase
      */
     public function canViewRegistrationsListMessageWithoutNeededRegistrationReturnsNoRegistrationMessage(): void
     {
-        /** @var LegacyEvent&MockObject $subject */
         $subject = $this->createPartialMock(LegacyEvent::class, ['needsRegistration']);
         $subject->method('needsRegistration')->willReturn(false);
 
@@ -8050,7 +8039,6 @@ final class LegacyEventTest extends TestCase
      */
     public function canViewRegistrationsListMessageForListAndNoLoginAndAttendeesAccessReturnsPleaseLoginMessage(): void
     {
-        /** @var LegacyEvent&MockObject $subject */
         $subject = $this->createPartialMock(LegacyEvent::class, ['needsRegistration']);
         $subject->method('needsRegistration')->willReturn(true);
 
@@ -8065,7 +8053,6 @@ final class LegacyEventTest extends TestCase
      */
     public function canViewRegistrationsListMessageForListAndNoLoginAndLoginAccessReturnsPleaseLoginMessage(): void
     {
-        /** @var LegacyEvent&MockObject $subject */
         $subject = $this->createPartialMock(LegacyEvent::class, ['needsRegistration']);
         $subject->method('needsRegistration')->willReturn(true);
 
@@ -8080,7 +8067,6 @@ final class LegacyEventTest extends TestCase
      */
     public function canViewRegistrationsListMessageForListAndNoLoginAndWorldAccessReturnsEmptyString(): void
     {
-        /** @var LegacyEvent&MockObject $subject */
         $subject = $this->createPartialMock(LegacyEvent::class, ['needsRegistration']);
         $subject->method('needsRegistration')->willReturn(true);
 
@@ -8112,7 +8098,6 @@ final class LegacyEventTest extends TestCase
     public function canViewRegistrationsListMessageForVipListAndNoLoginReturnsPleaseLoginMessage(
         string $accessLevel
     ): void {
-        /** @var LegacyEvent&MockObject $subject */
         $subject = $this->createPartialMock(LegacyEvent::class, ['needsRegistration']);
         $subject->method('needsRegistration')->willReturn(true);
 
@@ -8127,7 +8112,6 @@ final class LegacyEventTest extends TestCase
      */
     public function canViewRegistrationsListMessageForVipListAndWorldAccessAndNoLoginReturnsEmptyString(): void
     {
-        /** @var LegacyEvent&MockObject $subject */
         $subject = $this->createPartialMock(LegacyEvent::class, ['needsRegistration']);
         $subject->method('needsRegistration')->willReturn(true);
 
@@ -8166,7 +8150,6 @@ final class LegacyEventTest extends TestCase
         string $whichPlugin,
         string $accessLevel
     ): void {
-        /** @var LegacyEvent&MockObject $subject */
         $subject = $this->createPartialMock(
             LegacyEvent::class,
             ['needsRegistration', 'canViewRegistrationsList']
@@ -8189,7 +8172,6 @@ final class LegacyEventTest extends TestCase
      */
     public function canViewRegistrationsListMessageWithLoginAndAccessGrantedReturnsEmptyString(): void
     {
-        /** @var LegacyEvent&MockObject $subject */
         $subject = $this->createPartialMock(
             LegacyEvent::class,
             ['needsRegistration', 'canViewRegistrationsList']
@@ -8213,7 +8195,6 @@ final class LegacyEventTest extends TestCase
      */
     public function canViewRegistrationsListMessageWithLoginAndAccessDeniedReturnsAccessDeniedMessage(): void
     {
-        /** @var LegacyEvent&MockObject $subject */
         $subject = $this->createPartialMock(
             LegacyEvent::class,
             ['needsRegistration', 'canViewRegistrationsList']
@@ -8367,7 +8348,6 @@ final class LegacyEventTest extends TestCase
         bool $hasPriceRegularBoard,
         bool $hasPriceSpecialBoard
     ): void {
-        /** @var LegacyEvent&MockObject $subject */
         $subject = $this->createPartialMock(
             LegacyEvent::class,
             [

--- a/Tests/LegacyUnit/SchedulerTasks/MailNotifierTest.php
+++ b/Tests/LegacyUnit/SchedulerTasks/MailNotifierTest.php
@@ -113,20 +113,14 @@ final class MailNotifierTest extends TestCase
         $this->configuration->setAsBoolean('showAttendancesOnRegistrationQueueInEmailCsv', true);
         ConfigurationRegistry::getInstance()->set('plugin.tx_seminars', $this->configuration);
 
-        /** @var EventStatusService&MockObject $eventStatusService */
-        $eventStatusService = $this->createMock(EventStatusService::class);
-        $this->eventStatusService = $eventStatusService;
+        $this->eventStatusService = $this->createMock(EventStatusService::class);
         GeneralUtility::setSingletonInstance(EventStatusService::class, $this->eventStatusService);
 
-        /** @var EmailService&MockObject $emailService */
-        $emailService = $this->createMock(EmailService::class);
-        $this->emailService = $emailService;
+        $this->emailService = $this->createMock(EmailService::class);
         GeneralUtility::setSingletonInstance(EmailService::class, $this->emailService);
 
-        /** @var EventMapper&MockObject $eventMapper */
-        $eventMapper = $this->createMock(EventMapper::class);
-        $this->eventMapper = $eventMapper;
-        MapperRegistry::set(EventMapper::class, $eventMapper);
+        $this->eventMapper = $this->createMock(EventMapper::class);
+        MapperRegistry::set(EventMapper::class, $this->eventMapper);
 
         /** @var ObjectProphecy<ObjectManager> $objectManagerProphecy */
         $objectManagerProphecy = $this->prophesize(ObjectManager::class);

--- a/Tests/LegacyUnit/Service/EventStatusServiceTest.php
+++ b/Tests/LegacyUnit/Service/EventStatusServiceTest.php
@@ -55,9 +55,7 @@ final class EventStatusServiceTest extends TestCase
         MapperRegistry::denyDatabaseAccess();
         MapperRegistry::getInstance()->activateTestingMode($this->testingFramework);
 
-        /** @var EventMapper&MockObject $eventMapper */
-        $eventMapper = $this->createMock(EventMapper::class);
-        $this->eventMapper = $eventMapper;
+        $this->eventMapper = $this->createMock(EventMapper::class);
         MapperRegistry::set(EventMapper::class, $this->eventMapper);
 
         $this->subject = new EventStatusService();

--- a/Tests/LegacyUnit/Service/RegistrationManagerTest.php
+++ b/Tests/LegacyUnit/Service/RegistrationManagerTest.php
@@ -205,7 +205,6 @@ final class RegistrationManagerTest extends TestCase
         $this->seminar = new TestingLegacyEvent($this->seminarUid);
         $this->subject = TestingRegistrationManager::getInstance();
 
-        /** @var SingleViewLinkBuilder&MockObject $linkBuilder */
         $linkBuilder = $this->createPartialMock(
             SingleViewLinkBuilder::class,
             ['createAbsoluteUrlForEvent']
@@ -3898,7 +3897,6 @@ final class RegistrationManagerTest extends TestCase
      */
     public function notifyAttendeeForUnregistrationMailDoesNotAppendUnregistrationNotice(): void
     {
-        /** @var TestingRegistrationManager&MockObject $subject */
         $subject = $this->getMockBuilder(TestingRegistrationManager::class)
             ->setMethods(['getUnregistrationNotice'])->getMock();
         $subject->expects(self::never())->method('getUnregistrationNotice');
@@ -3929,7 +3927,6 @@ final class RegistrationManagerTest extends TestCase
     {
         $this->configuration->setAsBoolean('allowUnregistrationWithEmptyWaitingList', false);
 
-        /** @var TestingRegistrationManager&MockObject $subject */
         $subject = $this->getMockBuilder(TestingRegistrationManager::class)
             ->setMethods(['getUnregistrationNotice'])->getMock();
         $subject->expects(self::never())->method('getUnregistrationNotice');
@@ -3957,7 +3954,6 @@ final class RegistrationManagerTest extends TestCase
     {
         $this->configuration->setAsBoolean('allowUnregistrationWithEmptyWaitingList', true);
 
-        /** @var TestingRegistrationManager&MockObject $subject */
         $subject = $this->getMockBuilder(TestingRegistrationManager::class)
             ->setMethods(['getUnregistrationNotice'])->getMock();
         $subject->expects(self::once())->method('getUnregistrationNotice');
@@ -3990,7 +3986,6 @@ final class RegistrationManagerTest extends TestCase
     {
         $this->configuration->setAsBoolean('sendConfirmationOnRegistrationForQueue', true);
 
-        /** @var TestingRegistrationManager&MockObject $subject */
         $subject = $this->getMockBuilder(TestingRegistrationManager::class)
             ->setMethods(['getUnregistrationNotice'])->getMock();
         $subject->expects(self::once())->method('getUnregistrationNotice');
@@ -4028,7 +4023,6 @@ final class RegistrationManagerTest extends TestCase
     {
         $this->configuration->setAsBoolean('sendConfirmationOnQueueUpdate', true);
 
-        /** @var TestingRegistrationManager&MockObject $subject */
         $subject = $this->getMockBuilder(TestingRegistrationManager::class)
             ->setMethods(['getUnregistrationNotice'])->getMock();
         $subject->expects(self::once())->method('getUnregistrationNotice');
@@ -5102,7 +5096,6 @@ final class RegistrationManagerTest extends TestCase
 
         $plugin = new DefaultController();
         $plugin->cObj = $this->getFrontEndController()->cObj;
-        /** @var TestingRegistrationManager&MockObject $subject */
         $subject = $this->createPartialMock(
             TestingRegistrationManager::class,
             [
@@ -5138,7 +5131,6 @@ final class RegistrationManagerTest extends TestCase
 
         $plugin = new DefaultController();
         $plugin->cObj = $this->getFrontEndController()->cObj;
-        /** @var TestingRegistrationManager&MockObject $subject */
         $subject = $this->createPartialMock(
             TestingRegistrationManager::class,
             [
@@ -5171,7 +5163,6 @@ final class RegistrationManagerTest extends TestCase
 
         $plugin = new DefaultController();
         $plugin->cObj = $this->getFrontEndController()->cObj;
-        /** @var TestingRegistrationManager&MockObject $subject */
         $subject = $this->createPartialMock(
             TestingRegistrationManager::class,
             [
@@ -5213,7 +5204,6 @@ final class RegistrationManagerTest extends TestCase
 
         $plugin = new DefaultController();
         $plugin->cObj = $this->getFrontEndController()->cObj;
-        /** @var TestingRegistrationManager&MockObject $subject */
         $subject = $this->createPartialMock(
             TestingRegistrationManager::class,
             [
@@ -5402,7 +5392,6 @@ final class RegistrationManagerTest extends TestCase
     {
         $subject = new TestingRegistrationManager();
 
-        /** @var Event&MockObject $event */
         $event = $this->createPartialMock(Event::class, ['getAvailablePrices']);
         $event->setData(['payment_methods' => new Collection()]);
         $event->method('getAvailablePrices')
@@ -5428,7 +5417,6 @@ final class RegistrationManagerTest extends TestCase
     {
         $subject = new TestingRegistrationManager();
 
-        /** @var Event&MockObject $event */
         $event = $this->createPartialMock(Event::class, ['getAvailablePrices']);
         $event->setData(['payment_methods' => new Collection()]);
         $event->method('getAvailablePrices')
@@ -5454,7 +5442,6 @@ final class RegistrationManagerTest extends TestCase
     {
         $subject = new TestingRegistrationManager();
 
-        /** @var Event&MockObject $event */
         $event = $this->createPartialMock(Event::class, ['getAvailablePrices']);
         $event->setData(['payment_methods' => new Collection()]);
         $event->method('getAvailablePrices')
@@ -5480,7 +5467,6 @@ final class RegistrationManagerTest extends TestCase
     {
         $subject = new TestingRegistrationManager();
 
-        /** @var Event&MockObject $event */
         $event = $this->createPartialMock(Event::class, ['getAvailablePrices']);
         $event->setData(['payment_methods' => new Collection()]);
         $event->method('getAvailablePrices')
@@ -5506,7 +5492,6 @@ final class RegistrationManagerTest extends TestCase
     {
         $subject = new TestingRegistrationManager();
 
-        /** @var Event&MockObject $event */
         $event = $this->createPartialMock(Event::class, ['getAvailablePrices']);
         $event->setData(['payment_methods' => new Collection()]);
         $event->method('getAvailablePrices')
@@ -5532,7 +5517,6 @@ final class RegistrationManagerTest extends TestCase
     {
         $subject = new TestingRegistrationManager();
 
-        /** @var Event&MockObject $event */
         $event = $this->createPartialMock(Event::class, ['getAvailablePrices']);
         $event->setData(['payment_methods' => new Collection()]);
         $event->method('getAvailablePrices')
@@ -5738,7 +5722,6 @@ final class RegistrationManagerTest extends TestCase
         $paymentMethods = new Collection();
         $paymentMethods->add($paymentMethod);
 
-        /** @var Event&MockObject $event */
         $event = $this->createPartialMock(Event::class, ['getAvailablePrices', 'getPaymentMethods']);
         $event->method('getAvailablePrices')
             ->willReturn(['regular' => 12]);
@@ -5768,7 +5751,6 @@ final class RegistrationManagerTest extends TestCase
         $paymentMethods->add($paymentMethod1);
         $paymentMethods->add($paymentMethod2);
 
-        /** @var Event&MockObject $event */
         $event = $this->createPartialMock(Event::class, ['getAvailablePrices', 'getPaymentMethods']);
         $event->method('getAvailablePrices')
             ->willReturn(['regular' => 12]);
@@ -5796,7 +5778,6 @@ final class RegistrationManagerTest extends TestCase
         $paymentMethods = new Collection();
         $paymentMethods->add($paymentMethod);
 
-        /** @var Event&MockObject $event */
         $event = $this->createPartialMock(Event::class, ['getAvailablePrices', 'getPaymentMethods']);
         $event->method('getAvailablePrices')
             ->willReturn(['regular' => 0]);
@@ -5819,7 +5800,6 @@ final class RegistrationManagerTest extends TestCase
     {
         $subject = new TestingRegistrationManager();
 
-        /** @var Event&MockObject $event */
         $event = $this->createPartialMock(Event::class, ['getAvailablePrices', 'getPaymentMethods']);
         $event->method('getAvailablePrices')
             ->willReturn(['regular' => 0]);
@@ -5851,7 +5831,6 @@ final class RegistrationManagerTest extends TestCase
         $paymentMethods->add($paymentMethod1);
         $paymentMethods->add($paymentMethod2);
 
-        /** @var Event&MockObject $event */
         $event = $this->createPartialMock(Event::class, ['getAvailablePrices', 'getPaymentMethods']);
         $event->method('getAvailablePrices')
             ->willReturn(['regular' => 12]);
@@ -5878,7 +5857,6 @@ final class RegistrationManagerTest extends TestCase
         $paymentMethods = new Collection();
         $paymentMethods->add($paymentMethod);
 
-        /** @var Event&MockObject $event */
         $event = $this->createPartialMock(Event::class, ['getAvailablePrices', 'getPaymentMethods']);
         $event->method('getAvailablePrices')
             ->willReturn(['regular' => 12]);
@@ -5908,7 +5886,6 @@ final class RegistrationManagerTest extends TestCase
         $paymentMethods->add($paymentMethod1);
         $paymentMethods->add($paymentMethod2);
 
-        /** @var Event&MockObject $event */
         $event = $this->createPartialMock(Event::class, ['getAvailablePrices', 'getPaymentMethods']);
         $event->method('getAvailablePrices')
             ->willReturn(['regular' => 12]);
@@ -5938,7 +5915,6 @@ final class RegistrationManagerTest extends TestCase
         $paymentMethods = new Collection();
         $paymentMethods->add($paymentMethod);
 
-        /** @var Event&MockObject $event */
         $event = $this->createPartialMock(Event::class, ['getAvailablePrices', 'getPaymentMethods']);
         $event->method('getAvailablePrices')
             ->willReturn(['regular' => 12]);

--- a/Tests/LegacyUnit/Support/Traits/BackEndTestsTrait.php
+++ b/Tests/LegacyUnit/Support/Traits/BackEndTestsTrait.php
@@ -8,7 +8,6 @@ use OliverKlee\Oelib\Configuration\ConfigurationRegistry;
 use OliverKlee\Oelib\Configuration\DummyConfiguration;
 use OliverKlee\Oelib\Http\HeaderCollector;
 use OliverKlee\Oelib\Http\HeaderProxyFactory;
-use PHPUnit\Framework\MockObject\MockObject;
 use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 use TYPO3\CMS\Core\Core\Bootstrap;
 use TYPO3\CMS\Core\Localization\LanguageService;
@@ -93,7 +92,6 @@ trait BackEndTestsTrait
         /** @var BackendUserAuthentication $currentBackEndUser */
         $currentBackEndUser = $GLOBALS['BE_USER'];
         $this->backEndUserBackup = $currentBackEndUser;
-        /** @var BackendUserAuthentication&MockObject $mockBackEndUser */
         $mockBackEndUser = $this->createPartialMock(
             BackendUserAuthentication::class,
             ['check', 'doesUserHaveAccess', 'setAndSaveSessionData', 'writeUC']

--- a/Tests/LegacyUnit/ViewHelpers/DateRangeViewHelperTest.php
+++ b/Tests/LegacyUnit/ViewHelpers/DateRangeViewHelperTest.php
@@ -9,7 +9,6 @@ use OliverKlee\Oelib\Configuration\DummyConfiguration;
 use OliverKlee\Seminars\Model\AbstractTimeSpan;
 use OliverKlee\Seminars\Tests\Functional\Traits\LanguageHelper;
 use OliverKlee\Seminars\ViewHelpers\DateRangeViewHelper;
-use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -45,7 +44,6 @@ final class DateRangeViewHelperTest extends TestCase
      */
     public function renderWithNoDatesReturnsWillBeAnnounced(): void
     {
-        /** @var AbstractTimeSpan&MockObject $timeSpan */
         $timeSpan = $this->getMockForAbstractClass(AbstractTimeSpan::class);
         $timeSpan->setData([]);
 
@@ -60,7 +58,6 @@ final class DateRangeViewHelperTest extends TestCase
      */
     public function renderWithBeginDateOnlyRendersOnlyBeginDate(): void
     {
-        /** @var AbstractTimeSpan&MockObject $timeSpan */
         $timeSpan = $this->getMockForAbstractClass(AbstractTimeSpan::class);
         $timeSpan->setBeginDateAsUnixTimeStamp(self::BEGIN_DATE);
 
@@ -75,7 +72,6 @@ final class DateRangeViewHelperTest extends TestCase
      */
     public function renderWithEqualBeginAndEndDateReturnsOnlyBeginDate(): void
     {
-        /** @var AbstractTimeSpan&MockObject $timeSpan */
         $timeSpan = $this->getMockForAbstractClass(AbstractTimeSpan::class);
         $timeSpan->setBeginDateAsUnixTimeStamp(self::BEGIN_DATE);
         $timeSpan->setEndDateAsUnixTimeStamp(self::BEGIN_DATE);
@@ -91,7 +87,6 @@ final class DateRangeViewHelperTest extends TestCase
      */
     public function renderWithBeginAndEndDateOnSameDayReturnsOnlyBeginDate(): void
     {
-        /** @var AbstractTimeSpan&MockObject $timeSpan */
         $timeSpan = $this->getMockForAbstractClass(AbstractTimeSpan::class);
         $timeSpan->setBeginDateAsUnixTimeStamp(self::BEGIN_DATE);
         $timeSpan->setEndDateAsUnixTimeStamp(self::BEGIN_DATE + 3600);
@@ -107,7 +102,6 @@ final class DateRangeViewHelperTest extends TestCase
      */
     public function renderWithBeginAndEndDateOnDifferentDaysReturnsBothFullDatesSeparatedByDash(): void
     {
-        /** @var AbstractTimeSpan&MockObject $timeSpan */
         $timeSpan = $this->getMockForAbstractClass(AbstractTimeSpan::class);
         $timeSpan->setBeginDateAsUnixTimeStamp(self::BEGIN_DATE);
         $endDate = self::BEGIN_DATE + (2 * 86400);
@@ -126,7 +120,6 @@ final class DateRangeViewHelperTest extends TestCase
     {
         $dash = '#DASH#';
 
-        /** @var AbstractTimeSpan&MockObject $timeSpan */
         $timeSpan = $this->getMockForAbstractClass(AbstractTimeSpan::class);
         $timeSpan->setBeginDateAsUnixTimeStamp(self::BEGIN_DATE);
         $endDate = self::BEGIN_DATE + (2 * 86400);

--- a/Tests/Unit/FrontEnd/DefaultControllerTest.php
+++ b/Tests/Unit/FrontEnd/DefaultControllerTest.php
@@ -6,7 +6,6 @@ namespace OliverKlee\Seminars\Tests\Unit\FrontEnd;
 
 use Nimut\TestingFramework\TestCase\UnitTestCase;
 use OliverKlee\Seminars\FrontEnd\DefaultController;
-use PHPUnit\Framework\MockObject\MockObject;
 
 /**
  * @covers \OliverKlee\Seminars\FrontEnd\DefaultController
@@ -20,7 +19,6 @@ final class DefaultControllerTest extends UnitTestCase
      */
     public function singleViewFlavorWithUidCreatesSingleView(): void
     {
-        /** @var DefaultController&MockObject $controller */
         $controller = $this->createPartialMock(
             DefaultController::class,
             [
@@ -45,7 +43,6 @@ final class DefaultControllerTest extends UnitTestCase
      */
     public function singleViewFlavorWithUidFromShowSingleEventConfigurationCreatesSingleView(): void
     {
-        /** @var DefaultController&MockObject $controller */
         $controller = $this->createPartialMock(
             DefaultController::class,
             [
@@ -70,7 +67,6 @@ final class DefaultControllerTest extends UnitTestCase
      */
     public function singleViewFlavorWithoutUidCreatesSingleView(): void
     {
-        /** @var DefaultController&MockObject $controller */
         $controller = $this->createPartialMock(
             DefaultController::class,
             [
@@ -97,7 +93,6 @@ final class DefaultControllerTest extends UnitTestCase
      */
     public function eventListFlavorWithoutUidCreatesListView(): void
     {
-        /** @var DefaultController&MockObject $controller */
         $controller = $this->createPartialMock(
             DefaultController::class,
             [
@@ -122,7 +117,6 @@ final class DefaultControllerTest extends UnitTestCase
      */
     public function eventListFlavorWithUidCreatesListView(): void
     {
-        /** @var DefaultController&MockObject $controller */
         $controller = $this->createPartialMock(
             DefaultController::class,
             [

--- a/Tests/Unit/Traits/EmailTrait.php
+++ b/Tests/Unit/Traits/EmailTrait.php
@@ -27,15 +27,12 @@ trait EmailTrait
      */
     private function createEmailMock(): MailMessage
     {
-        /** @var MailMessage&MockObject $message */
-        $message = $this->getMockBuilder(MailMessage::class)
+        return $this->getMockBuilder(MailMessage::class)
             ->disableOriginalClone()
             ->disableArgumentCloning()
             ->disallowMockingUnknownTypes()
             ->setMethods(['send'])
             ->getMock();
-
-        return $message;
     }
 
     /**


### PR DESCRIPTION
In many cases, PHPUnit's generics already provide all information needed
for static analysis of mocks.

Fixes #1371