### PR TITLE
[TASK] Pin `phpstan/extension-installer` to ~1.1.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,6 +23,8 @@ updates:
         versions: [ ">= 3.0.0" ]
       - dependency-name: "oliverklee/oelib"
       - dependency-name: "pelago/emogrifier"
+      - dependency-name: "phpstan/extension-installer"
+        versions: [ ">= 1.2.0" ]
       - dependency-name: "phpunit/phpunit"
         versions: [ ">= 9" ]
       - dependency-name: "sjbr/sr-feuser-register"

--- a/composer.json
+++ b/composer.json
@@ -62,7 +62,7 @@
 		"oliverklee/phpunit": "^8.5.0",
 		"php-coveralls/php-coveralls": "^2.5.3",
 		"phpspec/prophecy": "^1.15.0",
-		"phpstan/extension-installer": "^1.1.0",
+		"phpstan/extension-installer": "~1.1.0",
 		"phpstan/phpstan": "^1.8.9",
 		"phpstan/phpstan-phpunit": "^1.1.1",
 		"phpstan/phpstan-strict-rules": "^1.4.4",


### PR DESCRIPTION
This is required as long as we are using Composer 1 for some CI tasks (as version 1.2.0 required Composer 2).

Fixes #1592