### PR TITLE
[BUGFIX] Also run PHPStan as part of the `ci:static` Composer script

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -162,9 +162,10 @@
 		"ci:php:stan": ".Build/vendor/bin/phpstan --no-progress",
 		"ci:static": [
 			"@ci:composer:normalize",
+			"@ci:php:cs-fixer",
 			"@ci:php:lint",
 			"@ci:php:sniff",
-			"@ci:php:cs-fixer",
+			"@ci:php:stan",
 			"@ci:ts:lint"
 		],
 		"ci:tests": [


### PR DESCRIPTION
This probably got lost during some cleanup.

Fixes #1587