### PR TITLE
[FEATURE] Show the Composer configuration in the CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,10 @@ jobs:
           php-version: "${{ matrix.php-version }}"
           tools: composer:v2
           coverage: none
+      - name: "Show Composer version"
+        run: composer --version
+      - name: "Show the Composer configuration"
+        run: composer config --global --list
       - name: "Run PHP lint"
         run: "composer ci:php:lint"
     strategy:
@@ -47,6 +51,8 @@ jobs:
           coverage: none
       - name: "Show Composer version"
         run: composer --version
+      - name: "Show the Composer configuration"
+        run: composer config --global --list
       - name: "Cache dependencies installed with composer"
         uses: actions/cache@v3
         with:
@@ -85,6 +91,8 @@ jobs:
           coverage: none
       - name: "Show Composer version"
         run: composer --version
+      - name: "Show the Composer configuration"
+        run: composer config --global --list
       - name: "Cache dependencies installed with composer"
         uses: actions/cache@v3
         with:
@@ -167,6 +175,8 @@ jobs:
           coverage: none
       - name: "Show Composer version"
         run: composer --version
+      - name: "Show the Composer configuration"
+        run: composer config --global --list
       - name: "Cache dependencies installed with composer"
         uses: actions/cache@v3
         with:
@@ -270,6 +280,8 @@ jobs:
           coverage: none
       - name: "Show Composer version"
         run: composer --version
+      - name: "Show the Composer configuration"
+        run: composer config --global --list
       - name: "Cache dependencies installed with composer"
         uses: actions/cache@v3
         with:

--- a/.github/workflows/codecoverage.yml
+++ b/.github/workflows/codecoverage.yml
@@ -35,6 +35,8 @@ jobs:
           tools: composer:v1, phive
       - name: "Show Composer version"
         run: composer --version
+      - name: "Show the Composer configuration"
+        run: composer config --global --list
       - name: "Cache dependencies installed with composer"
         uses: actions/cache@v3
         with:


### PR DESCRIPTION
This helps debug problems, e.g., using an incorrect Composer cache directory.