### PR TITLE
[BUGFIX] Always create the tests directory on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,6 +201,8 @@ jobs:
           composer show
       - name: "Start MySQL"
         run: "sudo /etc/init.d/mysql start"
+      - name: "Create the tests directory"
+        run: "mkdir -p .Build/public/typo3temp/var/tests"
       - name: "Run functional tests"
         run: |
           export typo3DatabaseName="typo3";

--- a/.github/workflows/codecoverage.yml
+++ b/.github/workflows/codecoverage.yml
@@ -69,6 +69,8 @@ jobs:
           --database-user-name="${DATABASE_USER}" --database-host-name="${DATABASE_HOST}"
           --database-port="${{ job.services.mysql.ports[3306] }}" --database-name="${DATABASE_NAME}"
           --admin-user-name="admin" --admin-password="password" --site-name="Test installation";
+      - name: "Create the tests directory"
+        run: "mkdir -p .Build/public/typo3temp/var/tests"
       - name: "Run unit tests with coverage"
         run: composer ci:coverage:unit
       - name: "Run legacy tests with coverage"


### PR DESCRIPTION
Usually the testing framework automatically does this, but there seems to be a race condition resulting in the directory not getting consistently created.