### PR TITLE
[BUGFIX] Provide a `Context` for the FE in the functional tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Removed
 
 ### Fixed
-- 11LTS compatibility fixes (#1526)
+- 11LTS compatibility fixes (#1526, #1527)
 - Fix type warnings for `str_replace` in the `MailNotifier` (#1524)
 
 ## 4.1.6

--- a/Tests/Functional/FrontEnd/CategoryListTest.php
+++ b/Tests/Functional/FrontEnd/CategoryListTest.php
@@ -10,6 +10,7 @@ use OliverKlee\Oelib\Testing\CacheNullifyer;
 use OliverKlee\Seminars\FrontEnd\CategoryList;
 use OliverKlee\Seminars\Tests\Functional\Traits\LanguageHelper;
 use Psr\Log\NullLogger;
+use TYPO3\CMS\Core\Context\Context;
 use TYPO3\CMS\Core\Http\Uri;
 use TYPO3\CMS\Core\Site\Entity\Site;
 use TYPO3\CMS\Core\Site\Entity\SiteLanguage;
@@ -42,7 +43,7 @@ final class CategoryListTest extends FunctionalTestCase
         if (Typo3Version::isAtLeast(10)) {
             $frontEnd = GeneralUtility::makeInstance(
                 TypoScriptFrontendController::class,
-                $GLOBALS['TYPO3_CONF_VARS'],
+                new Context(),
                 new Site('test', 0, []),
                 new SiteLanguage(0, 'en_US.utf8', new Uri(), [])
             );

--- a/Tests/Functional/FrontEnd/DefaultController/ListViewTest.php
+++ b/Tests/Functional/FrontEnd/DefaultController/ListViewTest.php
@@ -12,6 +12,7 @@ use OliverKlee\Seminars\Tests\Functional\FrontEnd\Fixtures\TestingDefaultControl
 use OliverKlee\Seminars\Tests\Functional\Traits\LanguageHelper;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
+use TYPO3\CMS\Core\Context\Context;
 use TYPO3\CMS\Core\Http\Uri;
 use TYPO3\CMS\Core\Site\Entity\Site;
 use TYPO3\CMS\Core\Site\Entity\SiteLanguage;
@@ -72,7 +73,7 @@ final class ListViewTest extends FunctionalTestCase
         if (Typo3Version::isAtLeast(10)) {
             $frontEndController = GeneralUtility::makeInstance(
                 TypoScriptFrontendController::class,
-                $GLOBALS['TYPO3_CONF_VARS'],
+                new Context(),
                 new Site('test', self::CURRENT_PAGE_UID, []),
                 new SiteLanguage(0, 'en_US.utf8', new Uri(), [])
             );

--- a/Tests/Functional/FrontEnd/DefaultController/SingleViewTest.php
+++ b/Tests/Functional/FrontEnd/DefaultController/SingleViewTest.php
@@ -12,6 +12,7 @@ use OliverKlee\Seminars\Tests\Functional\FrontEnd\Fixtures\TestingDefaultControl
 use OliverKlee\Seminars\Tests\Functional\Traits\LanguageHelper;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
+use TYPO3\CMS\Core\Context\Context;
 use TYPO3\CMS\Core\Http\Uri;
 use TYPO3\CMS\Core\Site\Entity\Site;
 use TYPO3\CMS\Core\Site\Entity\SiteLanguage;
@@ -67,7 +68,7 @@ final class SingleViewTest extends FunctionalTestCase
         if (Typo3Version::isAtLeast(10)) {
             $frontEndController = GeneralUtility::makeInstance(
                 TypoScriptFrontendController::class,
-                $GLOBALS['TYPO3_CONF_VARS'],
+                new Context(),
                 new Site('test', self::CURRENT_PAGE_UID, []),
                 new SiteLanguage(0, 'en_US.utf8', new Uri(), [])
             );


### PR DESCRIPTION
This is required in TYPO3 11LTS.

Fixes #1517