### PR TITLE
[BUGFIX] Provide the `NullRenderingContext` with a request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Removed
 
 ### Fixed
+- 11LTS compatibility fixes (#1526)
 - Fix type warnings for `str_replace` in the `MailNotifier` (#1524)
 
 ## 4.1.6

--- a/Classes/Rendering/NullRenderingContext.php
+++ b/Classes/Rendering/NullRenderingContext.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace OliverKlee\Seminars\Rendering;
 
+use Psr\Http\Message\ServerRequestInterface;
 use TYPO3Fluid\Fluid\Core\Cache\FluidCacheInterface;
 use TYPO3Fluid\Fluid\Core\Compiler\TemplateCompiler;
 use TYPO3Fluid\Fluid\Core\ErrorHandler\ErrorHandlerInterface;
@@ -20,7 +21,7 @@ use TYPO3Fluid\Fluid\View\TemplatePaths;
  *
  * Its methods are not intended to get called.
  */
-class NullRenderingContext implements RenderingContextInterface
+final class NullRenderingContext implements RenderingContextInterface
 {
     /**
      * @return never
@@ -198,5 +199,10 @@ class NullRenderingContext implements RenderingContextInterface
      */
     public function setControllerAction($action): void
     {
+    }
+
+    public function getRequest(): ServerRequestInterface
+    {
+        return new NullRequest();
     }
 }

--- a/Classes/Rendering/NullRequest.php
+++ b/Classes/Rendering/NullRequest.php
@@ -1,0 +1,174 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OliverKlee\Seminars\Rendering;
+
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\StreamInterface;
+use Psr\Http\Message\UriInterface;
+use TYPO3\CMS\Core\Core\SystemEnvironmentBuilder;
+use TYPO3\CMS\Core\Http\Uri;
+
+/**
+ * Dummy request to be used with `HtmlViewHelper`.
+ */
+final class NullRequest implements ServerRequestInterface
+{
+    public function getServerParams(): array
+    {
+        return [];
+    }
+
+    public function getCookieParams(): array
+    {
+        return [];
+    }
+
+    public function withCookieParams(array $cookies): self
+    {
+        return new self();
+    }
+
+    public function getQueryParams(): array
+    {
+        return [];
+    }
+
+    public function withQueryParams(array $query): self
+    {
+        return new self();
+    }
+
+    public function getUploadedFiles(): array
+    {
+        return [];
+    }
+
+    public function withUploadedFiles(array $uploadedFiles): self
+    {
+        return new NullRequest();
+    }
+
+    public function getParsedBody()
+    {
+        return null;
+    }
+
+    public function withParsedBody($data): self
+    {
+        return new NullRequest();
+    }
+
+    public function getAttribute($name, $default = null)
+    {
+        if ($name === 'applicationType') {
+            return SystemEnvironmentBuilder::REQUESTTYPE_BE;
+        }
+
+        return '';
+    }
+
+    public function getAttributes(): array
+    {
+        return [];
+    }
+
+    public function withAttribute($name, $value): self
+    {
+        return new NullRequest();
+    }
+
+    public function withoutAttribute($name): self
+    {
+        return new NullRequest();
+    }
+
+    public function getRequestTarget(): string
+    {
+        return '';
+    }
+
+    public function withRequestTarget($requestTarget): self
+    {
+        return new NullRequest();
+    }
+
+    public function getMethod(): string
+    {
+        return '';
+    }
+
+    public function withMethod($method): self
+    {
+        return new NullRequest();
+    }
+
+    public function getUri(): UriInterface
+    {
+        return new Uri('');
+    }
+
+    public function withUri(UriInterface $uri, $preserveHost = false): self
+    {
+        return new NullRequest();
+    }
+
+    public function getProtocolVersion(): string
+    {
+        return '';
+    }
+
+    public function withProtocolVersion($version): self
+    {
+        return new NullRequest();
+    }
+
+    public function getHeaders(): array
+    {
+        return [];
+    }
+
+    public function hasHeader($name): bool
+    {
+        return false;
+    }
+
+    public function getHeader($name): array
+    {
+        return [];
+    }
+
+    public function getHeaderLine($name): string
+    {
+        return '';
+    }
+
+    public function withHeader($name, $value): self
+    {
+        return new NullRequest();
+    }
+
+    public function withAddedHeader($name, $value)
+    {
+        return new NullRequest();
+    }
+
+    public function withoutHeader($name): self
+    {
+        return new NullRequest();
+    }
+
+    /**
+     * @return never
+     */
+    public function getBody(): StreamInterface
+    {
+        throw new \BadMethodCallException('Not implemented.', 1664435982);
+    }
+
+    public function withBody(StreamInterface $body): self
+    {
+        return new NullRequest();
+    }
+}

--- a/Tests/Unit/Rendering/NullRenderingContextTest.php
+++ b/Tests/Unit/Rendering/NullRenderingContextTest.php
@@ -6,6 +6,7 @@ namespace OliverKlee\Seminars\Tests\Unit\Rendering;
 
 use Nimut\TestingFramework\TestCase\UnitTestCase;
 use OliverKlee\Seminars\Rendering\NullRenderingContext;
+use OliverKlee\Seminars\Rendering\NullRequest;
 use TYPO3Fluid\Fluid\Core\Cache\FluidCacheInterface;
 use TYPO3Fluid\Fluid\Core\Compiler\TemplateCompiler;
 use TYPO3Fluid\Fluid\Core\ErrorHandler\ErrorHandlerInterface;
@@ -331,5 +332,13 @@ final class NullRenderingContextTest extends UnitTestCase
     public function setControllerActionCanBeCalled(): void
     {
         $this->subject->setControllerAction('');
+    }
+
+    /**
+     * @test
+     */
+    public function getRequestReturnsNullRequest(): void
+    {
+        self::assertInstanceOf(NullRequest::class, $this->subject->getRequest());
     }
 }

--- a/Tests/Unit/Rendering/NullRequestTest.php
+++ b/Tests/Unit/Rendering/NullRequestTest.php
@@ -1,0 +1,437 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OliverKlee\Seminars\Tests\Unit\Rendering;
+
+use Nimut\TestingFramework\TestCase\UnitTestCase;
+use OliverKlee\Seminars\Rendering\NullRequest;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\StreamInterface;
+use Psr\Http\Message\UriInterface;
+use TYPO3\CMS\Core\Core\SystemEnvironmentBuilder;
+use TYPO3\CMS\Core\Http\Uri;
+
+/**
+ * @covers \OliverKlee\Seminars\Rendering\NullRequest
+ */
+final class NullRequestTest extends UnitTestCase
+{
+    /**
+     * @var NullRequest
+     */
+    protected $subject;
+
+    protected function setUp(): void
+    {
+        $this->subject = new NullRequest();
+    }
+
+    /**
+     * @test
+     */
+    public function implementsServerRequestInterface(): void
+    {
+        self::assertInstanceOf(ServerRequestInterface::class, $this->subject);
+    }
+
+    /**
+     * @test
+     */
+    public function getServerParamsReturnsEmptyArray(): void
+    {
+        $result = $this->subject->getServerParams();
+
+        self::assertSame([], $result);
+    }
+
+    /**
+     * @test
+     */
+    public function getCookieParamsReturnsEmptyArray(): void
+    {
+        $result = $this->subject->getCookieParams();
+
+        self::assertSame([], $result);
+    }
+
+    /**
+     * @test
+     */
+    public function withCookieParamsReturnsInstanceOfSameClass(): void
+    {
+        self::assertInstanceOf(NullRequest::class, $this->subject->withCookieParams([]));
+    }
+
+    /**
+     * @test
+     */
+    public function withCookieParamsReturnsNewInstance(): void
+    {
+        self::assertNotSame($this->subject, $this->subject->withCookieParams([]));
+    }
+
+    /**
+     * @test
+     */
+    public function getQueryParamsReturnsEmptyArray(): void
+    {
+        $result = $this->subject->getQueryParams();
+
+        self::assertSame([], $result);
+    }
+
+    /**
+     * @test
+     */
+    public function withQueryParamsReturnsInstanceOfSameClass(): void
+    {
+        self::assertInstanceOf(NullRequest::class, $this->subject->withQueryParams([]));
+    }
+
+    /**
+     * @test
+     */
+    public function withQueryParamsReturnsNewInstance(): void
+    {
+        self::assertNotSame($this->subject, $this->subject->withQueryParams([]));
+    }
+
+    /**
+     * @test
+     */
+    public function getUploadedFilesReturnsEmptyArray(): void
+    {
+        $result = $this->subject->getUploadedFiles();
+
+        self::assertSame([], $result);
+    }
+
+    /**
+     * @test
+     */
+    public function withUploadedFilesReturnsInstanceOfSameClass(): void
+    {
+        self::assertInstanceOf(NullRequest::class, $this->subject->withUploadedFiles([]));
+    }
+
+    /**
+     * @test
+     */
+    public function withUploadedFilesReturnsNewInstance(): void
+    {
+        self::assertNotSame($this->subject, $this->subject->withUploadedFiles([]));
+    }
+
+    /**
+     * @test
+     */
+    public function getParsedBodyReturnsNull(): void
+    {
+        $result = $this->subject->getParsedBody();
+
+        self::assertNull($result);
+    }
+
+    /**
+     * @test
+     */
+    public function withParsedBodyReturnsInstanceOfSameClass(): void
+    {
+        self::assertInstanceOf(NullRequest::class, $this->subject->withParsedBody(null));
+    }
+
+    /**
+     * @test
+     */
+    public function withParsedBodyReturnsNewInstance(): void
+    {
+        self::assertNotSame($this->subject, $this->subject->withParsedBody(null));
+    }
+
+    /**
+     * @test
+     */
+    public function getAttributeWithEmptyStringReturnsEmptyString(): void
+    {
+        $result = $this->subject->getAttribute('');
+
+        self::assertSame('', $result);
+    }
+
+    /**
+     * @test
+     */
+    public function getAttributeWithApplicationTypeReturnsBackendRequestType(): void
+    {
+        $result = $this->subject->getAttribute('applicationType');
+
+        self::assertSame(SystemEnvironmentBuilder::REQUESTTYPE_BE, $result);
+    }
+
+    /**
+     * @test
+     */
+    public function getAttributesReturnsEmptyArray(): void
+    {
+        $result = $this->subject->getAttributes();
+
+        self::assertSame([], $result);
+    }
+
+    /**
+     * @test
+     */
+    public function withAttributeReturnsInstanceOfSameClass(): void
+    {
+        self::assertInstanceOf(NullRequest::class, $this->subject->withAttribute('foo', 'bar'));
+    }
+
+    /**
+     * @test
+     */
+    public function withAttributeReturnsNewInstance(): void
+    {
+        self::assertNotSame($this->subject, $this->subject->withAttribute('foo', 'bar'));
+    }
+
+    /**
+     * @test
+     */
+    public function withoutAttributeReturnsInstanceOfSameClass(): void
+    {
+        self::assertInstanceOf(NullRequest::class, $this->subject->withoutAttribute('foo'));
+    }
+
+    /**
+     * @test
+     */
+    public function withoutAttributeReturnsNewInstance(): void
+    {
+        self::assertNotSame($this->subject, $this->subject->withoutAttribute('foo'));
+    }
+
+    /**
+     * @test
+     */
+    public function getRequestTargetReturnsEmptyString(): void
+    {
+        $result = $this->subject->getRequestTarget();
+
+        self::assertSame('', $result);
+    }
+
+    /**
+     * @test
+     */
+    public function withRequestTargetReturnsInstanceOfSameClass(): void
+    {
+        self::assertInstanceOf(NullRequest::class, $this->subject->withRequestTarget(''));
+    }
+
+    /**
+     * @test
+     */
+    public function withRequestTargetReturnsNewInstance(): void
+    {
+        self::assertNotSame($this->subject, $this->subject->withRequestTarget(''));
+    }
+
+    /**
+     * @test
+     */
+    public function getMethodReturnsEmptyString(): void
+    {
+        $result = $this->subject->getMethod();
+
+        self::assertSame('', $result);
+    }
+
+    /**
+     * @test
+     */
+    public function withMethodReturnsInstanceOfSameClass(): void
+    {
+        self::assertInstanceOf(NullRequest::class, $this->subject->withMethod(''));
+    }
+
+    /**
+     * @test
+     */
+    public function withMethodReturnsNewInstance(): void
+    {
+        self::assertNotSame($this->subject, $this->subject->withMethod(''));
+    }
+
+    /**
+     * @test
+     */
+    public function getUriReturnsUri(): void
+    {
+        $result = $this->subject->getUri();
+
+        self::assertInstanceOf(UriInterface::class, $result);
+    }
+
+    /**
+     * @test
+     */
+    public function withUriReturnsInstanceOfSameClass(): void
+    {
+        self::assertInstanceOf(NullRequest::class, $this->subject->withUri(new Uri('')));
+    }
+
+    /**
+     * @test
+     */
+    public function withUriReturnsNewInstance(): void
+    {
+        self::assertNotSame($this->subject, $this->subject->withUri(new Uri('')));
+    }
+
+    /**
+     * @test
+     */
+    public function getProtocolVersionReturnsEmptyString(): void
+    {
+        $result = $this->subject->getProtocolVersion();
+
+        self::assertSame('', $result);
+    }
+
+    /**
+     * @test
+     */
+    public function withProtocolVersionReturnsInstanceOfSameClass(): void
+    {
+        self::assertInstanceOf(NullRequest::class, $this->subject->withProtocolVersion(''));
+    }
+
+    /**
+     * @test
+     */
+    public function withProtocolVersionReturnsNewInstance(): void
+    {
+        self::assertNotSame($this->subject, $this->subject->withProtocolVersion(''));
+    }
+
+    /**
+     * @test
+     */
+    public function getHeadersReturnsEmptyArray(): void
+    {
+        $result = $this->subject->getHeaders();
+
+        self::assertSame([], $result);
+    }
+
+    /**
+     * @test
+     */
+    public function hasHeaderReturnsFalse(): void
+    {
+        $result = $this->subject->hasHeader('foo');
+
+        self::assertFalse($result);
+    }
+
+    /**
+     * @test
+     */
+    public function getHeaderReturnsEmptyArray(): void
+    {
+        $result = $this->subject->getHeader('foo');
+
+        self::assertSame([], $result);
+    }
+
+    /**
+     * @test
+     */
+    public function getHeaderLineReturnsEmptyString(): void
+    {
+        $result = $this->subject->getHeaderLine('foo');
+
+        self::assertSame('', $result);
+    }
+
+    /**
+     * @test
+     */
+    public function withHeaderReturnsInstanceOfSameClass(): void
+    {
+        self::assertInstanceOf(NullRequest::class, $this->subject->withHeader('foo', ''));
+    }
+
+    /**
+     * @test
+     */
+    public function withHeaderReturnsNewInstance(): void
+    {
+        self::assertNotSame($this->subject, $this->subject->withHeader('foo', ''));
+    }
+
+    /**
+     * @test
+     */
+    public function withAddedHeaderReturnsInstanceOfSameClass(): void
+    {
+        self::assertInstanceOf(NullRequest::class, $this->subject->withAddedHeader('foo', ''));
+    }
+
+    /**
+     * @test
+     */
+    public function withAddedHeaderReturnsNewInstance(): void
+    {
+        self::assertNotSame($this->subject, $this->subject->withAddedHeader('foo', ''));
+    }
+
+    /**
+     * @test
+     */
+    public function withoutHeaderReturnsInstanceOfSameClass(): void
+    {
+        self::assertInstanceOf(NullRequest::class, $this->subject->withoutHeader('foo'));
+    }
+
+    /**
+     * @test
+     */
+    public function withoutHeaderReturnsNewInstance(): void
+    {
+        self::assertNotSame($this->subject, $this->subject->withoutHeader('foo'));
+    }
+
+    /**
+     * @test
+     */
+    public function getBodyMustNotBeCalled(): void
+    {
+        $this->expectException(\BadMethodCallException::class);
+        $this->expectExceptionMessage('Not implemented.');
+        $this->expectExceptionCode(1664435982);
+
+        $this->subject->getBody();
+    }
+
+    /**
+     * @test
+     */
+    public function withBodyReturnsInstanceOfSameClass(): void
+    {
+        $body = $this->prophesize(StreamInterface::class)->reveal();
+
+        self::assertInstanceOf(NullRequest::class, $this->subject->withBody($body));
+    }
+
+    /**
+     * @test
+     */
+    public function withBodyReturnsNewInstance(): void
+    {
+        $body = $this->prophesize(StreamInterface::class)->reveal();
+
+        self::assertNotSame($this->subject, $this->subject->withBody($body));
+    }
+}

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -836,6 +836,56 @@ parameters:
 			path: Classes/Rendering/NullRenderingContext.php
 
 		-
+			message: "#^Method OliverKlee\\\\Seminars\\\\Rendering\\\\NullRequest\\:\\:getAttributes\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: Classes/Rendering/NullRequest.php
+
+		-
+			message: "#^Method OliverKlee\\\\Seminars\\\\Rendering\\\\NullRequest\\:\\:getCookieParams\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: Classes/Rendering/NullRequest.php
+
+		-
+			message: "#^Method OliverKlee\\\\Seminars\\\\Rendering\\\\NullRequest\\:\\:getParsedBody\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: Classes/Rendering/NullRequest.php
+
+		-
+			message: "#^Method OliverKlee\\\\Seminars\\\\Rendering\\\\NullRequest\\:\\:getQueryParams\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: Classes/Rendering/NullRequest.php
+
+		-
+			message: "#^Method OliverKlee\\\\Seminars\\\\Rendering\\\\NullRequest\\:\\:getServerParams\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: Classes/Rendering/NullRequest.php
+
+		-
+			message: "#^Method OliverKlee\\\\Seminars\\\\Rendering\\\\NullRequest\\:\\:getUploadedFiles\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: Classes/Rendering/NullRequest.php
+
+		-
+			message: "#^Method OliverKlee\\\\Seminars\\\\Rendering\\\\NullRequest\\:\\:withCookieParams\\(\\) has parameter \\$cookies with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: Classes/Rendering/NullRequest.php
+
+		-
+			message: "#^Method OliverKlee\\\\Seminars\\\\Rendering\\\\NullRequest\\:\\:withParsedBody\\(\\) has parameter \\$data with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: Classes/Rendering/NullRequest.php
+
+		-
+			message: "#^Method OliverKlee\\\\Seminars\\\\Rendering\\\\NullRequest\\:\\:withQueryParams\\(\\) has parameter \\$query with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: Classes/Rendering/NullRequest.php
+
+		-
+			message: "#^Method OliverKlee\\\\Seminars\\\\Rendering\\\\NullRequest\\:\\:withUploadedFiles\\(\\) has parameter \\$uploadedFiles with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: Classes/Rendering/NullRequest.php
+
+		-
 			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
 			count: 1
 			path: Classes/SchedulerTasks/MailNotifier.php


### PR DESCRIPTION
This is required in 11LTS.

Also make the `NullRenderingContext` final.

Fixes #1516