### PR TITLE
[BUGFIX] Bump the minimal 10.4 Extbase requirement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Removed
 
 ### Fixed
+- Bump the minimal 10.4 Extbase requirement (#1445)
 - Only show the configuration check with a logged-in BE admin (#1427)
 - Do not rely on transitive Composer dependencies (#1426)
 - Fix a flaky test (#1403, #1408)

--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
 		"symfony/mime": "^4.4 || ^5.2 || ^6.0",
 		"typo3/cms-backend": "^9.5 || ^10.4",
 		"typo3/cms-core": "^9.5.7 || ^10.4.6",
-		"typo3/cms-extbase": "^9.5 || ^10.4",
+		"typo3/cms-extbase": "^9.5 || ^10.4.6",
 		"typo3/cms-fluid": "^9.5 || ^10.4",
 		"typo3/cms-frontend": "^9.5 || ^10.4",
 		"typo3fluid/fluid": "^2.6.10"


### PR DESCRIPTION
Extbase < 10.4.6 has a bug that causes it to stumble over PHPDoc
annotations in the repository.