### PR TITLE
[CLEANUP] Drop type annotations for `makeInstance` & `ObjectManager::…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 - Fix a flaky test (#1403, #1408)
-- Improve the type annotations (#1401, #1417)
+- Improve the type annotations (#1401, #1417, #1424)
 
 ## 4.1.5
 

--- a/Classes/BackEnd/AbstractEventMailForm.php
+++ b/Classes/BackEnd/AbstractEventMailForm.php
@@ -387,7 +387,6 @@ abstract class AbstractEventMailForm
         $organizer = $event->getFirstOrganizer();
         $sender = $event->getEmailSender();
 
-        /** @var RegistrationBagBuilder $registrationBagBuilder */
         $registrationBagBuilder = GeneralUtility::makeInstance(RegistrationBagBuilder::class);
         $registrationBagBuilder->limitToEvent($event->getUid());
         $registrations = $registrationBagBuilder->build();
@@ -413,7 +412,6 @@ abstract class AbstractEventMailForm
                 $email->send();
             }
 
-            /** @var FlashMessage $message */
             $message = GeneralUtility::makeInstance(
                 FlashMessage::class,
                 $this->getLanguageService()->getLL('message_emailToAttendeesSent'),
@@ -432,9 +430,8 @@ abstract class AbstractEventMailForm
      */
     protected function addFlashMessage(FlashMessage $flashMessage): void
     {
-        /** @var FlashMessageService $flashMessageService */
-        $flashMessageService = GeneralUtility::makeInstance(FlashMessageService::class);
-        $defaultFlashMessageQueue = $flashMessageService->getMessageQueueByIdentifier();
+        $defaultFlashMessageQueue = GeneralUtility::makeInstance(FlashMessageService::class)
+            ->getMessageQueueByIdentifier();
         $defaultFlashMessageQueue->enqueue($flashMessage);
     }
 
@@ -544,9 +541,7 @@ abstract class AbstractEventMailForm
      */
     protected function localizeSalutationPlaceholder(string $prefix): string
     {
-        /** @var Salutation $salutation */
-        $salutation = GeneralUtility::makeInstance(Salutation::class);
-        $eventDetails = $salutation->createIntroduction(
+        $eventDetails = GeneralUtility::makeInstance(Salutation::class)->createIntroduction(
             '"%s"',
             $this->getOldEvent()
         );
@@ -568,11 +563,9 @@ abstract class AbstractEventMailForm
      */
     private function createMessageBody(FrontEndUser $user, Organizer $organizer): string
     {
-        /** @var Salutation $salutation */
-        $salutation = GeneralUtility::makeInstance(Salutation::class);
         $messageText = str_replace(
             '%salutation',
-            $salutation->getSalutation($user),
+            GeneralUtility::makeInstance(Salutation::class)->getSalutation($user),
             $this->getPostData('messageBody')
         );
         $messageFooter = $organizer->hasEmailFooter()

--- a/Classes/BackEnd/AbstractList.php
+++ b/Classes/BackEnd/AbstractList.php
@@ -227,7 +227,6 @@ abstract class AbstractList
                 '</a>' .
                 '</div>';
 
-            /** @var FlashMessage $message */
             $message = GeneralUtility::makeInstance(
                 FlashMessage::class,
                 $storageLabel,
@@ -236,9 +235,8 @@ abstract class AbstractList
             );
             $this->addFlashMessage($message);
 
-            /** @var FlashMessageService $flashMessageService */
-            $flashMessageService = GeneralUtility::makeInstance(FlashMessageService::class);
-            $renderedFlashMessages = $flashMessageService->getMessageQueueByIdentifier()->renderFlashMessages();
+            $renderedFlashMessages = GeneralUtility::makeInstance(FlashMessageService::class)
+                ->getMessageQueueByIdentifier()->renderFlashMessages();
 
             $result .= '<div id="eventsList-clear"></div>' . $renderedFlashMessages;
 
@@ -255,9 +253,8 @@ abstract class AbstractList
      */
     protected function addFlashMessage(FlashMessage $flashMessage): void
     {
-        /** @var FlashMessageService $flashMessageService */
-        $flashMessageService = GeneralUtility::makeInstance(FlashMessageService::class);
-        $defaultFlashMessageQueue = $flashMessageService->getMessageQueueByIdentifier();
+        $defaultFlashMessageQueue = GeneralUtility::makeInstance(FlashMessageService::class)
+            ->getMessageQueueByIdentifier();
         $defaultFlashMessageQueue->enqueue($flashMessage);
     }
 

--- a/Classes/BackEnd/CancelEventMailForm.php
+++ b/Classes/BackEnd/CancelEventMailForm.php
@@ -42,11 +42,8 @@ class CancelEventMailForm extends AbstractEventMailForm
      */
     protected function setEventStatus(): void
     {
-        /** @var EventStatusService $eventStatusService */
-        $eventStatusService = GeneralUtility::makeInstance(EventStatusService::class);
-        $eventStatusService->cancelAndSave($this->getEvent());
+        GeneralUtility::makeInstance(EventStatusService::class)->cancelAndSave($this->getEvent());
 
-        /** @var FlashMessage $message */
         $message = GeneralUtility::makeInstance(
             FlashMessage::class,
             $this->getLanguageService()->getLL('message_eventCanceled'),

--- a/Classes/BackEnd/ConfirmEventMailForm.php
+++ b/Classes/BackEnd/ConfirmEventMailForm.php
@@ -52,11 +52,8 @@ class ConfirmEventMailForm extends AbstractEventMailForm
      */
     protected function setEventStatus(): void
     {
-        /** @var EventStatusService $eventStatusService */
-        $eventStatusService = GeneralUtility::makeInstance(EventStatusService::class);
-        $eventStatusService->confirmAndSave($this->getEvent());
+        GeneralUtility::makeInstance(EventStatusService::class)->confirmAndSave($this->getEvent());
 
-        /** @var FlashMessage $message */
         $message = GeneralUtility::makeInstance(
             FlashMessage::class,
             $this->getLanguageService()->getLL('message_eventConfirmed'),

--- a/Classes/BackEnd/Controller.php
+++ b/Classes/BackEnd/Controller.php
@@ -45,9 +45,7 @@ class Controller extends AbstractModule
                     $filename = null;
             }
 
-            /** @var CsvDownloader $csvExporter */
-            $csvExporter = GeneralUtility::makeInstance(CsvDownloader::class);
-            $csvContent = $csvExporter->main();
+            $csvContent = GeneralUtility::makeInstance(CsvDownloader::class)->main();
             $response = new CsvResponse($csvContent, $filename);
         } else {
             $htmlContent = $this->main();
@@ -67,9 +65,6 @@ class Controller extends AbstractModule
         $languageService = $this->getLanguageService();
         $backEndUser = $this->getBackendUser();
 
-        /** @var DocumentTemplate $document */
-        $document = GeneralUtility::makeInstance(DocumentTemplate::class);
-
         $pageRenderer = $this->getPageRenderer();
         $pageRenderer->addCssFile(
             '../typo3conf/ext/seminars/Resources/Public/CSS/BackEnd/BackEnd.css',
@@ -79,11 +74,11 @@ class Controller extends AbstractModule
             false
         );
 
+        $document = GeneralUtility::makeInstance(DocumentTemplate::class);
         $content = $document->startPage($languageService->getLL('title')) .
             '<h1>' . $languageService->getLL('title') . '</h1></div>';
 
         if ($this->id <= 0) {
-            /** @var FlashMessage $message */
             $message = GeneralUtility::makeInstance(
                 FlashMessage::class,
                 $languageService->getLL('message_noPageTypeSelected'),
@@ -101,7 +96,6 @@ class Controller extends AbstractModule
         }
 
         if (!$this->hasStaticTemplate()) {
-            /** @var FlashMessage $message */
             $message = GeneralUtility::makeInstance(
                 FlashMessage::class,
                 $languageService->getLL('message_noStaticTemplateFound'),
@@ -155,19 +149,13 @@ class Controller extends AbstractModule
 
         switch ($this->subModule) {
             case 2:
-                /** @var RegistrationsList $registrationsList */
-                $registrationsList = GeneralUtility::makeInstance(RegistrationsList::class, $this);
-                $content .= $registrationsList->show();
+                $content .= GeneralUtility::makeInstance(RegistrationsList::class, $this)->show();
                 break;
             case 3:
-                /** @var SpeakersList $speakersList */
-                $speakersList = GeneralUtility::makeInstance(SpeakersList::class, $this);
-                $content .= $speakersList->show();
+                $content .= GeneralUtility::makeInstance(SpeakersList::class, $this)->show();
                 break;
             case 4:
-                /** @var OrganizersList $organizersList */
-                $organizersList = GeneralUtility::makeInstance(OrganizersList::class, $this);
-                $content .= $organizersList->show();
+                $content .= GeneralUtility::makeInstance(OrganizersList::class, $this)->show();
                 break;
             case 1:
                 if ($this->isGeneralEmailFormRequested()) {
@@ -177,9 +165,7 @@ class Controller extends AbstractModule
                 } elseif ($this->isCancelEventFormRequested()) {
                     $content .= $this->getCancelEventMailForm();
                 } else {
-                    /** @var EventsList $eventsList */
-                    $eventsList = GeneralUtility::makeInstance(EventsList::class, $this);
-                    $content .= $eventsList->show();
+                    $content .= GeneralUtility::makeInstance(EventsList::class, $this)->show();
                 }
                 break;
             default:
@@ -203,9 +189,8 @@ class Controller extends AbstractModule
      */
     protected function addFlashMessage(FlashMessage $flashMessage): void
     {
-        /** @var FlashMessageService $flashMessageService */
-        $flashMessageService = GeneralUtility::makeInstance(FlashMessageService::class);
-        $defaultFlashMessageQueue = $flashMessageService->getMessageQueueByIdentifier();
+        $defaultFlashMessageQueue = GeneralUtility::makeInstance(FlashMessageService::class)
+            ->getMessageQueueByIdentifier();
         $defaultFlashMessageQueue->enqueue($flashMessage);
     }
 
@@ -216,9 +201,8 @@ class Controller extends AbstractModule
      */
     protected function getRenderedFlashMessages(): string
     {
-        /** @var FlashMessageService $flashMessageService */
-        $flashMessageService = GeneralUtility::makeInstance(FlashMessageService::class);
-        return $flashMessageService->getMessageQueueByIdentifier()->renderFlashMessages();
+        return GeneralUtility::makeInstance(FlashMessageService::class)
+            ->getMessageQueueByIdentifier()->renderFlashMessages();
     }
 
     /**
@@ -282,7 +266,6 @@ class Controller extends AbstractModule
      */
     private function getGeneralMailForm(): string
     {
-        /** @var GeneralEventMailForm $form */
         $form = GeneralUtility::makeInstance(GeneralEventMailForm::class, $this->getEventUid());
         $form->setPostData(GeneralUtility::_POST());
 
@@ -296,7 +279,6 @@ class Controller extends AbstractModule
      */
     private function getConfirmEventMailForm(): string
     {
-        /** @var ConfirmEventMailForm $form */
         $form = GeneralUtility::makeInstance(ConfirmEventMailForm::class, $this->getEventUid());
         $form->setPostData(GeneralUtility::_POST());
 
@@ -310,7 +292,6 @@ class Controller extends AbstractModule
      */
     private function getCancelEventMailForm(): string
     {
-        /** @var CancelEventMailForm $form */
         $form = GeneralUtility::makeInstance(CancelEventMailForm::class, $this->getEventUid());
         $form->setPostData(GeneralUtility::_POST());
 
@@ -392,7 +373,7 @@ class Controller extends AbstractModule
      */
     protected function getRouteUrl(string $moduleName, array $urlParameters = []): string
     {
-        $uriBuilder = $this->getUriBuilder();
+        $uriBuilder = GeneralUtility::makeInstance(UriBuilder::class);
         try {
             $uri = $uriBuilder->buildUriFromRoute($moduleName, $urlParameters);
         } catch (RouteNotFoundException $e) {
@@ -402,10 +383,5 @@ class Controller extends AbstractModule
         }
 
         return (string)$uri;
-    }
-
-    protected function getUriBuilder(): UriBuilder
-    {
-        return GeneralUtility::makeInstance(UriBuilder::class);
     }
 }

--- a/Classes/BackEnd/EventsList.php
+++ b/Classes/BackEnd/EventsList.php
@@ -49,7 +49,6 @@ class EventsList extends AbstractList
 
         $this->createTableHeading();
 
-        /** @var EventBagBuilder $builder */
         $builder = GeneralUtility::makeInstance(EventBagBuilder::class);
         $builder->setBackEndMode();
 

--- a/Classes/BackEnd/OrganizersList.php
+++ b/Classes/BackEnd/OrganizersList.php
@@ -50,11 +50,8 @@ class OrganizersList extends AbstractList
             $this->getLanguageService()->getLL('organizerlist.title')
         );
 
-        /** @var OrganizerBagBuilder $builder */
         $builder = GeneralUtility::makeInstance(OrganizerBagBuilder::class);
-
         $builder->setSourcePages((string)$pageData['uid'], self::RECURSION_DEPTH);
-
         $organizerBag = $builder->build();
 
         $tableRows = '';

--- a/Classes/BackEnd/RegistrationsList.php
+++ b/Classes/BackEnd/RegistrationsList.php
@@ -134,7 +134,6 @@ class RegistrationsList extends AbstractList
      */
     private function setRegistrationTableMarkers(int $registrationsToShow): bool
     {
-        /** @var RegistrationBagBuilder $builder */
         $builder = GeneralUtility::makeInstance(RegistrationBagBuilder::class);
         $pageData = $this->page->getPageData();
 

--- a/Classes/BackEnd/SpeakersList.php
+++ b/Classes/BackEnd/SpeakersList.php
@@ -49,12 +49,9 @@ class SpeakersList extends AbstractList
         $this->template->setMarker('label_full_name', $languageService->getLL('speakerlist.title'));
         $this->template->setMarker('label_skills', $languageService->getLL('speakerlist.skills'));
 
-        /** @var SpeakerBagBuilder $builder */
         $builder = GeneralUtility::makeInstance(SpeakerBagBuilder::class);
         $builder->showHiddenRecords();
-
         $builder->setSourcePages((string)$pageData['uid'], self::RECURSION_DEPTH);
-
         $speakerBag = $builder->build();
 
         $tableRows = '';

--- a/Classes/BackEnd/TceForms.php
+++ b/Classes/BackEnd/TceForms.php
@@ -71,9 +71,6 @@ class TceForms
 
     private static function getConnectionForTable(string $table): Connection
     {
-        /** @var ConnectionPool $pool */
-        $pool = GeneralUtility::makeInstance(ConnectionPool::class);
-
-        return $pool->getConnectionForTable($table);
+        return GeneralUtility::makeInstance(ConnectionPool::class)->getConnectionForTable($table);
     }
 }

--- a/Classes/BackEnd/TimeSlotWizard.php
+++ b/Classes/BackEnd/TimeSlotWizard.php
@@ -74,13 +74,10 @@ class TimeSlotWizard extends AbstractFormElement
 
     private function buildSingleToggleButton(string $labelKey, string $icon, string $additionalClass = ''): string
     {
-        /** @var IconFactory $iconFactory */
-        $iconFactory = GeneralUtility::makeInstance(IconFactory::class);
-
         $allClasses = 'btn btn-default ' .
             't3js-formengine-timeslotwizard-toggle t3js-formengine-timeslotwizard-toggleable ' . $additionalClass;
         return '<button class="' . $allClasses . '" type="button">' .
-            $iconFactory->getIcon($icon, Icon::SIZE_SMALL) . ' ' .
+            GeneralUtility::makeInstance(IconFactory::class)->getIcon($icon, Icon::SIZE_SMALL) . ' ' .
             $this->createEncodedLabel($labelKey) .
             '</button>';
     }
@@ -195,10 +192,8 @@ class TimeSlotWizard extends AbstractFormElement
 
     private function buildSubmitButton(): string
     {
-        /** @var IconFactory $iconFactory */
         $iconFactory = GeneralUtility::makeInstance(IconFactory::class);
 
-        /** @var InputButton $button */
         $button = GeneralUtility::makeInstance(InputButton::class);
         $button->setTitle($this->getLanguageService()->sL(self::LABEL_KEY_PREFIX . 'create'))
             ->setName('_savedok')

--- a/Classes/BagBuilder/AbstractBagBuilder.php
+++ b/Classes/BagBuilder/AbstractBagBuilder.php
@@ -133,8 +133,8 @@ abstract class AbstractBagBuilder
         // Todo: Remove this after we pass an array from outside
         $uids = GeneralUtility::intExplode(',', $sourcePagePids);
 
-        $recursivePidList =
-            GeneralUtility::makeInstance(OelibPageRepository::class)->findWithinParentPages($uids, $recursionDepth);
+        $recursivePidList = GeneralUtility::makeInstance(OelibPageRepository::class)
+            ->findWithinParentPages($uids, $recursionDepth);
 
         $this->whereClauseParts['pages'] = $this->tableName . '.pid IN (' . \implode(',', $recursivePidList) . ')';
     }

--- a/Classes/Configuration/SharedConfigurationCheck.php
+++ b/Classes/Configuration/SharedConfigurationCheck.php
@@ -43,9 +43,7 @@ class SharedConfigurationCheck extends AbstractConfigurationCheck
      */
     private function checkCurrency(): void
     {
-        /** @var ConnectionPool $pool */
-        $pool = GeneralUtility::makeInstance(ConnectionPool::class);
-        $connection = $pool->getConnectionForTable('static_currencies');
+        $connection = GeneralUtility::makeInstance(ConnectionPool::class)->getConnectionForTable('static_currencies');
         $result = $connection->select(['cu_iso_3'], 'static_currencies')->fetchAll();
         $allowedValues = \array_column($result, 'cu_iso_3');
 

--- a/Classes/Csv/AbstractRegistrationListView.php
+++ b/Classes/Csv/AbstractRegistrationListView.php
@@ -100,9 +100,8 @@ abstract class AbstractRegistrationListView extends AbstractListView
             . implode(self::LINE_SEPARATOR, $allLines)
             . self::LINE_SEPARATOR;
 
-        /** @var HookProvider $csvHookProvider */
-        $csvHookProvider = GeneralUtility::makeInstance(HookProvider::class, RegistrationListCsv::class);
-        return $csvHookProvider->executeHookReturningModifiedValue('modifyCsv', $allLines, $this);
+        return GeneralUtility::makeInstance(HookProvider::class, RegistrationListCsv::class)
+            ->executeHookReturningModifiedValue('modifyCsv', $allLines, $this);
     }
 
     /**
@@ -180,9 +179,7 @@ abstract class AbstractRegistrationListView extends AbstractListView
      */
     protected function createRegistrationBagBuilder(): RegistrationBagBuilder
     {
-        /** @var RegistrationBagBuilder $registrationBagBuilder */
         $registrationBagBuilder = GeneralUtility::makeInstance(RegistrationBagBuilder::class);
-
         if (!$this->shouldAlsoContainRegistrationsOnQueue()) {
             $registrationBagBuilder->limitToRegular();
         }

--- a/Classes/Csv/CsvDownloader.php
+++ b/Classes/Csv/CsvDownloader.php
@@ -96,7 +96,6 @@ class CsvDownloader
      */
     public function createAndOutputListOfRegistrations(int $eventUid = 0): string
     {
-        /** @var DownloadRegistrationListView $listView */
         $listView = GeneralUtility::makeInstance(DownloadRegistrationListView::class);
 
         $pageUid = (int)GeneralUtility::_GET('pid');
@@ -134,7 +133,6 @@ class CsvDownloader
             return '';
         }
 
-        /** @var DownloadRegistrationListView $listView */
         $listView = GeneralUtility::makeInstance(DownloadRegistrationListView::class);
         $listView->setEventUid($eventUid);
 
@@ -177,7 +175,6 @@ class CsvDownloader
      */
     public function createListOfEvents(int $pageUid): string
     {
-        /** @var EventListView $eventListView */
         $eventListView = GeneralUtility::makeInstance(EventListView::class);
         $eventListView->setPageUid($pageUid);
 
@@ -199,19 +196,13 @@ class CsvDownloader
     {
         switch ($this->getTypo3Mode()) {
             case 'BE':
-                /** @var BackEndRegistrationAccessCheck $accessCheck */
-                $accessCheck = GeneralUtility::makeInstance(BackEndRegistrationAccessCheck::class);
-                $result = $accessCheck->hasAccess();
+                $result = GeneralUtility::makeInstance(BackEndRegistrationAccessCheck::class)->hasAccess();
                 break;
             case 'FE':
-                /** @var FrontEndRegistrationAccessCheck $accessCheck */
-                $accessCheck = GeneralUtility::makeInstance(FrontEndRegistrationAccessCheck::class);
-
-                /** @var LegacyEvent $event */
                 $event = GeneralUtility::makeInstance(LegacyEvent::class, $eventUid, false, true);
-                $accessCheck->setEvent($event);
+                GeneralUtility::makeInstance(FrontEndRegistrationAccessCheck::class)->setEvent($event);
 
-                $result = $accessCheck->hasAccess();
+                $result = GeneralUtility::makeInstance(FrontEndRegistrationAccessCheck::class)->hasAccess();
                 break;
             default:
                 $result = false;
@@ -229,7 +220,6 @@ class CsvDownloader
      */
     protected function canAccessListOfEvents(int $pageUid): bool
     {
-        /** @var BackEndEventAccessCheck $accessCheck */
         $accessCheck = GeneralUtility::makeInstance(BackEndEventAccessCheck::class);
         $accessCheck->setPageUid($pageUid);
 
@@ -309,7 +299,6 @@ class CsvDownloader
     {
         switch ($this->getTypo3Mode()) {
             case 'BE':
-                /** @var BackEndRegistrationAccessCheck $accessCheck */
                 $accessCheck = GeneralUtility::makeInstance(BackEndRegistrationAccessCheck::class);
                 $accessCheck->setPageUid($pageUid);
                 $result = $accessCheck->hasAccess();

--- a/Classes/Csv/EventListView.php
+++ b/Classes/Csv/EventListView.php
@@ -85,7 +85,6 @@ class EventListView extends AbstractListView
      */
     protected function createCsvBodyLines(): array
     {
-        /** @var EventBagBuilder $builder */
         $builder = GeneralUtility::makeInstance(EventBagBuilder::class);
         $builder->setBackEndMode();
         $builder->setSourcePages((string)$this->getPageUid(), self::RECURSION_DEPTH);

--- a/Classes/FrontEnd/AbstractEditor.php
+++ b/Classes/FrontEnd/AbstractEditor.php
@@ -146,8 +146,6 @@ abstract class AbstractEditor extends AbstractView
 
         /**
          * Configuration instance for plugin data. Necessary for LABEL translation.
-         *
-         * @var ConfigurationProcessor $pluginConfiguration
          */
         $pluginConfiguration = GeneralUtility::makeInstance(ConfigurationProcessor::class);
         $pluginConfiguration->init($this->conf, $this->cObj, 'mkforms', 'mkforms');

--- a/Classes/FrontEnd/CategoryList.php
+++ b/Classes/FrontEnd/CategoryList.php
@@ -26,7 +26,6 @@ class CategoryList extends AbstractView
      */
     public function render(): string
     {
-        /** @var EventBagBuilder $seminarBagBuilder */
         $seminarBagBuilder = GeneralUtility::makeInstance(EventBagBuilder::class);
         $seminarBagBuilder->setSourcePages(
             $this->getConfValueString('pages'),
@@ -48,7 +47,6 @@ class CategoryList extends AbstractView
 
         $eventUids = $seminarBagBuilder->build()->getUids();
 
-        /** @var CategoryBagBuilder $categoryBagBuilder */
         $categoryBagBuilder = GeneralUtility::makeInstance(CategoryBagBuilder::class);
         $categoryBagBuilder->limitToEvents($eventUids);
         $categoryBag = $categoryBagBuilder->build();

--- a/Classes/FrontEnd/Countdown.php
+++ b/Classes/FrontEnd/Countdown.php
@@ -46,9 +46,7 @@ class Countdown extends AbstractView
             throw new \BadMethodCallException('The method injectEventMapper() needs to be called first.', 1333617194);
         }
         if ($this->viewHelper === null) {
-            /** @var CountdownViewHelper $viewHelper */
-            $viewHelper = GeneralUtility::makeInstance(CountdownViewHelper::class);
-            $this->injectCountDownViewHelper($viewHelper);
+            $this->injectCountDownViewHelper(GeneralUtility::makeInstance(CountdownViewHelper::class));
         }
 
         try {

--- a/Classes/FrontEnd/DefaultController.php
+++ b/Classes/FrontEnd/DefaultController.php
@@ -281,7 +281,6 @@ class DefaultController extends TemplateHelper
                 // The fallthrough is intended
                 // because createRegistrationsListPage() will differentiate later.
             case 'list_registrations':
-                /** @var RegistrationsList $registrationsList */
                 $registrationsList = GeneralUtility::makeInstance(
                     RegistrationsList::class,
                     $this->conf,
@@ -300,7 +299,6 @@ class DefaultController extends TemplateHelper
                 }
                 break;
             case 'countdown':
-                /** @var Countdown $countdown */
                 $countdown = GeneralUtility::makeInstance(
                     Countdown::class,
                     $this->conf,
@@ -318,7 +316,6 @@ class DefaultController extends TemplateHelper
                 }
                 break;
             case 'category_list':
-                /** @var CategoryList $categoryList */
                 $categoryList = GeneralUtility::makeInstance(
                     CategoryList::class,
                     $this->conf,
@@ -335,7 +332,6 @@ class DefaultController extends TemplateHelper
                 }
                 break;
             case 'event_headline':
-                /** @var EventHeadline $eventHeadline */
                 $eventHeadline = GeneralUtility::makeInstance(
                     EventHeadline::class,
                     $this->conf,
@@ -1195,7 +1191,7 @@ class DefaultController extends TemplateHelper
             return;
         }
 
-        $requirementsLists = $this->createRequirementsList();
+        $requirementsLists = GeneralUtility::makeInstance(RequirementsList::class, $this->conf, $this->cObj);
         $requirementsLists->setEvent($this->seminar);
 
         $this->setSubpart(
@@ -1888,9 +1884,8 @@ class DefaultController extends TemplateHelper
             }
             $this->setMarker('image', $image);
 
-            /** @var CategoryList $categoryList */
-            $categoryList = GeneralUtility::makeInstance(CategoryList::class, $this->conf, $this->cObj);
-            $listOfCategories = $categoryList->createCategoryList($this->seminar->getCategories());
+            $listOfCategories = GeneralUtility::makeInstance(CategoryList::class, $this->conf, $this->cObj)
+                ->createCategoryList($this->seminar->getCategories());
 
             if (
                 $listOfCategories === $this->previousCategory
@@ -1977,7 +1972,6 @@ class DefaultController extends TemplateHelper
      */
     private function createSeminarBagBuilder(): EventBagBuilder
     {
-        /** @var EventBagBuilder $seminarBagBuilder */
         $seminarBagBuilder = GeneralUtility::makeInstance(EventBagBuilder::class);
 
         $seminarBagBuilder->setSourcePages(
@@ -1997,7 +1991,6 @@ class DefaultController extends TemplateHelper
      */
     private function createRegistrationBagBuilder(): RegistrationBagBuilder
     {
-        /** @var RegistrationBagBuilder $registrationBagBuilder */
         $registrationBagBuilder = GeneralUtility::makeInstance(RegistrationBagBuilder::class);
 
         /** @var FrontEndUser $loggedInUser */
@@ -2006,16 +1999,6 @@ class DefaultController extends TemplateHelper
         $registrationBagBuilder->setOrderByEventColumn($this->getOrderByForListView());
 
         return $registrationBagBuilder;
-    }
-
-    /**
-     * @return RequirementsList the object to build the requirements list with
-     */
-    private function createRequirementsList(): RequirementsList
-    {
-        /** @var RequirementsList $list */
-        $list = GeneralUtility::makeInstance(RequirementsList::class, $this->conf, $this->cObj);
-        return $list;
     }
 
     /**
@@ -2086,7 +2069,6 @@ class DefaultController extends TemplateHelper
             return '';
         }
 
-        /** @var SelectorWidget $selectorWidget */
         $selectorWidget = GeneralUtility::makeInstance(
             SelectorWidget::class,
             $this->conf,
@@ -2633,7 +2615,7 @@ class DefaultController extends TemplateHelper
                 $registrationForm = $this->createRegistrationForm();
             } else {
                 $errorMessage = $this->translate('message_requirementsNotFulfilled');
-                $requirementsList = $this->createRequirementsList();
+                $requirementsList = GeneralUtility::makeInstance(RequirementsList::class, $this->conf, $this->cObj);
                 $requirementsList->setEvent($this->seminar);
                 $requirementsList->limitToMissingRegistrations();
                 $registrationForm = $requirementsList->render();
@@ -2700,7 +2682,6 @@ class DefaultController extends TemplateHelper
      */
     protected function createRegistrationForm(): string
     {
-        /** @var RegistrationForm $registrationEditor */
         $registrationEditor = GeneralUtility::makeInstance(
             RegistrationForm::class,
             $this->conf,
@@ -2812,7 +2793,6 @@ class DefaultController extends TemplateHelper
      */
     protected function createEventEditorInstance(): EventEditor
     {
-        /** @var EventEditor $eventEditor */
         $eventEditor = GeneralUtility::makeInstance(EventEditor::class, $this->conf, $this->cObj);
         $eventEditor->setObjectUid((int)$this->piVars['seminar']);
 
@@ -3275,7 +3255,6 @@ class DefaultController extends TemplateHelper
     {
         if (!$this->linkBuilder instanceof SingleViewLinkBuilder) {
             $configuration = $this->getConfigurationWithFlexForms();
-            /** @var SingleViewLinkBuilder $linkBuilder */
             $linkBuilder = GeneralUtility::makeInstance(SingleViewLinkBuilder::class, $configuration);
             $this->injectLinkBuilder($linkBuilder);
         }

--- a/Classes/FrontEnd/EventEditor.php
+++ b/Classes/FrontEnd/EventEditor.php
@@ -128,7 +128,6 @@ class EventEditor extends AbstractEditor
         $this->setFormConfiguration((array)$this->conf['form.']['eventEditor.']);
         $this->declareDataHandler();
 
-        /** @var Template $template */
         $template = GeneralUtility::makeInstance(Template::class);
         $template->processTemplate(parent::render());
 
@@ -821,10 +820,9 @@ class EventEditor extends AbstractEditor
      */
     private function getHiddenSubparts(): array
     {
-        /** @var Tree $visibilityTree */
         $visibilityTree = GeneralUtility::makeInstance(Tree::class, $this->createTemplateStructure());
-
         $visibilityTree->makeNodesVisible($this->getFieldsToShow());
+
         return $visibilityTree->getKeysOfHiddenSubparts();
     }
 
@@ -1282,7 +1280,6 @@ class EventEditor extends AbstractEditor
             ];
         }
 
-        /** @var Place $place */
         $place = GeneralUtility::makeInstance(Place::class);
         $place->setData(self::createBasicAuxiliaryData());
         self::setPlaceData($place, 'newPlace_', $formData);
@@ -1579,7 +1576,6 @@ class EventEditor extends AbstractEditor
             ];
         }
 
-        /** @var Speaker $speaker */
         $speaker = GeneralUtility::makeInstance(Speaker::class);
 
         self::createBasicAuxiliaryData();
@@ -1843,7 +1839,6 @@ class EventEditor extends AbstractEditor
             ];
         }
 
-        /** @var Checkbox $checkbox */
         $checkbox = GeneralUtility::makeInstance(Checkbox::class);
         $checkbox->setData(self::createBasicAuxiliaryData());
         self::setCheckboxData($checkbox, 'newCheckbox_', $formData);
@@ -2050,7 +2045,6 @@ class EventEditor extends AbstractEditor
             ];
         }
 
-        /** @var TargetGroup $targetGroup */
         $targetGroup = GeneralUtility::makeInstance(TargetGroup::class);
         $targetGroup->setData(self::createBasicAuxiliaryData());
         self::setTargetGroupData($targetGroup, 'newTargetGroup_', $formData);

--- a/Classes/FrontEnd/EventHeadline.php
+++ b/Classes/FrontEnd/EventHeadline.php
@@ -68,9 +68,6 @@ class EventHeadline extends AbstractView
             return $result;
         }
 
-        /** @var DateRangeViewHelper $dateRangeViewHelper */
-        $dateRangeViewHelper = GeneralUtility::makeInstance(DateRangeViewHelper::class);
-
-        return $result . ', ' . $dateRangeViewHelper->render($event);
+        return $result . ', ' . GeneralUtility::makeInstance(DateRangeViewHelper::class)->render($event);
     }
 }

--- a/Classes/FrontEnd/EventPublication.php
+++ b/Classes/FrontEnd/EventPublication.php
@@ -51,7 +51,6 @@ class EventPublication extends TemplateHelper
             return $this->translate('message_publishingFailed');
         }
 
-        /** @var EventMapper $eventMapper */
         $eventMapper = GeneralUtility::makeInstance(EventMapper::class);
         /** @var Event|null $event */
         $event = $eventMapper->findByPublicationHash($this->piVars['hash']);

--- a/Classes/FrontEnd/RegistrationForm.php
+++ b/Classes/FrontEnd/RegistrationForm.php
@@ -380,13 +380,10 @@ class RegistrationForm extends AbstractEditor
             $userGroups->add($userGroup);
         }
 
-        /** @var Random $random */
         $random = GeneralUtility::makeInstance(Random::class);
-        /** @var Collection $additionalPersons */
         $additionalPersons = $registration->getAdditionalPersons();
         /** @var array $personData */
         foreach ($allPersonsData as $personData) {
-            /** @var FrontEndUser $user */
             $user = GeneralUtility::makeInstance(FrontEndUser::class);
             $user->setPageUid($pageUid);
             $user->setPassword($random->generateRandomHexString(8));
@@ -745,9 +742,8 @@ class RegistrationForm extends AbstractEditor
             return [];
         }
 
-        /** @var ConnectionPool $connectionPool */
-        $connectionPool = GeneralUtility::makeInstance(ConnectionPool::class);
-        $queryBuilder = $connectionPool->getQueryBuilderForTable('tx_seminars_payment_methods');
+        $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)
+            ->getQueryBuilderForTable('tx_seminars_payment_methods');
         $rows = $queryBuilder
             ->select('uid', 'title')
             ->from('tx_seminars_payment_methods')

--- a/Classes/FrontEnd/RegistrationsList.php
+++ b/Classes/FrontEnd/RegistrationsList.php
@@ -174,7 +174,6 @@ class RegistrationsList extends AbstractView
      */
     private function createRegistrationBagBuilder(): RegistrationBagBuilder
     {
-        /** @var RegistrationBagBuilder $builder */
         $builder = GeneralUtility::makeInstance(RegistrationBagBuilder::class);
         $builder->limitToEvent($this->seminar->getUid());
         $builder->limitToExistingUsers();

--- a/Classes/FrontEnd/RequirementsList.php
+++ b/Classes/FrontEnd/RequirementsList.php
@@ -77,9 +77,7 @@ class RequirementsList extends AbstractView
 
         if (!$this->linkBuilder instanceof SingleViewLinkBuilder) {
             $configuration = $this->getConfigurationWithFlexForms();
-            /** @var SingleViewLinkBuilder $linkBuilder */
-            $linkBuilder = GeneralUtility::makeInstance(SingleViewLinkBuilder::class, $configuration);
-            $this->injectLinkBuilder($linkBuilder);
+            $this->injectLinkBuilder(GeneralUtility::makeInstance(SingleViewLinkBuilder::class, $configuration));
         }
 
         $output = '';

--- a/Classes/FrontEnd/SelectorWidget.php
+++ b/Classes/FrontEnd/SelectorWidget.php
@@ -101,7 +101,6 @@ class SelectorWidget extends AbstractView
         );
 
         $this->instantiateStaticInfo();
-        /** @var EventBagBuilder $builder */
         $builder = GeneralUtility::makeInstance(EventBagBuilder::class);
         $builder->limitToEventTypes(
             GeneralUtility::intExplode(',', $this->getConfValueString('limitListViewToEventTypes', 's_listView'), true)
@@ -219,9 +218,8 @@ class SelectorWidget extends AbstractView
             return;
         }
 
-        /** @var ConnectionPool $connectionPool */
-        $connectionPool = GeneralUtility::makeInstance(ConnectionPool::class);
-        $queryBuilder = $connectionPool->getQueryBuilderForTable('tx_seminars_sites');
+        $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)
+            ->getQueryBuilderForTable('tx_seminars_sites');
         $eventUids = GeneralUtility::intExplode(',', $this->seminarBag->getUids());
         $eventUidsParameter = $queryBuilder->createNamedParameter($eventUids, Connection::PARAM_INT_ARRAY);
         $dataOfPlaces = $queryBuilder

--- a/Classes/Hooks/DataHandlerHook.php
+++ b/Classes/Hooks/DataHandlerHook.php
@@ -142,7 +142,6 @@ class DataHandlerHook
         $this->copyDatesFromTimeSlots($uid, $updatedData);
         $this->sanitizeEventDates($updatedData);
 
-        /** @var HookProvider $dataSanitizationHookProvider */
         $dataSanitizationHookProvider = GeneralUtility::makeInstance(HookProvider::class, DataSanitization::class);
         $updatedData = array_merge(
             $updatedData,

--- a/Classes/Model/Speaker.php
+++ b/Classes/Model/Speaker.php
@@ -324,16 +324,9 @@ class Speaker extends AbstractModel implements MailRole
             return null;
         }
 
-        $images = $this->getFileRepository()->findByRelation('tx_seminars_speakers', 'image', $this->getUid());
+        $images = GeneralUtility::makeInstance(FileRepository::class)
+            ->findByRelation('tx_seminars_speakers', 'image', $this->getUid());
 
         return \array_shift($images);
-    }
-
-    private function getFileRepository(): FileRepository
-    {
-        /** @var FileRepository $fileRepository */
-        $fileRepository = GeneralUtility::makeInstance(FileRepository::class);
-
-        return $fileRepository;
     }
 }

--- a/Classes/OldModel/AbstractModel.php
+++ b/Classes/OldModel/AbstractModel.php
@@ -64,7 +64,6 @@ abstract class AbstractModel
      */
     public static function fromData(array $data): AbstractModel
     {
-        /** @var static $model */
         $model = GeneralUtility::makeInstance(static::class);
         $model->setData($data);
 
@@ -428,9 +427,8 @@ abstract class AbstractModel
      */
     public function getRecordIcon(): string
     {
-        /** @var IconFactory $iconFactory */
-        $iconFactory = GeneralUtility::makeInstance(IconFactory::class);
-        return $iconFactory->getIconForRecord(static::$tableName, $this->recordData, Icon::SIZE_SMALL)->render();
+        return GeneralUtility::makeInstance(IconFactory::class)
+            ->getIconForRecord(static::$tableName, $this->recordData, Icon::SIZE_SMALL)->render();
     }
 
     /**
@@ -549,10 +547,7 @@ abstract class AbstractModel
 
     protected function getFileRepository(): FileRepository
     {
-        /** @var FileRepository $fileRepository */
-        $fileRepository = GeneralUtility::makeInstance(FileRepository::class);
-
-        return $fileRepository;
+        return GeneralUtility::makeInstance(FileRepository::class);
     }
 
     /**

--- a/Classes/OldModel/LegacyEvent.php
+++ b/Classes/OldModel/LegacyEvent.php
@@ -979,7 +979,6 @@ class LegacyEvent extends AbstractTimeSpan
      */
     public function formatPrice(string $value): string
     {
-        /** @var PriceViewHelper $priceViewHelper */
         $priceViewHelper = GeneralUtility::makeInstance(PriceViewHelper::class);
         $priceViewHelper
             ->setCurrencyFromIsoAlpha3Code(ConfigurationRegistry::get('plugin.tx_seminars')->getAsString('currency'));
@@ -1820,7 +1819,6 @@ class LegacyEvent extends AbstractTimeSpan
             throw new \BadMethodCallException('There are no organizers related to this event.', 1333291857);
         }
 
-        /** @var OrganizerBagBuilder $builder */
         $builder = GeneralUtility::makeInstance(OrganizerBagBuilder::class);
         $builder->limitToEvent($this->getUid());
         /** @var OrganizerBag $bag */
@@ -2007,7 +2005,6 @@ class LegacyEvent extends AbstractTimeSpan
         }
         $result = [];
 
-        /** @var OrganizerBag $organizerBag */
         $organizerBag = GeneralUtility::makeInstance(
             OrganizerBag::class,
             'tx_seminars_seminars_organizing_partners_mm.uid_local = ' . $this->getUid() . ' AND ' .
@@ -3443,10 +3440,7 @@ class LegacyEvent extends AbstractTimeSpan
             'tx_seminars_attendances.seminar' .
             ' AND tx_seminars_attendances.user = ' . $uid;
 
-        /** @var EventBag $blockingEvents */
-        $blockingEvents = GeneralUtility::makeInstance(EventBag::class, $queryWhere, $additionalTables);
-
-        return !$blockingEvents->isEmpty();
+        return !GeneralUtility::makeInstance(EventBag::class, $queryWhere, $additionalTables)->isEmpty();
     }
 
     private function getQueryForCollidingEvents(): string
@@ -3687,16 +3681,13 @@ class LegacyEvent extends AbstractTimeSpan
 
     public function getTimeSlots(): TimeSlotBag
     {
-        /** @var TimeSlotBag $timeSlotBag */
-        $timeSlotBag = GeneralUtility::makeInstance(
+        return GeneralUtility::makeInstance(
             TimeSlotBag::class,
             'tx_seminars_timeslots.seminar = ' . $this->getUid(),
             '',
             '',
             'tx_seminars_timeslots.begin_date ASC'
         );
-
-        return $timeSlotBag;
     }
 
     /**
@@ -3733,7 +3724,6 @@ class LegacyEvent extends AbstractTimeSpan
             return [];
         }
 
-        /** @var CategoryBagBuilder $builder */
         $builder = GeneralUtility::makeInstance(CategoryBagBuilder::class);
         $builder->limitToEvents((string)$this->getTopicOrSelfUid());
         $builder->sortByRelationOrder();
@@ -3833,7 +3823,6 @@ class LegacyEvent extends AbstractTimeSpan
      */
     public function getRequirements(): EventBag
     {
-        /** @var EventBagBuilder $builder */
         $builder = GeneralUtility::makeInstance(EventBagBuilder::class);
         $builder->limitToRequiredEventTopics($this->getTopicOrSelfUid());
         /** @var EventBag $bag */
@@ -3851,7 +3840,6 @@ class LegacyEvent extends AbstractTimeSpan
      */
     public function getDependencies(): EventBag
     {
-        /** @var EventBagBuilder $builder */
         $builder = GeneralUtility::makeInstance(EventBagBuilder::class);
         $builder->limitToDependingEventTopics($this->getTopicOrSelfUid());
         /** @var EventBag $bag */
@@ -4040,11 +4028,7 @@ class LegacyEvent extends AbstractTimeSpan
             return $emptyPlaces;
         }
 
-        $places = $this->getPlacesAsArray();
-
-        /** @var PlaceMapper $mapper */
-        $mapper = GeneralUtility::makeInstance(PlaceMapper::class);
-        return $mapper->getListOfModels($places);
+        return GeneralUtility::makeInstance(PlaceMapper::class)->getListOfModels($this->getPlacesAsArray());
     }
 
     /**

--- a/Classes/OldModel/LegacyRegistration.php
+++ b/Classes/OldModel/LegacyRegistration.php
@@ -114,19 +114,10 @@ class LegacyRegistration extends AbstractModel
         self::$cachedSeminars = [];
     }
 
-    protected function getObjectManager(): ObjectManager
-    {
-        /** @var ObjectManager $objectManager */
-        $objectManager = GeneralUtility::makeInstance(ObjectManager::class);
-
-        return $objectManager;
-    }
-
     protected function getFrontEndUserGroupRepository(): FrontendUserGroupRepository
     {
         if (!$this->frontEndUserGroupRepository instanceof FrontendUserGroupRepository) {
-            /** @var FrontendUserGroupRepository $repository */
-            $repository = $this->getObjectManager()->get(FrontendUserGroupRepository::class);
+            $repository = GeneralUtility::makeInstance(ObjectManager::class)->get(FrontendUserGroupRepository::class);
             $this->frontEndUserGroupRepository = $repository;
         }
 
@@ -176,9 +167,8 @@ class LegacyRegistration extends AbstractModel
         // selected, there actually is anything to pay and only one payment
         // method is provided.
         if (!$methodOfPayment && $this->recordData['total_price'] > 0.00 && $event->getNumberOfPaymentMethods() === 1) {
-            /** @var ConnectionPool $connectionPool */
-            $connectionPool = GeneralUtility::makeInstance(ConnectionPool::class);
-            $queryBuilder = $connectionPool->getQueryBuilderForTable('tx_seminars_payment_methods');
+            $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)
+                ->getQueryBuilderForTable('tx_seminars_payment_methods');
             $rows = $queryBuilder
                 ->select('uid')
                 ->from('tx_seminars_payment_methods')
@@ -1102,9 +1092,8 @@ class LegacyRegistration extends AbstractModel
             $this->createMmRecords('tx_seminars_attendances_checkboxes_mm', $this->checkboxes);
         }
 
-        /** @var ReferenceIndex $referenceIndex */
-        $referenceIndex = GeneralUtility::makeInstance(ReferenceIndex::class);
-        $referenceIndex->updateRefIndexTable('tx_seminars_attendances', $this->getUid());
+        GeneralUtility::makeInstance(ReferenceIndex::class)
+            ->updateRefIndexTable('tx_seminars_attendances', $this->getUid());
 
         return true;
     }

--- a/Classes/OldModel/LegacyTimeSlot.php
+++ b/Classes/OldModel/LegacyTimeSlot.php
@@ -22,16 +22,13 @@ class LegacyTimeSlot extends AbstractTimeSpan
      */
     private function getSpeakerBag(): SpeakerBag
     {
-        /** @var SpeakerBag $bag */
-        $bag = GeneralUtility::makeInstance(
+        return GeneralUtility::makeInstance(
             SpeakerBag::class,
             'tx_seminars_timeslots_speakers_mm.uid_local = ' . $this->getUid() . ' AND uid = uid_foreign',
             'tx_seminars_timeslots_speakers_mm',
             '',
             'sorting'
         );
-
-        return $bag;
     }
 
     /**

--- a/Classes/SchedulerTasks/MailNotifier.php
+++ b/Classes/SchedulerTasks/MailNotifier.php
@@ -75,9 +75,7 @@ class MailNotifier extends AbstractTask
         $this->eventStatusService = GeneralUtility::makeInstance(EventStatusService::class);
         $this->emailService = GeneralUtility::makeInstance(EmailService::class);
         $this->eventMapper = MapperRegistry::get(EventMapper::class);
-        /** @var ObjectManager $objectManager */
-        $objectManager = GeneralUtility::makeInstance(ObjectManager::class);
-        $this->registrationDigest = $objectManager->get(RegistrationDigest::class);
+        $this->registrationDigest = GeneralUtility::makeInstance(ObjectManager::class)->get(RegistrationDigest::class);
 
         $this->useUserConfiguredLanguage();
         $this->getLanguageService()->includeLLFile('EXT:seminars/Resources/Private/Language/locallang.xlf');
@@ -276,7 +274,6 @@ class MailNotifier extends AbstractTask
      */
     private function getSeminarBagBuilder(int $status): EventBagBuilder
     {
-        /** @var EventBagBuilder $builder */
         $builder = GeneralUtility::makeInstance(EventBagBuilder::class);
         $builder->setTimeFrame('upcomingWithBeginDate');
         $builder->limitToStatus($status);

--- a/Classes/SchedulerTasks/MailNotifierConfiguration.php
+++ b/Classes/SchedulerTasks/MailNotifierConfiguration.php
@@ -61,7 +61,6 @@ class MailNotifierConfiguration extends AbstractAdditionalFieldProvider
         $pageUid = (int)$submittedData['seminars_configurationPageUid'];
         $submittedData['seminars_configurationPageUid'] = $pageUid;
 
-        /** @var \TYPO3\CMS\Core\Database\Connection $connection */
         $connection = GeneralUtility::makeInstance(ConnectionPool::class)->getConnectionForTable('pages');
         $pageWithUidExist = $connection->count('*', 'pages', ['uid' => $pageUid]) > 0;
         $hasPageUid = $pageUid > 0 && $pageWithUidExist;

--- a/Classes/Service/RegistrationManager.php
+++ b/Classes/Service/RegistrationManager.php
@@ -97,7 +97,6 @@ class RegistrationManager
     public static function getInstance(): RegistrationManager
     {
         if (!self::$instance instanceof static) {
-            /** @var static $instance */
             $instance = GeneralUtility::makeInstance(static::class);
             self::$instance = $instance;
         }
@@ -617,7 +616,6 @@ class RegistrationManager
 
         $vacancies = $seminar->getVacancies();
 
-        /** @var RegistrationBagBuilder $registrationBagBuilder */
         $registrationBagBuilder = GeneralUtility::makeInstance(RegistrationBagBuilder::class);
         $registrationBagBuilder->limitToEvent($seminar->getUid());
         $registrationBagBuilder->limitToOnQueue();
@@ -674,7 +672,6 @@ class RegistrationManager
      */
     public function getMissingRequiredTopics(LegacyEvent $event): EventBag
     {
-        /** @var EventBagBuilder $builder */
         $builder = GeneralUtility::makeInstance(EventBagBuilder::class);
         $builder->limitToRequiredEventTopics($event->getTopicOrSelfUid());
         $builder->limitToTopicsWithoutRegistrationByUser($this->getLoggedInFrontEndUserUid());
@@ -1051,9 +1048,7 @@ class RegistrationManager
     ): string {
         if (!$this->linkBuilder instanceof SingleViewLinkBuilder) {
             $configuration = $this->buildConfigurationWithFlexforms($plugin);
-            /** @var SingleViewLinkBuilder $linkBuilder */
-            $linkBuilder = GeneralUtility::makeInstance(SingleViewLinkBuilder::class, $configuration);
-            $this->injectLinkBuilder($linkBuilder);
+            $this->injectLinkBuilder(GeneralUtility::makeInstance(SingleViewLinkBuilder::class, $configuration));
         }
 
         $wrapperPrefix = ($useHtml ? 'html_' : '') . 'field_wrapper';
@@ -1362,7 +1357,6 @@ class RegistrationManager
         LegacyRegistration $registration
     ): void {
         $template = $this->getInitializedEmailTemplate();
-        /** @var Salutation $salutation */
         $salutation = GeneralUtility::makeInstance(Salutation::class);
         $user = $registration->getFrontEndUser();
         if ($user instanceof FrontEndUser) {
@@ -1445,8 +1439,8 @@ class RegistrationManager
     protected function getRegistrationEmailHookProvider(): HookProvider
     {
         if (!$this->registrationEmailHookProvider instanceof HookProvider) {
-            $this->registrationEmailHookProvider =
-                GeneralUtility::makeInstance(HookProvider::class, RegistrationEmail::class);
+            $this->registrationEmailHookProvider
+                = GeneralUtility::makeInstance(HookProvider::class, RegistrationEmail::class);
         }
 
         return $this->registrationEmailHookProvider;
@@ -1505,10 +1499,7 @@ class RegistrationManager
 
     private function getConnectionForTable(string $table): Connection
     {
-        /** @var ConnectionPool $connectionPool */
-        $connectionPool = GeneralUtility::makeInstance(ConnectionPool::class);
-
-        return $connectionPool->getConnectionForTable($table);
+        return GeneralUtility::makeInstance(ConnectionPool::class)->getConnectionForTable($table);
     }
 
     /**

--- a/Tests/Functional/SchedulerTasks/MailNotifierConfigurationTest.php
+++ b/Tests/Functional/SchedulerTasks/MailNotifierConfigurationTest.php
@@ -66,10 +66,7 @@ final class MailNotifierConfigurationTest extends FunctionalTestCase
 
     private function getFlashMessageQueue(): FlashMessageQueue
     {
-        /** @var FlashMessageService $service */
-        $service = GeneralUtility::makeInstance(FlashMessageService::class);
-
-        return $service->getMessageQueueByIdentifier();
+        return GeneralUtility::makeInstance(FlashMessageService::class)->getMessageQueueByIdentifier();
     }
 
     /**

--- a/Tests/Functional/SchedulerTasks/RegistrationDigestTest.php
+++ b/Tests/Functional/SchedulerTasks/RegistrationDigestTest.php
@@ -28,9 +28,7 @@ final class RegistrationDigestTest extends FunctionalTestCase
      */
     public function objectManagerInitializesObject(): void
     {
-        /** @var ObjectManager $objectManager */
-        $objectManager = GeneralUtility::makeInstance(ObjectManager::class);
-        $subject = $objectManager->get(RegistrationDigest::class);
+        $subject = GeneralUtility::makeInstance(ObjectManager::class)->get(RegistrationDigest::class);
 
         self::assertTrue($subject->isInitialized());
     }

--- a/Tests/LegacyUnit/FrontEnd/EventPublicationTest.php
+++ b/Tests/LegacyUnit/FrontEnd/EventPublicationTest.php
@@ -167,8 +167,6 @@ final class EventPublicationTest extends TestCase
 
     private function getConnectionForTable(string $table): Connection
     {
-        /** @var ConnectionPool $connectionPool */
-        $connectionPool = GeneralUtility::makeInstance(ConnectionPool::class);
-        return $connectionPool->getConnectionForTable($table);
+        return GeneralUtility::makeInstance(ConnectionPool::class)->getConnectionForTable($table);
     }
 }

--- a/Tests/LegacyUnit/FrontEnd/RegistrationsListTest.php
+++ b/Tests/LegacyUnit/FrontEnd/RegistrationsListTest.php
@@ -138,10 +138,8 @@ final class RegistrationsListTest extends TestCase
     public function createLogInAndRegisterFrontEndUserCreatesRegistrationRecord(): void
     {
         $this->createLogInAndRegisterFrontEndUser();
-        /** @var ConnectionPool $connectionPool */
-        $connectionPool = GeneralUtility::makeInstance(ConnectionPool::class);
-
-        $connection = $connectionPool->getConnectionForTable('tx_seminars_attendances');
+        $connection = GeneralUtility::makeInstance(ConnectionPool::class)
+            ->getConnectionForTable('tx_seminars_attendances');
 
         self::assertSame(
             1,

--- a/Tests/LegacyUnit/OldModel/LegacyTimeSlotTest.php
+++ b/Tests/LegacyUnit/OldModel/LegacyTimeSlotTest.php
@@ -170,9 +170,8 @@ final class LegacyTimeSlotTest extends TestCase
     {
         $placeUid = $this->testingFramework->createRecord('tx_seminars_sites');
         $this->subject->setPlace($placeUid);
-        /** @var ConnectionPool $connectionPool */
-        $connectionPool = GeneralUtility::makeInstance(ConnectionPool::class);
-        $connection = $connectionPool->getConnectionForTable('tx_seminars_attendances');
+        $connection = GeneralUtility::makeInstance(ConnectionPool::class)
+            ->getConnectionForTable('tx_seminars_attendances');
         $connection->delete('tx_seminars_sites', ['uid' => $placeUid]);
 
         self::assertSame('', $this->subject->getPlaceShort());

--- a/Tests/LegacyUnit/SchedulerTasks/MailNotifierTest.php
+++ b/Tests/LegacyUnit/SchedulerTasks/MailNotifierTest.php
@@ -1740,8 +1740,6 @@ final class MailNotifierTest extends TestCase
 
     private function getConnectionForTable(string $table): Connection
     {
-        /** @var ConnectionPool $connectionPool */
-        $connectionPool = GeneralUtility::makeInstance(ConnectionPool::class);
-        return $connectionPool->getConnectionForTable($table);
+        return GeneralUtility::makeInstance(ConnectionPool::class)->getConnectionForTable($table);
     }
 }

--- a/Tests/LegacyUnit/Service/RegistrationManagerTest.php
+++ b/Tests/LegacyUnit/Service/RegistrationManagerTest.php
@@ -7295,10 +7295,7 @@ final class RegistrationManagerTest extends TestCase
 
     private function getConnectionPool(): ConnectionPool
     {
-        /** @var ConnectionPool $connectionPool */
-        $connectionPool = GeneralUtility::makeInstance(ConnectionPool::class);
-
-        return $connectionPool;
+        return GeneralUtility::makeInstance(ConnectionPool::class);
     }
 
     private function getConnectionForTable(string $table): Connection

--- a/Tests/LegacyUnit/Support/Traits/BackEndTestsTrait.php
+++ b/Tests/LegacyUnit/Support/Traits/BackEndTestsTrait.php
@@ -157,9 +157,8 @@ trait BackEndTestsTrait
      */
     private function flushAllFlashMessages(): void
     {
-        /** @var FlashMessageService $flashMessageService */
-        $flashMessageService = GeneralUtility::makeInstance(FlashMessageService::class);
-        $defaultFlashMessageQueue = $flashMessageService->getMessageQueueByIdentifier();
+        $defaultFlashMessageQueue = GeneralUtility::makeInstance(FlashMessageService::class)
+            ->getMessageQueueByIdentifier();
         $defaultFlashMessageQueue->getAllMessagesAndFlush();
     }
 


### PR DESCRIPTION
…get`

Nowadays, PHPStan can derive the type of the created class using the
power of gererics.

Fixes #1370