### PR TITLE
[CLEANUP] Use the `EventInterface::TYPE_*` constants in the tests

### DIFF
--- a/Tests/LegacyUnit/BackEnd/CancelEventMailFormTest.php
+++ b/Tests/LegacyUnit/BackEnd/CancelEventMailFormTest.php
@@ -8,7 +8,7 @@ use OliverKlee\Oelib\Configuration\PageFinder;
 use OliverKlee\Oelib\Mapper\MapperRegistry;
 use OliverKlee\Oelib\Testing\TestingFramework;
 use OliverKlee\Seminars\BackEnd\CancelEventMailForm;
-use OliverKlee\Seminars\Model\Event;
+use OliverKlee\Seminars\Domain\Model\Event\EventInterface;
 use OliverKlee\Seminars\Tests\LegacyUnit\Support\Traits\BackEndTestsTrait;
 use PHPUnit\Framework\TestCase;
 use TYPO3\CMS\Core\Information\Typo3Version;
@@ -53,7 +53,7 @@ final class CancelEventMailFormTest extends TestCase
             [
                 'pid' => $dummySysFolderUid,
                 'title' => 'Dummy event',
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
                 'begin_date' => $GLOBALS['SIM_EXEC_TIME'] + 86400,
                 'organizers' => 0,
             ]

--- a/Tests/LegacyUnit/BackEnd/ConfirmEventMailFormTest.php
+++ b/Tests/LegacyUnit/BackEnd/ConfirmEventMailFormTest.php
@@ -8,7 +8,7 @@ use OliverKlee\Oelib\Configuration\PageFinder;
 use OliverKlee\Oelib\Mapper\MapperRegistry;
 use OliverKlee\Oelib\Testing\TestingFramework;
 use OliverKlee\Seminars\BackEnd\ConfirmEventMailForm;
-use OliverKlee\Seminars\Model\Event;
+use OliverKlee\Seminars\Domain\Model\Event\EventInterface;
 use OliverKlee\Seminars\Tests\LegacyUnit\Support\Traits\BackEndTestsTrait;
 use PHPUnit\Framework\TestCase;
 use TYPO3\CMS\Core\Information\Typo3Version;
@@ -53,7 +53,7 @@ final class ConfirmEventMailFormTest extends TestCase
             [
                 'pid' => $dummySysFolderUid,
                 'title' => 'Dummy event',
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
                 'begin_date' => $GLOBALS['SIM_EXEC_TIME'] + 86400,
                 'organizers' => 0,
             ]

--- a/Tests/LegacyUnit/BackEnd/EventsListTest.php
+++ b/Tests/LegacyUnit/BackEnd/EventsListTest.php
@@ -9,6 +9,7 @@ use OliverKlee\Oelib\Mapper\MapperRegistry;
 use OliverKlee\Oelib\Testing\TestingFramework;
 use OliverKlee\Seminars\BackEnd\AbstractList;
 use OliverKlee\Seminars\BackEnd\EventsList;
+use OliverKlee\Seminars\Domain\Model\Event\EventInterface;
 use OliverKlee\Seminars\Mapper\BackEndUserGroupMapper;
 use OliverKlee\Seminars\Mapper\BackEndUserMapper;
 use OliverKlee\Seminars\Model\Event;
@@ -429,7 +430,7 @@ final class EventsListTest extends TestCase
             'tx_seminars_seminars',
             [
                 'pid' => $this->dummySysFolderPid,
-                'object_type' => Event::TYPE_TOPIC,
+                'object_type' => EventInterface::TYPE_EVENT_TOPIC,
             ]
         );
 
@@ -566,7 +567,7 @@ final class EventsListTest extends TestCase
             [
                 'pid' => $this->dummySysFolderPid,
                 'begin_date' => $GLOBALS['SIM_EXEC_TIME'] + 42,
-                'object_type' => Event::TYPE_TOPIC,
+                'object_type' => EventInterface::TYPE_EVENT_TOPIC,
             ]
         );
 
@@ -797,7 +798,7 @@ final class EventsListTest extends TestCase
             [
                 'pid' => $this->dummySysFolderPid,
                 'title' => 'event_1',
-                'object_type' => Event::TYPE_COMPLETE,
+                'object_type' => EventInterface::TYPE_SINGLE_EVENT,
             ]
         );
 

--- a/Tests/LegacyUnit/BagBuilder/EventBagBuilderTest.php
+++ b/Tests/LegacyUnit/BagBuilder/EventBagBuilderTest.php
@@ -9,6 +9,7 @@ use OliverKlee\Oelib\Testing\TestingFramework;
 use OliverKlee\Seminars\Bag\AbstractBag;
 use OliverKlee\Seminars\Bag\EventBag;
 use OliverKlee\Seminars\BagBuilder\EventBagBuilder;
+use OliverKlee\Seminars\Domain\Model\Event\EventInterface;
 use OliverKlee\Seminars\Model\Event;
 use OliverKlee\Seminars\OldModel\LegacyEvent;
 use OliverKlee\Seminars\Service\RegistrationManager;
@@ -1815,7 +1816,7 @@ final class EventBagBuilderTest extends TestCase
     {
         $this->testingFramework->createRecord(
             'tx_seminars_seminars',
-            ['object_type' => Event::TYPE_COMPLETE]
+            ['object_type' => EventInterface::TYPE_SINGLE_EVENT]
         );
 
         $typeUid = $this->testingFramework->createRecord(
@@ -1824,7 +1825,7 @@ final class EventBagBuilderTest extends TestCase
         $this->testingFramework->createRecord(
             'tx_seminars_seminars',
             [
-                'object_type' => Event::TYPE_COMPLETE,
+                'object_type' => EventInterface::TYPE_SINGLE_EVENT,
                 'event_type' => $typeUid,
             ]
         );
@@ -1843,7 +1844,7 @@ final class EventBagBuilderTest extends TestCase
     {
         $this->testingFramework->createRecord(
             'tx_seminars_seminars',
-            ['object_type' => Event::TYPE_COMPLETE]
+            ['object_type' => EventInterface::TYPE_SINGLE_EVENT]
         );
 
         $typeUid = $this->testingFramework->createRecord(
@@ -1852,7 +1853,7 @@ final class EventBagBuilderTest extends TestCase
         $this->testingFramework->createRecord(
             'tx_seminars_seminars',
             [
-                'object_type' => Event::TYPE_COMPLETE,
+                'object_type' => EventInterface::TYPE_SINGLE_EVENT,
                 'event_type' => $typeUid,
             ]
         );
@@ -1873,7 +1874,7 @@ final class EventBagBuilderTest extends TestCase
     {
         $this->testingFramework->createRecord(
             'tx_seminars_seminars',
-            ['object_type' => Event::TYPE_COMPLETE]
+            ['object_type' => EventInterface::TYPE_SINGLE_EVENT]
         );
 
         $typeUid = $this->testingFramework->createRecord(
@@ -1882,7 +1883,7 @@ final class EventBagBuilderTest extends TestCase
         $this->testingFramework->createRecord(
             'tx_seminars_seminars',
             [
-                'object_type' => Event::TYPE_COMPLETE,
+                'object_type' => EventInterface::TYPE_SINGLE_EVENT,
                 'event_type' => $typeUid,
             ]
         );
@@ -1908,7 +1909,7 @@ final class EventBagBuilderTest extends TestCase
         $this->testingFramework->createRecord(
             'tx_seminars_seminars',
             [
-                'object_type' => Event::TYPE_COMPLETE,
+                'object_type' => EventInterface::TYPE_SINGLE_EVENT,
                 'event_type' => $typeUid,
             ]
         );
@@ -1933,14 +1934,14 @@ final class EventBagBuilderTest extends TestCase
         $this->testingFramework->createRecord(
             'tx_seminars_seminars',
             [
-                'object_type' => Event::TYPE_COMPLETE,
+                'object_type' => EventInterface::TYPE_SINGLE_EVENT,
                 'event_type' => $typeUid,
             ]
         );
         $this->testingFramework->createRecord(
             'tx_seminars_seminars',
             [
-                'object_type' => Event::TYPE_COMPLETE,
+                'object_type' => EventInterface::TYPE_SINGLE_EVENT,
                 'event_type' => $typeUid,
             ]
         );
@@ -1961,7 +1962,7 @@ final class EventBagBuilderTest extends TestCase
     {
         $this->testingFramework->createRecord(
             'tx_seminars_seminars',
-            ['object_type' => Event::TYPE_COMPLETE]
+            ['object_type' => EventInterface::TYPE_SINGLE_EVENT]
         );
 
         $typeUid = $this->testingFramework->createRecord(
@@ -1970,7 +1971,7 @@ final class EventBagBuilderTest extends TestCase
         $eventUid = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
             [
-                'object_type' => Event::TYPE_COMPLETE,
+                'object_type' => EventInterface::TYPE_SINGLE_EVENT,
                 'event_type' => $typeUid,
             ]
         );
@@ -1999,7 +2000,7 @@ final class EventBagBuilderTest extends TestCase
         $eventUid1 = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
             [
-                'object_type' => Event::TYPE_COMPLETE,
+                'object_type' => EventInterface::TYPE_SINGLE_EVENT,
                 'event_type' => $typeUid1,
             ]
         );
@@ -2010,7 +2011,7 @@ final class EventBagBuilderTest extends TestCase
         $this->testingFramework->createRecord(
             'tx_seminars_seminars',
             [
-                'object_type' => Event::TYPE_COMPLETE,
+                'object_type' => EventInterface::TYPE_SINGLE_EVENT,
                 'event_type' => $typeUid2,
             ]
         );
@@ -2035,7 +2036,7 @@ final class EventBagBuilderTest extends TestCase
     {
         $this->testingFramework->createRecord(
             'tx_seminars_seminars',
-            ['object_type' => Event::TYPE_COMPLETE]
+            ['object_type' => EventInterface::TYPE_SINGLE_EVENT]
         );
 
         $typeUid1 = $this->testingFramework->createRecord(
@@ -2044,7 +2045,7 @@ final class EventBagBuilderTest extends TestCase
         $this->testingFramework->createRecord(
             'tx_seminars_seminars',
             [
-                'object_type' => Event::TYPE_COMPLETE,
+                'object_type' => EventInterface::TYPE_SINGLE_EVENT,
                 'event_type' => $typeUid1,
             ]
         );
@@ -2070,14 +2071,14 @@ final class EventBagBuilderTest extends TestCase
         $topicUid = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
             [
-                'object_type' => Event::TYPE_TOPIC,
+                'object_type' => EventInterface::TYPE_EVENT_TOPIC,
                 'event_type' => $typeUid,
             ]
         );
         $dateUid = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
             [
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
                 'topic' => $topicUid,
             ]
         );
@@ -2100,14 +2101,14 @@ final class EventBagBuilderTest extends TestCase
         $topicUid = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
             [
-                'object_type' => Event::TYPE_COMPLETE,
+                'object_type' => EventInterface::TYPE_SINGLE_EVENT,
                 'event_type' => $typeUid,
             ]
         );
         $this->testingFramework->createRecord(
             'tx_seminars_seminars',
             [
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
                 'topic' => $topicUid,
             ]
         );
@@ -2132,7 +2133,7 @@ final class EventBagBuilderTest extends TestCase
         $topicUid = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
             [
-                'object_type' => Event::TYPE_COMPLETE,
+                'object_type' => EventInterface::TYPE_SINGLE_EVENT,
                 'event_type' => $typeUid1,
             ]
         );
@@ -2143,7 +2144,7 @@ final class EventBagBuilderTest extends TestCase
         $this->testingFramework->createRecord(
             'tx_seminars_seminars',
             [
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
                 'topic' => $topicUid,
                 'event_type' => $typeUid2,
             ]
@@ -2168,7 +2169,7 @@ final class EventBagBuilderTest extends TestCase
         $this->testingFramework->createRecord(
             'tx_seminars_seminars',
             [
-                'object_type' => Event::TYPE_COMPLETE,
+                'object_type' => EventInterface::TYPE_SINGLE_EVENT,
                 'event_type' => $typeUid1,
             ]
         );
@@ -2179,7 +2180,7 @@ final class EventBagBuilderTest extends TestCase
         $this->testingFramework->createRecord(
             'tx_seminars_seminars',
             [
-                'object_type' => Event::TYPE_COMPLETE,
+                'object_type' => EventInterface::TYPE_SINGLE_EVENT,
                 'event_type' => $typeUid2,
             ]
         );
@@ -2202,7 +2203,7 @@ final class EventBagBuilderTest extends TestCase
         $topicUid = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
             [
-                'object_type' => Event::TYPE_TOPIC,
+                'object_type' => EventInterface::TYPE_EVENT_TOPIC,
                 'event_type' => $typeUid,
             ]
         );
@@ -2230,7 +2231,7 @@ final class EventBagBuilderTest extends TestCase
         $typeUid = $this->testingFramework->createRecord('tx_seminars_event_types');
         $this->testingFramework->createRecord(
             'tx_seminars_seminars',
-            ['object_type' => Event::TYPE_COMPLETE, 'event_type' => $typeUid]
+            ['object_type' => EventInterface::TYPE_SINGLE_EVENT, 'event_type' => $typeUid]
         );
 
         $this->subject->limitToEventTypes([$typeUid, $invalidUid]);
@@ -2908,7 +2909,7 @@ final class EventBagBuilderTest extends TestCase
     {
         $this->testingFramework->createRecord(
             'tx_seminars_seminars',
-            ['object_type' => Event::TYPE_TOPIC]
+            ['object_type' => EventInterface::TYPE_EVENT_TOPIC]
         );
         $this->subject->limitToTopicRecords();
         $bag = $this->subject->build();
@@ -2926,7 +2927,7 @@ final class EventBagBuilderTest extends TestCase
     {
         $this->testingFramework->createRecord(
             'tx_seminars_seminars',
-            ['object_type' => Event::TYPE_COMPLETE]
+            ['object_type' => EventInterface::TYPE_SINGLE_EVENT]
         );
         $this->subject->limitToTopicRecords();
         $bag = $this->subject->build();
@@ -2943,7 +2944,7 @@ final class EventBagBuilderTest extends TestCase
     {
         $this->testingFramework->createRecord(
             'tx_seminars_seminars',
-            ['object_type' => Event::TYPE_DATE]
+            ['object_type' => EventInterface::TYPE_EVENT_DATE]
         );
         $this->subject->limitToTopicRecords();
         $bag = $this->subject->build();
@@ -2964,7 +2965,7 @@ final class EventBagBuilderTest extends TestCase
     {
         $this->testingFramework->createRecord(
             'tx_seminars_seminars',
-            ['object_type' => Event::TYPE_COMPLETE]
+            ['object_type' => EventInterface::TYPE_SINGLE_EVENT]
         );
         $this->subject->limitToTopicRecords();
         $this->subject->removeLimitToTopicRecords();
@@ -2983,7 +2984,7 @@ final class EventBagBuilderTest extends TestCase
     {
         $this->testingFramework->createRecord(
             'tx_seminars_seminars',
-            ['object_type' => Event::TYPE_DATE]
+            ['object_type' => EventInterface::TYPE_EVENT_DATE]
         );
         $this->subject->limitToTopicRecords();
         $this->subject->removeLimitToTopicRecords();
@@ -3115,7 +3116,7 @@ final class EventBagBuilderTest extends TestCase
     {
         $this->testingFramework->createRecord(
             'tx_seminars_seminars',
-            ['object_type' => Event::TYPE_DATE]
+            ['object_type' => EventInterface::TYPE_EVENT_DATE]
         );
         $this->subject->limitToDateAndSingleRecords();
         $bag = $this->subject->build();
@@ -3133,7 +3134,7 @@ final class EventBagBuilderTest extends TestCase
     {
         $this->testingFramework->createRecord(
             'tx_seminars_seminars',
-            ['object_type' => Event::TYPE_COMPLETE]
+            ['object_type' => EventInterface::TYPE_SINGLE_EVENT]
         );
         $this->subject->limitToDateAndSingleRecords();
         $bag = $this->subject->build();
@@ -3151,7 +3152,7 @@ final class EventBagBuilderTest extends TestCase
     {
         $this->testingFramework->createRecord(
             'tx_seminars_seminars',
-            ['object_type' => Event::TYPE_TOPIC]
+            ['object_type' => EventInterface::TYPE_EVENT_TOPIC]
         );
         $this->subject->limitToDateAndSingleRecords();
         $bag = $this->subject->build();
@@ -3168,7 +3169,7 @@ final class EventBagBuilderTest extends TestCase
     {
         $this->testingFramework->createRecord(
             'tx_seminars_seminars',
-            ['object_type' => Event::TYPE_TOPIC]
+            ['object_type' => EventInterface::TYPE_EVENT_TOPIC]
         );
         $this->subject->limitToDateAndSingleRecords();
         $this->subject->removeLimitToDateAndSingleRecords();
@@ -3375,19 +3376,19 @@ final class EventBagBuilderTest extends TestCase
     {
         $topicUid = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
-            ['object_type' => Event::TYPE_TOPIC]
+            ['object_type' => EventInterface::TYPE_EVENT_TOPIC]
         );
         $dateUid1 = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
             [
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
                 'topic' => $topicUid,
             ]
         );
         $dateUid2 = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
             [
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
                 'topic' => $topicUid,
             ]
         );
@@ -3412,19 +3413,19 @@ final class EventBagBuilderTest extends TestCase
     {
         $topicUid = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
-            ['object_type' => Event::TYPE_TOPIC]
+            ['object_type' => EventInterface::TYPE_EVENT_TOPIC]
         );
         $this->testingFramework->createRecord(
             'tx_seminars_seminars',
             [
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
                 'topic' => $topicUid,
             ]
         );
         $this->testingFramework->createRecord(
             'tx_seminars_seminars',
             [
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
                 'topic' => $topicUid,
             ]
         );
@@ -3452,7 +3453,7 @@ final class EventBagBuilderTest extends TestCase
 
         $eventUid = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
-            ['object_type' => Event::TYPE_COMPLETE]
+            ['object_type' => EventInterface::TYPE_SINGLE_EVENT]
         );
         $event = new LegacyEvent($eventUid);
         $this->subject->limitToOtherDatesForTopic($event);
@@ -3465,23 +3466,23 @@ final class EventBagBuilderTest extends TestCase
     {
         $topicUid1 = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
-            ['object_type' => Event::TYPE_TOPIC]
+            ['object_type' => EventInterface::TYPE_EVENT_TOPIC]
         );
         $topicUid2 = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
-            ['object_type' => Event::TYPE_TOPIC]
+            ['object_type' => EventInterface::TYPE_EVENT_TOPIC]
         );
         $dateUid1 = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
             [
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
                 'topic' => $topicUid1,
             ]
         );
         $this->testingFramework->createRecord(
             'tx_seminars_seminars',
             [
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
                 'topic' => $topicUid2,
             ]
         );
@@ -3501,19 +3502,19 @@ final class EventBagBuilderTest extends TestCase
     {
         $topicUid = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
-            ['object_type' => Event::TYPE_TOPIC]
+            ['object_type' => EventInterface::TYPE_EVENT_TOPIC]
         );
         $dateUid = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
             [
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
                 'topic' => $topicUid,
             ]
         );
         $this->testingFramework->createRecord(
             'tx_seminars_seminars',
             [
-                'object_type' => Event::TYPE_COMPLETE,
+                'object_type' => EventInterface::TYPE_SINGLE_EVENT,
                 'topic' => $topicUid,
             ]
         );
@@ -3533,23 +3534,23 @@ final class EventBagBuilderTest extends TestCase
     {
         $topicUid1 = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
-            ['object_type' => Event::TYPE_TOPIC]
+            ['object_type' => EventInterface::TYPE_EVENT_TOPIC]
         );
         $topicUid2 = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
-            ['object_type' => Event::TYPE_TOPIC]
+            ['object_type' => EventInterface::TYPE_EVENT_TOPIC]
         );
         $dateUid1 = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
             [
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
                 'topic' => $topicUid1,
             ]
         );
         $this->testingFramework->createRecord(
             'tx_seminars_seminars',
             [
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
                 'topic' => $topicUid2,
             ]
         );
@@ -3571,19 +3572,19 @@ final class EventBagBuilderTest extends TestCase
     {
         $topicUid = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
-            ['object_type' => Event::TYPE_TOPIC]
+            ['object_type' => EventInterface::TYPE_EVENT_TOPIC]
         );
         $dateUid = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
             [
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
                 'topic' => $topicUid,
             ]
         );
         $this->testingFramework->createRecord(
             'tx_seminars_seminars',
             [
-                'object_type' => Event::TYPE_COMPLETE,
+                'object_type' => EventInterface::TYPE_SINGLE_EVENT,
                 'topic' => $topicUid,
             ]
         );
@@ -3699,7 +3700,7 @@ final class EventBagBuilderTest extends TestCase
             'tx_seminars_seminars',
             [
                 'accreditation_number' => 'avocado paprika event',
-                'object_type' => Event::TYPE_COMPLETE,
+                'object_type' => EventInterface::TYPE_SINGLE_EVENT,
             ]
         );
         $this->subject->limitToFullTextSearch('avocado');
@@ -3724,7 +3725,7 @@ final class EventBagBuilderTest extends TestCase
             'tx_seminars_seminars',
             [
                 'accreditation_number' => 'paprika event',
-                'object_type' => Event::TYPE_COMPLETE,
+                'object_type' => EventInterface::TYPE_SINGLE_EVENT,
             ]
         );
         $this->subject->limitToFullTextSearch('avocado');
@@ -3865,7 +3866,7 @@ final class EventBagBuilderTest extends TestCase
             'tx_seminars_seminars',
             [
                 'speakers' => 1,
-                'object_type' => Event::TYPE_COMPLETE,
+                'object_type' => EventInterface::TYPE_SINGLE_EVENT,
             ]
         );
         $this->testingFramework->createRelation(
@@ -3899,7 +3900,7 @@ final class EventBagBuilderTest extends TestCase
             'tx_seminars_seminars',
             [
                 'speakers' => 1,
-                'object_type' => Event::TYPE_COMPLETE,
+                'object_type' => EventInterface::TYPE_SINGLE_EVENT,
             ]
         );
         $this->testingFramework->createRelation(
@@ -3928,7 +3929,7 @@ final class EventBagBuilderTest extends TestCase
             'tx_seminars_seminars',
             [
                 'place' => 1,
-                'object_type' => Event::TYPE_COMPLETE,
+                'object_type' => EventInterface::TYPE_SINGLE_EVENT,
             ]
         );
         $this->testingFramework->createRelation(
@@ -3962,7 +3963,7 @@ final class EventBagBuilderTest extends TestCase
             'tx_seminars_seminars',
             [
                 'place' => 1,
-                'object_type' => Event::TYPE_COMPLETE,
+                'object_type' => EventInterface::TYPE_SINGLE_EVENT,
             ]
         );
         $this->testingFramework->createRelation(
@@ -3991,7 +3992,7 @@ final class EventBagBuilderTest extends TestCase
             'tx_seminars_seminars',
             [
                 'place' => 1,
-                'object_type' => Event::TYPE_COMPLETE,
+                'object_type' => EventInterface::TYPE_SINGLE_EVENT,
             ]
         );
         $this->testingFramework->createRelation(
@@ -4025,7 +4026,7 @@ final class EventBagBuilderTest extends TestCase
             'tx_seminars_seminars',
             [
                 'place' => 1,
-                'object_type' => Event::TYPE_COMPLETE,
+                'object_type' => EventInterface::TYPE_SINGLE_EVENT,
             ]
         );
         $this->testingFramework->createRelation(
@@ -4054,7 +4055,7 @@ final class EventBagBuilderTest extends TestCase
             'tx_seminars_seminars',
             [
                 'event_type' => $eventTypeUid,
-                'object_type' => Event::TYPE_COMPLETE,
+                'object_type' => EventInterface::TYPE_SINGLE_EVENT,
             ]
         );
         $this->subject->limitToFullTextSearch('avocado');
@@ -4083,7 +4084,7 @@ final class EventBagBuilderTest extends TestCase
             'tx_seminars_seminars',
             [
                 'event_type' => $eventTypeUid,
-                'object_type' => Event::TYPE_COMPLETE,
+                'object_type' => EventInterface::TYPE_SINGLE_EVENT,
             ]
         );
         $this->subject->limitToFullTextSearch('avocado');
@@ -4107,7 +4108,7 @@ final class EventBagBuilderTest extends TestCase
             'tx_seminars_seminars',
             [
                 'categories' => 1,
-                'object_type' => Event::TYPE_COMPLETE,
+                'object_type' => EventInterface::TYPE_SINGLE_EVENT,
             ]
         );
         $this->testingFramework->createRelation(
@@ -4141,7 +4142,7 @@ final class EventBagBuilderTest extends TestCase
             'tx_seminars_seminars',
             [
                 'categories' => 1,
-                'object_type' => Event::TYPE_COMPLETE,
+                'object_type' => EventInterface::TYPE_SINGLE_EVENT,
             ]
         );
         $this->testingFramework->createRelation(
@@ -4214,7 +4215,7 @@ final class EventBagBuilderTest extends TestCase
             'tx_seminars_seminars',
             [
                 'target_groups' => 1,
-                'object_type' => Event::TYPE_COMPLETE,
+                'object_type' => EventInterface::TYPE_SINGLE_EVENT,
             ]
         );
         $this->testingFramework->createRelation(
@@ -4248,7 +4249,7 @@ final class EventBagBuilderTest extends TestCase
             'tx_seminars_seminars',
             [
                 'target_groups' => 1,
-                'object_type' => Event::TYPE_COMPLETE,
+                'object_type' => EventInterface::TYPE_SINGLE_EVENT,
             ]
         );
         $this->testingFramework->createRelation(
@@ -4277,14 +4278,14 @@ final class EventBagBuilderTest extends TestCase
             'tx_seminars_seminars',
             [
                 'title' => 'avocado paprika event',
-                'object_type' => Event::TYPE_TOPIC,
+                'object_type' => EventInterface::TYPE_EVENT_TOPIC,
             ]
         );
         $dateUid = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
             [
                 'topic' => $topicUid,
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
             ]
         );
         $this->subject->limitToFullTextSearch('avocado');
@@ -4310,14 +4311,14 @@ final class EventBagBuilderTest extends TestCase
             'tx_seminars_seminars',
             [
                 'title' => 'paprika event',
-                'object_type' => Event::TYPE_TOPIC,
+                'object_type' => EventInterface::TYPE_EVENT_TOPIC,
             ]
         );
         $this->testingFramework->createRecord(
             'tx_seminars_seminars',
             [
                 'topic' => $topicUid,
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
             ]
         );
         $this->subject->limitToFullTextSearch('avocado');
@@ -4338,14 +4339,14 @@ final class EventBagBuilderTest extends TestCase
             'tx_seminars_seminars',
             [
                 'subtitle' => 'avocado paprika event',
-                'object_type' => Event::TYPE_TOPIC,
+                'object_type' => EventInterface::TYPE_EVENT_TOPIC,
             ]
         );
         $dateUid = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
             [
                 'topic' => $topicUid,
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
             ]
         );
         $this->subject->limitToFullTextSearch('avocado');
@@ -4371,14 +4372,14 @@ final class EventBagBuilderTest extends TestCase
             'tx_seminars_seminars',
             [
                 'subtitle' => 'paprika event',
-                'object_type' => Event::TYPE_TOPIC,
+                'object_type' => EventInterface::TYPE_EVENT_TOPIC,
             ]
         );
         $this->testingFramework->createRecord(
             'tx_seminars_seminars',
             [
                 'topic' => $topicUid,
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
             ]
         );
         $this->subject->limitToFullTextSearch('avocado');
@@ -4399,14 +4400,14 @@ final class EventBagBuilderTest extends TestCase
             'tx_seminars_seminars',
             [
                 'description' => 'avocado paprika event',
-                'object_type' => Event::TYPE_TOPIC,
+                'object_type' => EventInterface::TYPE_EVENT_TOPIC,
             ]
         );
         $dateUid = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
             [
                 'topic' => $topicUid,
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
             ]
         );
         $this->subject->limitToFullTextSearch('avocado');
@@ -4432,14 +4433,14 @@ final class EventBagBuilderTest extends TestCase
             'tx_seminars_seminars',
             [
                 'description' => 'paprika event',
-                'object_type' => Event::TYPE_TOPIC,
+                'object_type' => EventInterface::TYPE_EVENT_TOPIC,
             ]
         );
         $this->testingFramework->createRecord(
             'tx_seminars_seminars',
             [
                 'topic' => $topicUid,
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
             ]
         );
         $this->subject->limitToFullTextSearch('avocado');
@@ -4464,7 +4465,7 @@ final class EventBagBuilderTest extends TestCase
             'tx_seminars_seminars',
             [
                 'categories' => 1,
-                'object_type' => Event::TYPE_TOPIC,
+                'object_type' => EventInterface::TYPE_EVENT_TOPIC,
             ]
         );
         $this->testingFramework->createRelation(
@@ -4476,7 +4477,7 @@ final class EventBagBuilderTest extends TestCase
             'tx_seminars_seminars',
             [
                 'topic' => $topicUid,
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
             ]
         );
         $this->subject->limitToFullTextSearch('avocado');
@@ -4506,7 +4507,7 @@ final class EventBagBuilderTest extends TestCase
             'tx_seminars_seminars',
             [
                 'categories' => 1,
-                'object_type' => Event::TYPE_TOPIC,
+                'object_type' => EventInterface::TYPE_EVENT_TOPIC,
             ]
         );
         $this->testingFramework->createRelation(
@@ -4518,7 +4519,7 @@ final class EventBagBuilderTest extends TestCase
             'tx_seminars_seminars',
             [
                 'topic' => $topicUid,
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
             ]
         );
         $this->subject->limitToFullTextSearch('avocado');
@@ -4543,14 +4544,14 @@ final class EventBagBuilderTest extends TestCase
             'tx_seminars_seminars',
             [
                 'event_type' => $eventTypeUid,
-                'object_type' => Event::TYPE_TOPIC,
+                'object_type' => EventInterface::TYPE_EVENT_TOPIC,
             ]
         );
         $dateUid = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
             [
                 'topic' => $topicUid,
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
             ]
         );
         $this->subject->limitToFullTextSearch('avocado');
@@ -4580,14 +4581,14 @@ final class EventBagBuilderTest extends TestCase
             'tx_seminars_seminars',
             [
                 'event_type' => $eventTypeUid,
-                'object_type' => Event::TYPE_TOPIC,
+                'object_type' => EventInterface::TYPE_EVENT_TOPIC,
             ]
         );
         $this->testingFramework->createRecord(
             'tx_seminars_seminars',
             [
                 'topic' => $topicUid,
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
             ]
         );
         $this->subject->limitToFullTextSearch('avocado');
@@ -4612,7 +4613,7 @@ final class EventBagBuilderTest extends TestCase
             'tx_seminars_seminars',
             [
                 'accreditation_number' => 'avocado paprika event',
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
             ]
         );
         $this->subject->limitToFullTextSearch('avocado');
@@ -4637,7 +4638,7 @@ final class EventBagBuilderTest extends TestCase
             'tx_seminars_seminars',
             [
                 'accreditation_number' => 'paprika event',
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
             ]
         );
         $this->subject->limitToFullTextSearch('avocado');
@@ -4661,7 +4662,7 @@ final class EventBagBuilderTest extends TestCase
             'tx_seminars_seminars',
             [
                 'speakers' => 1,
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
             ]
         );
         $this->testingFramework->createRelation(
@@ -4695,7 +4696,7 @@ final class EventBagBuilderTest extends TestCase
             'tx_seminars_seminars',
             [
                 'speakers' => 1,
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
             ]
         );
         $this->testingFramework->createRelation(
@@ -4724,7 +4725,7 @@ final class EventBagBuilderTest extends TestCase
             'tx_seminars_seminars',
             [
                 'place' => 1,
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
             ]
         );
         $this->testingFramework->createRelation(
@@ -4758,7 +4759,7 @@ final class EventBagBuilderTest extends TestCase
             'tx_seminars_seminars',
             [
                 'place' => 1,
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
             ]
         );
         $this->testingFramework->createRelation(
@@ -4787,7 +4788,7 @@ final class EventBagBuilderTest extends TestCase
             'tx_seminars_seminars',
             [
                 'place' => 1,
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
             ]
         );
         $this->testingFramework->createRelation(
@@ -4821,7 +4822,7 @@ final class EventBagBuilderTest extends TestCase
             'tx_seminars_seminars',
             [
                 'place' => 1,
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
             ]
         );
         $this->testingFramework->createRelation(
@@ -5062,7 +5063,7 @@ final class EventBagBuilderTest extends TestCase
     {
         $topicUid = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
-            ['object_type' => Event::TYPE_TOPIC]
+            ['object_type' => EventInterface::TYPE_EVENT_TOPIC]
         );
 
         $this->subject->limitToTopicsWithoutRegistrationByUser(
@@ -5087,12 +5088,12 @@ final class EventBagBuilderTest extends TestCase
     {
         $topicUid = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
-            ['object_type' => Event::TYPE_TOPIC]
+            ['object_type' => EventInterface::TYPE_EVENT_TOPIC]
         );
         $this->testingFramework->createRecord(
             'tx_seminars_seminars',
             [
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
                 'topic' => $topicUid,
             ]
         );
@@ -5119,12 +5120,12 @@ final class EventBagBuilderTest extends TestCase
     {
         $topicUid = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
-            ['object_type' => Event::TYPE_TOPIC]
+            ['object_type' => EventInterface::TYPE_EVENT_TOPIC]
         );
         $this->testingFramework->createRecord(
             'tx_seminars_seminars',
             [
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
                 'topic' => $topicUid,
             ]
         );
@@ -5147,12 +5148,12 @@ final class EventBagBuilderTest extends TestCase
     {
         $topicUid = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
-            ['object_type' => Event::TYPE_TOPIC]
+            ['object_type' => EventInterface::TYPE_EVENT_TOPIC]
         );
         $dateUid = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
             [
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
                 'topic' => $topicUid,
             ]
         );
@@ -5186,12 +5187,12 @@ final class EventBagBuilderTest extends TestCase
     {
         $topicUid = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
-            ['object_type' => Event::TYPE_TOPIC]
+            ['object_type' => EventInterface::TYPE_EVENT_TOPIC]
         );
         $dateUid = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
             [
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
                 'topic' => $topicUid,
                 'expiry' => 0,
             ]
@@ -5217,12 +5218,12 @@ final class EventBagBuilderTest extends TestCase
     {
         $topicUid = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
-            ['object_type' => Event::TYPE_TOPIC]
+            ['object_type' => EventInterface::TYPE_EVENT_TOPIC]
         );
         $dateUid = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
             [
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
                 'topic' => $topicUid,
                 'expiry' => $this->future,
             ]
@@ -5248,12 +5249,12 @@ final class EventBagBuilderTest extends TestCase
     {
         $topicUid = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
-            ['object_type' => Event::TYPE_TOPIC]
+            ['object_type' => EventInterface::TYPE_EVENT_TOPIC]
         );
         $dateUid = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
             [
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
                 'topic' => $topicUid,
                 'expiry' => $this->past,
             ]
@@ -5280,12 +5281,12 @@ final class EventBagBuilderTest extends TestCase
     {
         $topicUid = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
-            ['object_type' => Event::TYPE_TOPIC]
+            ['object_type' => EventInterface::TYPE_EVENT_TOPIC]
         );
         $dateUid = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
             [
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
                 'topic' => $topicUid,
             ]
         );
@@ -5317,12 +5318,12 @@ final class EventBagBuilderTest extends TestCase
     {
         $requiredTopicUid = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
-            ['object_type' => Event::TYPE_TOPIC]
+            ['object_type' => EventInterface::TYPE_EVENT_TOPIC]
         );
         $this->testingFramework->createRecord(
             'tx_seminars_seminars',
             [
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
                 'topic' => $requiredTopicUid,
             ]
         );
@@ -5331,7 +5332,7 @@ final class EventBagBuilderTest extends TestCase
             'tx_seminars_seminars',
             [
                 'requirements' => 1,
-                'object_type' => Event::TYPE_TOPIC,
+                'object_type' => EventInterface::TYPE_EVENT_TOPIC,
             ]
         );
         $this->testingFramework->createRelation(
@@ -6351,7 +6352,7 @@ final class EventBagBuilderTest extends TestCase
     {
         $topicUid = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
-            ['object_type' => Event::TYPE_TOPIC]
+            ['object_type' => EventInterface::TYPE_EVENT_TOPIC]
         );
         $organizerUid = $this->testingFramework->createRecord(
             'tx_seminars_organizers'
@@ -6367,7 +6368,7 @@ final class EventBagBuilderTest extends TestCase
         $dateUid = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
             [
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
                 'topic' => $topicUid,
             ]
         );
@@ -7036,14 +7037,14 @@ final class EventBagBuilderTest extends TestCase
             'tx_seminars_seminars',
             [
                 'price_regular' => 49,
-                'object_type' => Event::TYPE_TOPIC,
+                'object_type' => EventInterface::TYPE_EVENT_TOPIC,
             ]
         );
         $dateUid = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
             [
                 'topic' => $topicUid,
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
             ]
         );
 
@@ -7069,14 +7070,14 @@ final class EventBagBuilderTest extends TestCase
             'tx_seminars_seminars',
             [
                 'price_regular' => 51,
-                'object_type' => Event::TYPE_TOPIC,
+                'object_type' => EventInterface::TYPE_EVENT_TOPIC,
             ]
         );
         $this->testingFramework->createRecord(
             'tx_seminars_seminars',
             [
                 'topic' => $topicUid,
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
             ]
         );
 

--- a/Tests/LegacyUnit/Fixtures/OldModel/TestingLegacyEvent.php
+++ b/Tests/LegacyUnit/Fixtures/OldModel/TestingLegacyEvent.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace OliverKlee\Seminars\Tests\LegacyUnit\Fixtures\OldModel;
 
+use OliverKlee\Seminars\Domain\Model\Event\EventInterface;
 use OliverKlee\Seminars\OldModel\LegacyEvent;
 
 /**
@@ -242,9 +243,7 @@ final class TestingLegacyEvent extends LegacyEvent
     /**
      * Sets the record type for this event record.
      *
-     * @param int $recordType
-     *        the record type for this event record, must be either Event::TYPE_COMPLETE,
-     *        Event::TYPE_TOPIC or Event::TYPE_DATE
+     * @param EventInterface::TYPE_* $recordType
      */
     public function setRecordType(int $recordType): void
     {

--- a/Tests/LegacyUnit/FrontEnd/CountdownTest.php
+++ b/Tests/LegacyUnit/FrontEnd/CountdownTest.php
@@ -8,9 +8,9 @@ use OliverKlee\Oelib\Configuration\ConfigurationRegistry;
 use OliverKlee\Oelib\Configuration\DummyConfiguration;
 use OliverKlee\Oelib\Exception\NotFoundException;
 use OliverKlee\Oelib\Testing\TestingFramework;
+use OliverKlee\Seminars\Domain\Model\Event\EventInterface;
 use OliverKlee\Seminars\FrontEnd\Countdown;
 use OliverKlee\Seminars\Mapper\EventMapper;
-use OliverKlee\Seminars\Model\Event;
 use OliverKlee\Seminars\Service\RegistrationManager;
 use OliverKlee\Seminars\ViewHelpers\CountdownViewHelper;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -125,7 +125,7 @@ final class CountdownTest extends TestCase
         $this->subject->injectEventMapper($this->mapper);
         $event = $this->mapper->getLoadedTestingModel(
             [
-                'object_type' => Event::TYPE_COMPLETE,
+                'object_type' => EventInterface::TYPE_SINGLE_EVENT,
                 'pid' => 0,
                 'title' => 'Test event',
                 'begin_date' => $GLOBALS['SIM_ACCESS_TIME'] + 1000,

--- a/Tests/LegacyUnit/FrontEnd/DefaultControllerTest.php
+++ b/Tests/LegacyUnit/FrontEnd/DefaultControllerTest.php
@@ -14,6 +14,7 @@ use OliverKlee\Oelib\Interfaces\Time;
 use OliverKlee\Oelib\Mapper\MapperRegistry;
 use OliverKlee\Oelib\System\Typo3Version;
 use OliverKlee\Oelib\Testing\TestingFramework;
+use OliverKlee\Seminars\Domain\Model\Event\EventInterface;
 use OliverKlee\Seminars\FrontEnd\EventEditor;
 use OliverKlee\Seminars\FrontEnd\RegistrationForm;
 use OliverKlee\Seminars\Hooks\Interfaces\SeminarListView;
@@ -593,7 +594,7 @@ final class DefaultControllerTest extends TestCase
             'tx_seminars_seminars',
             [
                 'pid' => $this->systemFolderPid,
-                'object_type' => Event::TYPE_TOPIC,
+                'object_type' => EventInterface::TYPE_EVENT_TOPIC,
                 'title' => 'Test topic',
             ]
         );
@@ -601,7 +602,7 @@ final class DefaultControllerTest extends TestCase
             'tx_seminars_seminars',
             [
                 'pid' => $this->systemFolderPid,
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
                 'topic' => $topicUid,
                 'title' => 'Test date',
                 'begin_date' => $GLOBALS['SIM_EXEC_TIME'] + Time::SECONDS_PER_WEEK,
@@ -612,7 +613,7 @@ final class DefaultControllerTest extends TestCase
             'tx_seminars_seminars',
             [
                 'pid' => $this->systemFolderPid,
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
                 'topic' => $topicUid,
                 'title' => 'Test date 2',
                 'begin_date' => $GLOBALS['SIM_EXEC_TIME'] + Time::SECONDS_PER_WEEK + 2 * Time::SECONDS_PER_DAY,
@@ -645,7 +646,7 @@ final class DefaultControllerTest extends TestCase
             'tx_seminars_seminars',
             [
                 'pid' => $this->systemFolderPid,
-                'object_type' => Event::TYPE_TOPIC,
+                'object_type' => EventInterface::TYPE_EVENT_TOPIC,
                 'title' => 'Test topic',
             ]
         );
@@ -653,7 +654,7 @@ final class DefaultControllerTest extends TestCase
             'tx_seminars_seminars',
             [
                 'pid' => $this->systemFolderPid,
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
                 'topic' => $topicUid,
                 'title' => 'Test date',
                 'begin_date' => $GLOBALS['SIM_EXEC_TIME'] + Time::SECONDS_PER_WEEK,
@@ -664,7 +665,7 @@ final class DefaultControllerTest extends TestCase
             'tx_seminars_seminars',
             [
                 'pid' => $this->systemFolderPid,
-                'object_type' => Event::TYPE_COMPLETE,
+                'object_type' => EventInterface::TYPE_SINGLE_EVENT,
                 'topic' => $topicUid,
                 'title' => 'Test single 2',
                 'begin_date' => $GLOBALS['SIM_EXEC_TIME'] + Time::SECONDS_PER_WEEK + 2 * Time::SECONDS_PER_DAY,
@@ -695,7 +696,7 @@ final class DefaultControllerTest extends TestCase
             'tx_seminars_seminars',
             [
                 'pid' => $this->systemFolderPid,
-                'object_type' => Event::TYPE_TOPIC,
+                'object_type' => EventInterface::TYPE_EVENT_TOPIC,
                 'title' => 'Test topic',
             ]
         );
@@ -703,7 +704,7 @@ final class DefaultControllerTest extends TestCase
             'tx_seminars_seminars',
             [
                 'pid' => $this->systemFolderPid,
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
                 'topic' => $topicUid,
                 'title' => 'Test date',
                 'begin_date' => $GLOBALS['SIM_EXEC_TIME'] + Time::SECONDS_PER_WEEK,
@@ -714,7 +715,7 @@ final class DefaultControllerTest extends TestCase
             'tx_seminars_seminars',
             [
                 'pid' => $this->systemFolderPid,
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
                 'topic' => $topicUid,
                 'title' => 'Test date 2',
                 'begin_date' => $GLOBALS['SIM_EXEC_TIME'] + Time::SECONDS_PER_WEEK + 2 * Time::SECONDS_PER_DAY,
@@ -748,7 +749,7 @@ final class DefaultControllerTest extends TestCase
             'tx_seminars_seminars',
             [
                 'pid' => $this->systemFolderPid,
-                'object_type' => Event::TYPE_TOPIC,
+                'object_type' => EventInterface::TYPE_EVENT_TOPIC,
                 'title' => 'Test topic',
             ]
         );
@@ -756,7 +757,7 @@ final class DefaultControllerTest extends TestCase
             'tx_seminars_seminars',
             [
                 'pid' => $this->systemFolderPid,
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
                 'topic' => $topicUid,
                 'title' => 'Test date',
                 'begin_date' => $GLOBALS['SIM_EXEC_TIME'] + Time::SECONDS_PER_WEEK,
@@ -767,7 +768,7 @@ final class DefaultControllerTest extends TestCase
             'tx_seminars_seminars',
             [
                 'pid' => $this->systemFolderPid,
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
                 'topic' => $topicUid,
                 'title' => 'Test date 2',
                 'begin_date' => $GLOBALS['SIM_EXEC_TIME'] + Time::SECONDS_PER_WEEK + 2 * Time::SECONDS_PER_DAY,
@@ -1426,11 +1427,11 @@ final class DefaultControllerTest extends TestCase
         $this->testingFramework->changeRecord(
             'tx_seminars_seminars',
             $this->seminarUid,
-            ['object_type' => Event::TYPE_TOPIC]
+            ['object_type' => EventInterface::TYPE_EVENT_TOPIC]
         );
         $requiredEvent = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
-            ['object_type' => Event::TYPE_TOPIC]
+            ['object_type' => EventInterface::TYPE_EVENT_TOPIC]
         );
         $this->testingFramework->createRelationAndUpdateCounter(
             'tx_seminars_seminars',
@@ -1458,12 +1459,12 @@ final class DefaultControllerTest extends TestCase
         $this->testingFramework->changeRecord(
             'tx_seminars_seminars',
             $this->seminarUid,
-            ['object_type' => Event::TYPE_TOPIC]
+            ['object_type' => EventInterface::TYPE_EVENT_TOPIC]
         );
         $requiredEvent = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
             [
-                'object_type' => Event::TYPE_TOPIC,
+                'object_type' => EventInterface::TYPE_EVENT_TOPIC,
                 'title' => 'required_foo',
             ]
         );
@@ -1508,13 +1509,13 @@ final class DefaultControllerTest extends TestCase
             'tx_seminars_seminars',
             $this->seminarUid,
             [
-                'object_type' => Event::TYPE_TOPIC,
+                'object_type' => EventInterface::TYPE_EVENT_TOPIC,
                 'dependencies' => 1,
             ]
         );
         $dependingEventUid = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
-            ['object_type' => Event::TYPE_TOPIC]
+            ['object_type' => EventInterface::TYPE_EVENT_TOPIC]
         );
         $this->testingFramework->createRelation(
             'tx_seminars_seminars_requirements_mm',
@@ -1539,14 +1540,14 @@ final class DefaultControllerTest extends TestCase
             'tx_seminars_seminars',
             $this->seminarUid,
             [
-                'object_type' => Event::TYPE_TOPIC,
+                'object_type' => EventInterface::TYPE_EVENT_TOPIC,
                 'dependencies' => 1,
             ]
         );
         $dependingEventUid = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
             [
-                'object_type' => Event::TYPE_TOPIC,
+                'object_type' => EventInterface::TYPE_EVENT_TOPIC,
                 'title' => 'depending_foo',
             ]
         );
@@ -1573,14 +1574,14 @@ final class DefaultControllerTest extends TestCase
             'tx_seminars_seminars',
             $this->seminarUid,
             [
-                'object_type' => Event::TYPE_TOPIC,
+                'object_type' => EventInterface::TYPE_EVENT_TOPIC,
                 'dependencies' => 1,
             ]
         );
         $dependingEventUid = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
             [
-                'object_type' => Event::TYPE_TOPIC,
+                'object_type' => EventInterface::TYPE_EVENT_TOPIC,
                 'title' => 'depending_foo',
             ]
         );
@@ -1607,14 +1608,14 @@ final class DefaultControllerTest extends TestCase
             'tx_seminars_seminars',
             $this->seminarUid,
             [
-                'object_type' => Event::TYPE_TOPIC,
+                'object_type' => EventInterface::TYPE_EVENT_TOPIC,
                 'dependencies' => 2,
             ]
         );
         $dependingEventUid1 = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
             [
-                'object_type' => Event::TYPE_TOPIC,
+                'object_type' => EventInterface::TYPE_EVENT_TOPIC,
                 'title' => 'depending_foo',
             ]
         );
@@ -1626,7 +1627,7 @@ final class DefaultControllerTest extends TestCase
         $dependingEventUid2 = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
             [
-                'object_type' => Event::TYPE_TOPIC,
+                'object_type' => EventInterface::TYPE_EVENT_TOPIC,
                 'title' => 'depending_bar',
             ]
         );
@@ -1770,7 +1771,7 @@ final class DefaultControllerTest extends TestCase
         $uid = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
             [
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
                 'topic' => $this->seminarUid,
                 'expiry' => mktime(0, 0, 0, 1, 1, 2008),
             ]
@@ -1793,7 +1794,7 @@ final class DefaultControllerTest extends TestCase
         $uid = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
             [
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
                 'topic' => $this->seminarUid,
                 'expiry' => 0,
             ]
@@ -5705,7 +5706,7 @@ final class DefaultControllerTest extends TestCase
         $eventUid = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
             [
-                'object_type' => Event::TYPE_COMPLETE,
+                'object_type' => EventInterface::TYPE_SINGLE_EVENT,
                 'title' => 'foo & bar',
                 'begin_date' => $GLOBALS['SIM_EXEC_TIME'] + 1000,
                 'end_date' => $GLOBALS['SIM_EXEC_TIME'] + 2000,
@@ -5732,16 +5733,16 @@ final class DefaultControllerTest extends TestCase
 
         $requiredTopic = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
-            ['object_type' => Event::TYPE_TOPIC]
+            ['object_type' => EventInterface::TYPE_EVENT_TOPIC]
         );
         $topic = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
-            ['object_type' => Event::TYPE_TOPIC]
+            ['object_type' => EventInterface::TYPE_EVENT_TOPIC]
         );
         $date = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
             [
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
                 'begin_date' => $GLOBALS['SIM_EXEC_TIME'] + 1000,
                 'end_date' => $GLOBALS['SIM_EXEC_TIME'] + 2000,
                 'attendees_max' => 10,
@@ -5773,16 +5774,16 @@ final class DefaultControllerTest extends TestCase
 
         $requiredTopic = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
-            ['object_type' => Event::TYPE_TOPIC]
+            ['object_type' => EventInterface::TYPE_EVENT_TOPIC]
         );
         $topic = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
-            ['object_type' => Event::TYPE_TOPIC]
+            ['object_type' => EventInterface::TYPE_EVENT_TOPIC]
         );
         $date = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
             [
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
                 'begin_date' => $GLOBALS['SIM_EXEC_TIME'] + 1000,
                 'end_date' => $GLOBALS['SIM_EXEC_TIME'] + 2000,
                 'attendees_max' => 10,
@@ -5817,12 +5818,12 @@ final class DefaultControllerTest extends TestCase
 
         $topic = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
-            ['object_type' => Event::TYPE_TOPIC]
+            ['object_type' => EventInterface::TYPE_EVENT_TOPIC]
         );
         $date = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
             [
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
                 'begin_date' => $GLOBALS['SIM_EXEC_TIME'] + 1000,
                 'end_date' => $GLOBALS['SIM_EXEC_TIME'] + 2000,
                 'attendees_max' => 10,
@@ -5834,7 +5835,7 @@ final class DefaultControllerTest extends TestCase
         $requiredTopic = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
             [
-                'object_type' => Event::TYPE_TOPIC,
+                'object_type' => EventInterface::TYPE_EVENT_TOPIC,
                 'title' => 'required & foo',
             ]
         );
@@ -5862,12 +5863,12 @@ final class DefaultControllerTest extends TestCase
 
         $topic = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
-            ['object_type' => Event::TYPE_TOPIC]
+            ['object_type' => EventInterface::TYPE_EVENT_TOPIC]
         );
         $date = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
             [
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
                 'begin_date' => $GLOBALS['SIM_EXEC_TIME'] + 1000,
                 'end_date' => $GLOBALS['SIM_EXEC_TIME'] + 2000,
                 'attendees_max' => 10,
@@ -5879,7 +5880,7 @@ final class DefaultControllerTest extends TestCase
         $requiredTopic1 = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
             [
-                'object_type' => Event::TYPE_TOPIC,
+                'object_type' => EventInterface::TYPE_EVENT_TOPIC,
                 'title' => 'required_foo',
             ]
         );
@@ -5892,7 +5893,7 @@ final class DefaultControllerTest extends TestCase
         $requiredTopic2 = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
             [
-                'object_type' => Event::TYPE_TOPIC,
+                'object_type' => EventInterface::TYPE_EVENT_TOPIC,
                 'title' => 'required_bar',
             ]
         );
@@ -5925,7 +5926,7 @@ final class DefaultControllerTest extends TestCase
         $eventUid = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
             [
-                'object_type' => Event::TYPE_COMPLETE,
+                'object_type' => EventInterface::TYPE_SINGLE_EVENT,
                 'title' => 'Registration form test',
                 'begin_date' => $GLOBALS['SIM_EXEC_TIME'] + 1000,
                 'end_date' => $GLOBALS['SIM_EXEC_TIME'] + 2000,
@@ -7706,14 +7707,14 @@ final class DefaultControllerTest extends TestCase
             'tx_seminars_seminars',
             [
                 'pid' => $this->systemFolderPid,
-                'object_type' => Event::TYPE_TOPIC,
+                'object_type' => EventInterface::TYPE_EVENT_TOPIC,
             ]
         );
         $this->testingFramework->createRecord(
             'tx_seminars_seminars',
             [
                 'pid' => $this->systemFolderPid,
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
                 'topic' => $topic,
                 'begin_date' => $GLOBALS['SIM_EXEC_TIME'] + 1000,
                 'end_date' => $GLOBALS['SIM_EXEC_TIME'] + 2000,
@@ -7769,14 +7770,14 @@ final class DefaultControllerTest extends TestCase
             'tx_seminars_seminars',
             [
                 'pid' => $this->systemFolderPid,
-                'object_type' => Event::TYPE_TOPIC,
+                'object_type' => EventInterface::TYPE_EVENT_TOPIC,
             ]
         );
         $dateUid = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
             [
                 'pid' => $this->systemFolderPid,
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
                 'topic' => $topicUId,
                 'begin_date' => $GLOBALS['SIM_EXEC_TIME'] + 1000,
                 'end_date' => $GLOBALS['SIM_EXEC_TIME'] + 2000,
@@ -7786,7 +7787,7 @@ final class DefaultControllerTest extends TestCase
             'tx_seminars_seminars',
             [
                 'pid' => $this->systemFolderPid,
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
                 'topic' => $topicUId,
                 'begin_date' => $GLOBALS['SIM_EXEC_TIME'] + 11000, // > 1 day after first date
                 'end_date' => $GLOBALS['SIM_EXEC_TIME'] + 12000,

--- a/Tests/LegacyUnit/FrontEnd/RegistrationsListTest.php
+++ b/Tests/LegacyUnit/FrontEnd/RegistrationsListTest.php
@@ -6,8 +6,8 @@ namespace OliverKlee\Seminars\Tests\LegacyUnit\FrontEnd;
 
 use OliverKlee\Oelib\Http\HeaderProxyFactory;
 use OliverKlee\Oelib\Testing\TestingFramework;
+use OliverKlee\Seminars\Domain\Model\Event\EventInterface;
 use OliverKlee\Seminars\FrontEnd\RegistrationsList;
-use OliverKlee\Seminars\Model\Event;
 use OliverKlee\Seminars\Service\RegistrationManager;
 use OliverKlee\Seminars\Tests\Functional\Traits\LanguageHelper;
 use PHPUnit\Framework\TestCase;
@@ -61,7 +61,7 @@ final class RegistrationsListTest extends TestCase
         $this->seminarUid = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
             [
-                'object_type' => Event::TYPE_COMPLETE,
+                'object_type' => EventInterface::TYPE_SINGLE_EVENT,
                 'title' => 'Test event & more',
                 'attendees_max' => 10,
                 'needs_registration' => 1,

--- a/Tests/LegacyUnit/FrontEnd/RequirementsListTest.php
+++ b/Tests/LegacyUnit/FrontEnd/RequirementsListTest.php
@@ -7,8 +7,8 @@ namespace OliverKlee\Seminars\Tests\LegacyUnit\FrontEnd;
 use OliverKlee\Oelib\Configuration\ConfigurationRegistry;
 use OliverKlee\Oelib\Configuration\DummyConfiguration;
 use OliverKlee\Oelib\Testing\TestingFramework;
+use OliverKlee\Seminars\Domain\Model\Event\EventInterface;
 use OliverKlee\Seminars\FrontEnd\RequirementsList;
-use OliverKlee\Seminars\Model\Event;
 use OliverKlee\Seminars\OldModel\LegacyEvent;
 use OliverKlee\Seminars\Service\RegistrationManager;
 use PHPUnit\Framework\TestCase;
@@ -108,12 +108,12 @@ final class RequirementsListTest extends TestCase
         $this->testingFramework->changeRecord(
             'tx_seminars_seminars',
             $this->seminarUid,
-            ['object_type' => Event::TYPE_TOPIC]
+            ['object_type' => EventInterface::TYPE_EVENT_TOPIC]
         );
         $requiredEvent = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
             [
-                'object_type' => Event::TYPE_TOPIC,
+                'object_type' => EventInterface::TYPE_EVENT_TOPIC,
                 'title' => 'required & foo',
             ]
         );
@@ -142,12 +142,12 @@ final class RequirementsListTest extends TestCase
         $this->testingFramework->changeRecord(
             'tx_seminars_seminars',
             $this->seminarUid,
-            ['object_type' => Event::TYPE_TOPIC]
+            ['object_type' => EventInterface::TYPE_EVENT_TOPIC]
         );
         $requiredEvent = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
             [
-                'object_type' => Event::TYPE_TOPIC,
+                'object_type' => EventInterface::TYPE_EVENT_TOPIC,
                 'title' => 'required_foo',
             ]
         );
@@ -173,12 +173,12 @@ final class RequirementsListTest extends TestCase
         $this->testingFramework->changeRecord(
             'tx_seminars_seminars',
             $this->seminarUid,
-            ['object_type' => Event::TYPE_TOPIC]
+            ['object_type' => EventInterface::TYPE_EVENT_TOPIC]
         );
         $requiredEvent1 = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
             [
-                'object_type' => Event::TYPE_TOPIC,
+                'object_type' => EventInterface::TYPE_EVENT_TOPIC,
                 'title' => 'required_foo',
             ]
         );
@@ -191,7 +191,7 @@ final class RequirementsListTest extends TestCase
         $requiredEvent2 = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
             [
-                'object_type' => Event::TYPE_TOPIC,
+                'object_type' => EventInterface::TYPE_EVENT_TOPIC,
                 'title' => 'required_bar',
             ]
         );
@@ -235,19 +235,19 @@ final class RequirementsListTest extends TestCase
         $this->testingFramework->changeRecord(
             'tx_seminars_seminars',
             $this->seminarUid,
-            ['object_type' => Event::TYPE_TOPIC]
+            ['object_type' => EventInterface::TYPE_EVENT_TOPIC]
         );
         $requiredEvent1 = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
             [
-                'object_type' => Event::TYPE_TOPIC,
+                'object_type' => EventInterface::TYPE_EVENT_TOPIC,
                 'title' => 'required_foo',
             ]
         );
         $this->testingFramework->createRecord(
             'tx_seminars_seminars',
             [
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
                 'topic' => $requiredEvent1,
             ]
         );
@@ -260,14 +260,14 @@ final class RequirementsListTest extends TestCase
         $requiredEvent2 = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
             [
-                'object_type' => Event::TYPE_TOPIC,
+                'object_type' => EventInterface::TYPE_EVENT_TOPIC,
                 'title' => 'required_bar',
             ]
         );
         $requiredDate2 = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
             [
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
                 'topic' => $requiredEvent2,
             ]
         );

--- a/Tests/LegacyUnit/Mapper/EventDateMapperTest.php
+++ b/Tests/LegacyUnit/Mapper/EventDateMapperTest.php
@@ -7,6 +7,7 @@ namespace OliverKlee\Seminars\Tests\LegacyUnit\Mapper;
 use OliverKlee\Oelib\DataStructures\Collection;
 use OliverKlee\Oelib\Mapper\MapperRegistry;
 use OliverKlee\Oelib\Testing\TestingFramework;
+use OliverKlee\Seminars\Domain\Model\Event\EventInterface;
 use OliverKlee\Seminars\Mapper\CategoryMapper;
 use OliverKlee\Seminars\Mapper\CheckboxMapper;
 use OliverKlee\Seminars\Mapper\EventMapper;
@@ -62,7 +63,7 @@ final class EventDateMapperTest extends TestCase
         $this->expectException(\BadMethodCallException::class);
 
         $model = $this->subject->getLoadedTestingModel(
-            ['object_type' => Event::TYPE_DATE]
+            ['object_type' => EventInterface::TYPE_EVENT_DATE]
         );
 
         $model->getTopic();
@@ -78,7 +79,7 @@ final class EventDateMapperTest extends TestCase
         $testingModel = $this->subject->getLoadedTestingModel(
             [
                 'topic' => $topic->getUid(),
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
             ]
         );
 
@@ -98,7 +99,7 @@ final class EventDateMapperTest extends TestCase
 
         $testingModel = $this->subject->getLoadedTestingModel(
             [
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
                 'topic' => $topicUid,
             ]
         );
@@ -115,7 +116,7 @@ final class EventDateMapperTest extends TestCase
         $uid = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
             [
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
                 'topic' => $topicUid,
             ]
         );
@@ -141,7 +142,7 @@ final class EventDateMapperTest extends TestCase
         $uid = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
             [
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
                 'topic' => $topicUid,
             ]
         );
@@ -171,7 +172,7 @@ final class EventDateMapperTest extends TestCase
         $topic = MapperRegistry::get(EventMapper::class)->getLoadedTestingModel([]);
         $testingModel = $this->subject->getLoadedTestingModel(
             [
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
                 'topic' => $topic->getUid(),
             ]
         );
@@ -189,7 +190,7 @@ final class EventDateMapperTest extends TestCase
             ->getLoadedTestingModel(['event_type' => $eventType->getUid()]);
         $testingModel = $this->subject->getLoadedTestingModel(
             [
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
                 'topic' => $topic->getUid(),
             ]
         );
@@ -207,7 +208,7 @@ final class EventDateMapperTest extends TestCase
         $topicUid = $this->testingFramework->createRecord('tx_seminars_seminars');
         $testingModel = $this->subject->getLoadedTestingModel(
             [
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
                 'topic' => $topicUid,
             ]
         );
@@ -228,7 +229,7 @@ final class EventDateMapperTest extends TestCase
         $uid = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
             [
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
                 'topic' => $topicUid,
             ]
         );
@@ -255,7 +256,7 @@ final class EventDateMapperTest extends TestCase
         $uid = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
             [
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
                 'topic' => $topicUid,
             ]
         );
@@ -284,7 +285,7 @@ final class EventDateMapperTest extends TestCase
         $topicUid = $this->testingFramework->createRecord('tx_seminars_seminars');
         $testingModel = $this->subject->getLoadedTestingModel(
             [
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
                 'topic' => $topicUid,
             ]
         );
@@ -301,7 +302,7 @@ final class EventDateMapperTest extends TestCase
         $uid = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
             [
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
                 'topic' => $topicUid,
             ]
         );
@@ -329,7 +330,7 @@ final class EventDateMapperTest extends TestCase
         $uid = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
             [
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
                 'topic' => $topicUid,
             ]
         );
@@ -360,7 +361,7 @@ final class EventDateMapperTest extends TestCase
         $topicUid = $this->testingFramework->createRecord('tx_seminars_seminars');
         $testingModel = $this->subject->getLoadedTestingModel(
             [
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
                 'topic' => $topicUid,
             ]
         );
@@ -377,7 +378,7 @@ final class EventDateMapperTest extends TestCase
         $uid = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
             [
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
                 'topic' => $topicUid,
             ]
         );
@@ -403,7 +404,7 @@ final class EventDateMapperTest extends TestCase
         $uid = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
             [
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
                 'topic' => $topicUid,
             ]
         );

--- a/Tests/LegacyUnit/Mapper/EventTopicMapperTest.php
+++ b/Tests/LegacyUnit/Mapper/EventTopicMapperTest.php
@@ -7,6 +7,7 @@ namespace OliverKlee\Seminars\Tests\LegacyUnit\Mapper;
 use OliverKlee\Oelib\DataStructures\Collection;
 use OliverKlee\Oelib\Mapper\MapperRegistry;
 use OliverKlee\Oelib\Testing\TestingFramework;
+use OliverKlee\Seminars\Domain\Model\Event\EventInterface;
 use OliverKlee\Seminars\Mapper\CategoryMapper;
 use OliverKlee\Seminars\Mapper\CheckboxMapper;
 use OliverKlee\Seminars\Mapper\EventMapper;
@@ -67,7 +68,7 @@ final class EventTopicMapperTest extends TestCase
         );
 
         $testingModel = $this->subject->getLoadedTestingModel(
-            ['object_type' => Event::TYPE_TOPIC]
+            ['object_type' => EventInterface::TYPE_EVENT_TOPIC]
         );
 
         $testingModel->getTopic();
@@ -81,7 +82,7 @@ final class EventTopicMapperTest extends TestCase
     public function getCategoriesForEventTopicReturnsListInstance(): void
     {
         $testingModel = $this->subject->getLoadedTestingModel(
-            ['object_type' => Event::TYPE_TOPIC]
+            ['object_type' => EventInterface::TYPE_EVENT_TOPIC]
         );
 
         self::assertInstanceOf(Collection::class, $testingModel->getCategories());
@@ -94,7 +95,7 @@ final class EventTopicMapperTest extends TestCase
     {
         $uid = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
-            ['object_type' => Event::TYPE_TOPIC]
+            ['object_type' => EventInterface::TYPE_EVENT_TOPIC]
         );
         $category = MapperRegistry::get(CategoryMapper::class)
             ->getNewGhost();
@@ -116,7 +117,7 @@ final class EventTopicMapperTest extends TestCase
     {
         $uid = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
-            ['object_type' => Event::TYPE_TOPIC]
+            ['object_type' => EventInterface::TYPE_EVENT_TOPIC]
         );
         $category = MapperRegistry::get(CategoryMapper::class)
             ->getNewGhost();
@@ -142,7 +143,7 @@ final class EventTopicMapperTest extends TestCase
     public function getEventTypeForEventTopicWithoutEventTypeReturnsNull(): void
     {
         $testingModel = $this->subject->getLoadedTestingModel(
-            ['object_type' => Event::TYPE_TOPIC]
+            ['object_type' => EventInterface::TYPE_EVENT_TOPIC]
         );
 
         self::assertNull($testingModel->getEventType());
@@ -157,7 +158,7 @@ final class EventTopicMapperTest extends TestCase
             ->getLoadedTestingModel([]);
         $testingModel = $this->subject->getLoadedTestingModel(
             [
-                'object_type' => Event::TYPE_TOPIC,
+                'object_type' => EventInterface::TYPE_EVENT_TOPIC,
                 'event_type' => $eventType->getUid(),
             ]
         );
@@ -173,7 +174,7 @@ final class EventTopicMapperTest extends TestCase
     public function getPaymentMethodsForEventTopicReturnsListInstance(): void
     {
         $testingModel = $this->subject->getLoadedTestingModel(
-            ['object_type' => Event::TYPE_TOPIC]
+            ['object_type' => EventInterface::TYPE_EVENT_TOPIC]
         );
 
         self::assertInstanceOf(Collection::class, $testingModel->getPaymentMethods());
@@ -188,7 +189,7 @@ final class EventTopicMapperTest extends TestCase
         $uid = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
             [
-                'object_type' => Event::TYPE_TOPIC,
+                'object_type' => EventInterface::TYPE_EVENT_TOPIC,
                 'payment_methods' => 1,
             ]
         );
@@ -211,7 +212,7 @@ final class EventTopicMapperTest extends TestCase
         $uid = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
             [
-                'object_type' => Event::TYPE_TOPIC,
+                'object_type' => EventInterface::TYPE_EVENT_TOPIC,
                 'payment_methods' => 1,
             ]
         );
@@ -236,7 +237,7 @@ final class EventTopicMapperTest extends TestCase
     public function getTargetGroupsForEventTopicReturnsListInstance(): void
     {
         $testingModel = $this->subject->getLoadedTestingModel(
-            ['object_type' => Event::TYPE_TOPIC]
+            ['object_type' => EventInterface::TYPE_EVENT_TOPIC]
         );
 
         self::assertInstanceOf(Collection::class, $testingModel->getTargetGroups());
@@ -249,7 +250,7 @@ final class EventTopicMapperTest extends TestCase
     {
         $uid = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
-            ['object_type' => Event::TYPE_TOPIC]
+            ['object_type' => EventInterface::TYPE_EVENT_TOPIC]
         );
         $targetGroup = MapperRegistry::get(TargetGroupMapper::class)->getNewGhost();
         $this->testingFramework->createRelationAndUpdateCounter(
@@ -273,7 +274,7 @@ final class EventTopicMapperTest extends TestCase
     {
         $uid = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
-            ['object_type' => Event::TYPE_TOPIC]
+            ['object_type' => EventInterface::TYPE_EVENT_TOPIC]
         );
         $targetGroup = MapperRegistry::get(TargetGroupMapper::class)->getNewGhost();
         $this->testingFramework->createRelationAndUpdateCounter(
@@ -298,7 +299,7 @@ final class EventTopicMapperTest extends TestCase
     public function getCheckboxesForEventTopicReturnsListInstance(): void
     {
         $testingModel = $this->subject->getLoadedTestingModel(
-            ['object_type' => Event::TYPE_TOPIC]
+            ['object_type' => EventInterface::TYPE_EVENT_TOPIC]
         );
 
         self::assertInstanceOf(Collection::class, $testingModel->getCheckboxes());
@@ -311,7 +312,7 @@ final class EventTopicMapperTest extends TestCase
     {
         $uid = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
-            ['object_type' => Event::TYPE_TOPIC]
+            ['object_type' => EventInterface::TYPE_EVENT_TOPIC]
         );
         $checkbox = MapperRegistry::get(CheckboxMapper::class)
             ->getNewGhost();
@@ -333,7 +334,7 @@ final class EventTopicMapperTest extends TestCase
     {
         $uid = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
-            ['object_type' => Event::TYPE_TOPIC]
+            ['object_type' => EventInterface::TYPE_EVENT_TOPIC]
         );
         $checkbox = MapperRegistry::get(CheckboxMapper::class)
             ->getNewGhost();

--- a/Tests/LegacyUnit/Mapper/SingleEventMapperTest.php
+++ b/Tests/LegacyUnit/Mapper/SingleEventMapperTest.php
@@ -7,6 +7,7 @@ namespace OliverKlee\Seminars\Tests\LegacyUnit\Mapper;
 use OliverKlee\Oelib\DataStructures\Collection;
 use OliverKlee\Oelib\Mapper\MapperRegistry;
 use OliverKlee\Oelib\Testing\TestingFramework;
+use OliverKlee\Seminars\Domain\Model\Event\EventInterface;
 use OliverKlee\Seminars\Mapper\CategoryMapper;
 use OliverKlee\Seminars\Mapper\CheckboxMapper;
 use OliverKlee\Seminars\Mapper\EventMapper;
@@ -15,7 +16,6 @@ use OliverKlee\Seminars\Mapper\PaymentMethodMapper;
 use OliverKlee\Seminars\Mapper\TargetGroupMapper;
 use OliverKlee\Seminars\Model\Category;
 use OliverKlee\Seminars\Model\Checkbox;
-use OliverKlee\Seminars\Model\Event;
 use OliverKlee\Seminars\Model\EventType;
 use OliverKlee\Seminars\Model\PaymentMethod;
 use OliverKlee\Seminars\Model\TargetGroup;
@@ -65,7 +65,7 @@ final class SingleEventMapperTest extends TestCase
         );
 
         $testingModel = $this->subject->getLoadedTestingModel(
-            ['object_type' => Event::TYPE_COMPLETE]
+            ['object_type' => EventInterface::TYPE_SINGLE_EVENT]
         );
 
         $testingModel->getTopic();
@@ -79,7 +79,7 @@ final class SingleEventMapperTest extends TestCase
     public function getCategoriesForSingleEventReturnsListInstance(): void
     {
         $testingModel = $this->subject->getLoadedTestingModel(
-            ['object_type' => Event::TYPE_COMPLETE]
+            ['object_type' => EventInterface::TYPE_SINGLE_EVENT]
         );
 
         self::assertInstanceOf(Collection::class, $testingModel->getCategories());
@@ -92,7 +92,7 @@ final class SingleEventMapperTest extends TestCase
     {
         $uid = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
-            ['object_type' => Event::TYPE_COMPLETE]
+            ['object_type' => EventInterface::TYPE_SINGLE_EVENT]
         );
         $category = MapperRegistry::get(CategoryMapper::class)
             ->getNewGhost();
@@ -114,7 +114,7 @@ final class SingleEventMapperTest extends TestCase
     {
         $uid = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
-            ['object_type' => Event::TYPE_COMPLETE]
+            ['object_type' => EventInterface::TYPE_SINGLE_EVENT]
         );
         $category = MapperRegistry::get(CategoryMapper::class)->getNewGhost();
         $this->testingFramework->createRelationAndUpdateCounter(
@@ -139,7 +139,7 @@ final class SingleEventMapperTest extends TestCase
     public function getEventTypeForSingleEventWithoutEventTypeReturnsNull(): void
     {
         $testingModel = $this->subject->getLoadedTestingModel(
-            ['object_type' => Event::TYPE_COMPLETE]
+            ['object_type' => EventInterface::TYPE_SINGLE_EVENT]
         );
 
         self::assertNull($testingModel->getEventType());
@@ -154,7 +154,7 @@ final class SingleEventMapperTest extends TestCase
             ->getLoadedTestingModel([]);
         $testingModel = $this->subject->getLoadedTestingModel(
             [
-                'object_type' => Event::TYPE_COMPLETE,
+                'object_type' => EventInterface::TYPE_SINGLE_EVENT,
                 'event_type' => $eventType->getUid(),
             ]
         );
@@ -170,7 +170,7 @@ final class SingleEventMapperTest extends TestCase
     public function getPaymentMethodsForSingleEventReturnsListInstance(): void
     {
         $testingModel = $this->subject->getLoadedTestingModel(
-            ['object_type' => Event::TYPE_COMPLETE]
+            ['object_type' => EventInterface::TYPE_SINGLE_EVENT]
         );
 
         self::assertInstanceOf(Collection::class, $testingModel->getPaymentMethods());
@@ -185,7 +185,7 @@ final class SingleEventMapperTest extends TestCase
         $uid = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
             [
-                'object_type' => Event::TYPE_COMPLETE,
+                'object_type' => EventInterface::TYPE_SINGLE_EVENT,
                 'payment_methods' => 1,
             ]
         );
@@ -208,7 +208,7 @@ final class SingleEventMapperTest extends TestCase
         $uid = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
             [
-                'object_type' => Event::TYPE_COMPLETE,
+                'object_type' => EventInterface::TYPE_SINGLE_EVENT,
                 'payment_methods' => 1,
             ]
         );
@@ -235,7 +235,7 @@ final class SingleEventMapperTest extends TestCase
     public function getTargetGroupsForSingleEventReturnsListInstance(): void
     {
         $testingModel = $this->subject->getLoadedTestingModel(
-            ['object_type' => Event::TYPE_COMPLETE]
+            ['object_type' => EventInterface::TYPE_SINGLE_EVENT]
         );
 
         self::assertInstanceOf(Collection::class, $testingModel->getTargetGroups());
@@ -248,7 +248,7 @@ final class SingleEventMapperTest extends TestCase
     {
         $uid = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
-            ['object_type' => Event::TYPE_COMPLETE]
+            ['object_type' => EventInterface::TYPE_SINGLE_EVENT]
         );
         $targetGroup = MapperRegistry::get(TargetGroupMapper::class)->getNewGhost();
         $this->testingFramework->createRelationAndUpdateCounter(
@@ -272,7 +272,7 @@ final class SingleEventMapperTest extends TestCase
     {
         $uid = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
-            ['object_type' => Event::TYPE_COMPLETE]
+            ['object_type' => EventInterface::TYPE_SINGLE_EVENT]
         );
         $targetGroup = MapperRegistry::get(TargetGroupMapper::class)->getNewGhost();
         $this->testingFramework->createRelationAndUpdateCounter(
@@ -295,7 +295,7 @@ final class SingleEventMapperTest extends TestCase
     public function getTargetGroupsForEventTopicReturnsListInstance(): void
     {
         $testingModel = $this->subject->getLoadedTestingModel(
-            ['object_type' => Event::TYPE_TOPIC]
+            ['object_type' => EventInterface::TYPE_EVENT_TOPIC]
         );
 
         self::assertInstanceOf(Collection::class, $testingModel->getTargetGroups());
@@ -308,7 +308,7 @@ final class SingleEventMapperTest extends TestCase
     {
         $uid = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
-            ['object_type' => Event::TYPE_TOPIC]
+            ['object_type' => EventInterface::TYPE_EVENT_TOPIC]
         );
         $targetGroup = MapperRegistry::get(TargetGroupMapper::class)->getNewGhost();
         $this->testingFramework->createRelationAndUpdateCounter(
@@ -332,7 +332,7 @@ final class SingleEventMapperTest extends TestCase
     {
         $uid = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
-            ['object_type' => Event::TYPE_TOPIC]
+            ['object_type' => EventInterface::TYPE_EVENT_TOPIC]
         );
         $targetGroup = MapperRegistry::get(TargetGroupMapper::class)->getNewGhost();
         $this->testingFramework->createRelationAndUpdateCounter(
@@ -357,7 +357,7 @@ final class SingleEventMapperTest extends TestCase
     public function getCheckboxesForSingleEventReturnsListInstance(): void
     {
         $testingModel = $this->subject->getLoadedTestingModel(
-            ['object_type' => Event::TYPE_COMPLETE]
+            ['object_type' => EventInterface::TYPE_SINGLE_EVENT]
         );
 
         self::assertInstanceOf(Collection::class, $testingModel->getCheckboxes());
@@ -370,7 +370,7 @@ final class SingleEventMapperTest extends TestCase
     {
         $uid = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
-            ['object_type' => Event::TYPE_COMPLETE]
+            ['object_type' => EventInterface::TYPE_SINGLE_EVENT]
         );
         $checkbox = MapperRegistry::get(CheckboxMapper::class)
             ->getNewGhost();
@@ -392,7 +392,7 @@ final class SingleEventMapperTest extends TestCase
     {
         $uid = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
-            ['object_type' => Event::TYPE_COMPLETE]
+            ['object_type' => EventInterface::TYPE_SINGLE_EVENT]
         );
         $checkbox = MapperRegistry::get(CheckboxMapper::class)
             ->getNewGhost();

--- a/Tests/LegacyUnit/Model/EventDateTest.php
+++ b/Tests/LegacyUnit/Model/EventDateTest.php
@@ -6,6 +6,7 @@ namespace OliverKlee\Seminars\Tests\LegacyUnit\Model;
 
 use OliverKlee\Oelib\DataStructures\Collection;
 use OliverKlee\Oelib\Mapper\MapperRegistry;
+use OliverKlee\Seminars\Domain\Model\Event\EventInterface;
 use OliverKlee\Seminars\Mapper\EventMapper;
 use OliverKlee\Seminars\Model\Event;
 use OliverKlee\Seminars\Model\PaymentMethod;
@@ -39,7 +40,7 @@ final class EventDateTest extends TestCase
             ->getLoadedTestingModel(['title' => 'Superhero']);
         $this->subject->setData(
             [
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
                 'topic' => $topic,
                 'title' => 'Supervillain',
             ]
@@ -59,7 +60,7 @@ final class EventDateTest extends TestCase
         $topic = MapperRegistry::get(EventMapper::class)->getLoadedTestingModel(['title' => 'Superhero']);
         $this->subject->setData(
             [
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
                 'topic' => $topic,
                 'title' => 'Supervillain',
             ]
@@ -82,7 +83,7 @@ final class EventDateTest extends TestCase
             ->getLoadedTestingModel([]);
         $this->subject->setData(
             [
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
                 'topic' => $topic,
             ]
         );
@@ -102,7 +103,7 @@ final class EventDateTest extends TestCase
             ->getLoadedTestingModel(['subtitle' => 'sub title']);
         $this->subject->setData(
             [
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
                 'topic' => $topic,
             ]
         );
@@ -121,7 +122,7 @@ final class EventDateTest extends TestCase
         $topic = MapperRegistry::get(EventMapper::class)->getLoadedTestingModel([]);
         $this->subject->setData(
             [
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
                 'topic' => $topic,
             ]
         );
@@ -142,7 +143,7 @@ final class EventDateTest extends TestCase
             ->getLoadedTestingModel([]);
         $this->subject->setData(
             [
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
                 'topic' => $topic,
             ]
         );
@@ -161,7 +162,7 @@ final class EventDateTest extends TestCase
             ->getLoadedTestingModel(['subtitle' => 'sub title']);
         $this->subject->setData(
             [
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
                 'topic' => $topic,
             ]
         );
@@ -182,7 +183,7 @@ final class EventDateTest extends TestCase
             ->getLoadedTestingModel([]);
         $this->subject->setData(
             [
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
                 'topic' => $topic,
             ]
         );
@@ -202,7 +203,7 @@ final class EventDateTest extends TestCase
             ->getLoadedTestingModel(['teaser' => 'wow, this is teasing']);
         $this->subject->setData(
             [
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
                 'topic' => $topic,
             ]
         );
@@ -222,7 +223,7 @@ final class EventDateTest extends TestCase
         $topic = MapperRegistry::get(EventMapper::class)->getLoadedTestingModel([]);
         $this->subject->setData(
             [
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
                 'topic' => $topic,
             ]
         );
@@ -243,7 +244,7 @@ final class EventDateTest extends TestCase
             ->getLoadedTestingModel([]);
         $this->subject->setData(
             [
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
                 'topic' => $topic,
             ]
         );
@@ -262,7 +263,7 @@ final class EventDateTest extends TestCase
             ->getLoadedTestingModel(['teaser' => 'wow, this is teasing']);
         $this->subject->setData(
             [
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
                 'topic' => $topic,
             ]
         );
@@ -283,7 +284,7 @@ final class EventDateTest extends TestCase
             ->getLoadedTestingModel([]);
         $this->subject->setData(
             [
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
                 'topic' => $topic,
             ]
         );
@@ -305,7 +306,7 @@ final class EventDateTest extends TestCase
             );
         $this->subject->setData(
             [
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
                 'topic' => $topic,
             ]
         );
@@ -324,7 +325,7 @@ final class EventDateTest extends TestCase
         $topic = MapperRegistry::get(EventMapper::class)->getLoadedTestingModel([]);
         $this->subject->setData(
             [
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
                 'topic' => $topic,
             ]
         );
@@ -345,7 +346,7 @@ final class EventDateTest extends TestCase
             ->getLoadedTestingModel([]);
         $this->subject->setData(
             [
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
                 'topic' => $topic,
             ]
         );
@@ -366,7 +367,7 @@ final class EventDateTest extends TestCase
             );
         $this->subject->setData(
             [
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
                 'topic' => $topic,
             ]
         );
@@ -387,7 +388,7 @@ final class EventDateTest extends TestCase
             ->getLoadedTestingModel([]);
         $this->subject->setData(
             [
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
                 'topic' => $topic,
             ]
         );
@@ -407,7 +408,7 @@ final class EventDateTest extends TestCase
             ->getLoadedTestingModel(['credit_points' => 42]);
         $this->subject->setData(
             [
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
                 'topic' => $topic,
             ]
         );
@@ -426,7 +427,7 @@ final class EventDateTest extends TestCase
         $topic = MapperRegistry::get(EventMapper::class)->getLoadedTestingModel([]);
         $this->subject->setData(
             [
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
                 'topic' => $topic,
             ]
         );
@@ -447,7 +448,7 @@ final class EventDateTest extends TestCase
         $topic = MapperRegistry::get(EventMapper::class)->getLoadedTestingModel([]);
         $this->subject->setData(
             [
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
                 'topic' => $topic,
             ]
         );
@@ -468,7 +469,7 @@ final class EventDateTest extends TestCase
             ->getLoadedTestingModel([]);
         $this->subject->setData(
             [
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
                 'topic' => $topic,
             ]
         );
@@ -487,7 +488,7 @@ final class EventDateTest extends TestCase
             ->getLoadedTestingModel(['credit_points' => 42]);
         $this->subject->setData(
             [
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
                 'topic' => $topic,
             ]
         );
@@ -508,7 +509,7 @@ final class EventDateTest extends TestCase
             ->getLoadedTestingModel(['price_regular' => '0.0']);
         $this->subject->setData(
             [
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
                 'topic' => $topic,
             ]
         );
@@ -528,7 +529,7 @@ final class EventDateTest extends TestCase
             ->getLoadedTestingModel(['price_regular' => '42.42']);
         $this->subject->setData(
             [
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
                 'topic' => $topic,
             ]
         );
@@ -547,7 +548,7 @@ final class EventDateTest extends TestCase
         $topic = MapperRegistry::get(EventMapper::class)->getLoadedTestingModel([]);
         $this->subject->setData(
             [
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
                 'topic' => $topic,
             ]
         );
@@ -567,7 +568,7 @@ final class EventDateTest extends TestCase
         $topic = MapperRegistry::get(EventMapper::class)->getLoadedTestingModel([]);
         $this->subject->setData(
             [
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
                 'topic' => $topic,
             ]
         );
@@ -588,7 +589,7 @@ final class EventDateTest extends TestCase
             ->getLoadedTestingModel([]);
         $this->subject->setData(
             [
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
                 'topic' => $topic,
             ]
         );
@@ -607,7 +608,7 @@ final class EventDateTest extends TestCase
             ->getLoadedTestingModel(['price_regular' => '42.42']);
         $this->subject->setData(
             [
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
                 'topic' => $topic,
             ]
         );
@@ -628,7 +629,7 @@ final class EventDateTest extends TestCase
             ->getLoadedTestingModel([]);
         $this->subject->setData(
             [
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
                 'topic' => $topic,
             ]
         );
@@ -648,7 +649,7 @@ final class EventDateTest extends TestCase
             ->getLoadedTestingModel(['price_regular_early' => '42.42']);
         $this->subject->setData(
             [
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
                 'topic' => $topic,
             ]
         );
@@ -667,7 +668,7 @@ final class EventDateTest extends TestCase
         $topic = MapperRegistry::get(EventMapper::class)->getLoadedTestingModel([]);
         $this->subject->setData(
             [
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
                 'topic' => $topic,
             ]
         );
@@ -687,7 +688,7 @@ final class EventDateTest extends TestCase
         $topic = MapperRegistry::get(EventMapper::class)->getLoadedTestingModel([]);
         $this->subject->setData(
             [
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
                 'topic' => $topic,
             ]
         );
@@ -708,7 +709,7 @@ final class EventDateTest extends TestCase
             ->getLoadedTestingModel([]);
         $this->subject->setData(
             [
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
                 'topic' => $topic,
             ]
         );
@@ -727,7 +728,7 @@ final class EventDateTest extends TestCase
             ->getLoadedTestingModel(['price_regular_early' => '42.42']);
         $this->subject->setData(
             [
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
                 'topic' => $topic,
             ]
         );
@@ -748,7 +749,7 @@ final class EventDateTest extends TestCase
             ->getLoadedTestingModel([]);
         $this->subject->setData(
             [
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
                 'topic' => $topic,
             ]
         );
@@ -768,7 +769,7 @@ final class EventDateTest extends TestCase
             ->getLoadedTestingModel(['price_regular_board' => '42.42']);
         $this->subject->setData(
             [
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
                 'topic' => $topic,
             ]
         );
@@ -787,7 +788,7 @@ final class EventDateTest extends TestCase
         $topic = MapperRegistry::get(EventMapper::class)->getLoadedTestingModel([]);
         $this->subject->setData(
             [
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
                 'topic' => $topic,
             ]
         );
@@ -807,7 +808,7 @@ final class EventDateTest extends TestCase
         $topic = MapperRegistry::get(EventMapper::class)->getLoadedTestingModel([]);
         $this->subject->setData(
             [
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
                 'topic' => $topic,
             ]
         );
@@ -828,7 +829,7 @@ final class EventDateTest extends TestCase
             ->getLoadedTestingModel([]);
         $this->subject->setData(
             [
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
                 'topic' => $topic,
             ]
         );
@@ -847,7 +848,7 @@ final class EventDateTest extends TestCase
             ->getLoadedTestingModel(['price_regular_board' => '42.42']);
         $this->subject->setData(
             [
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
                 'topic' => $topic,
             ]
         );
@@ -868,7 +869,7 @@ final class EventDateTest extends TestCase
             ->getLoadedTestingModel([]);
         $this->subject->setData(
             [
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
                 'topic' => $topic,
             ]
         );
@@ -888,7 +889,7 @@ final class EventDateTest extends TestCase
             ->getLoadedTestingModel(['price_special' => '42.42']);
         $this->subject->setData(
             [
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
                 'topic' => $topic,
             ]
         );
@@ -907,7 +908,7 @@ final class EventDateTest extends TestCase
         $topic = MapperRegistry::get(EventMapper::class)->getLoadedTestingModel([]);
         $this->subject->setData(
             [
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
                 'topic' => $topic,
             ]
         );
@@ -927,7 +928,7 @@ final class EventDateTest extends TestCase
         $topic = MapperRegistry::get(EventMapper::class)->getLoadedTestingModel([]);
         $this->subject->setData(
             [
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
                 'topic' => $topic,
             ]
         );
@@ -948,7 +949,7 @@ final class EventDateTest extends TestCase
             ->getLoadedTestingModel([]);
         $this->subject->setData(
             [
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
                 'topic' => $topic,
             ]
         );
@@ -967,7 +968,7 @@ final class EventDateTest extends TestCase
             ->getLoadedTestingModel(['price_special' => '42.42']);
         $this->subject->setData(
             [
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
                 'topic' => $topic,
             ]
         );
@@ -988,7 +989,7 @@ final class EventDateTest extends TestCase
             ->getLoadedTestingModel([]);
         $this->subject->setData(
             [
-                'object_type' => Event::TYPE_COMPLETE,
+                'object_type' => EventInterface::TYPE_SINGLE_EVENT,
                 'topic' => $topic,
             ]
         );
@@ -1008,7 +1009,7 @@ final class EventDateTest extends TestCase
             ->getLoadedTestingModel(['price_special_early' => '42.42']);
         $this->subject->setData(
             [
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
                 'topic' => $topic,
             ]
         );
@@ -1027,7 +1028,7 @@ final class EventDateTest extends TestCase
         $topic = MapperRegistry::get(EventMapper::class)->getLoadedTestingModel([]);
         $this->subject->setData(
             [
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
                 'topic' => $topic,
             ]
         );
@@ -1047,7 +1048,7 @@ final class EventDateTest extends TestCase
         $topic = MapperRegistry::get(EventMapper::class)->getLoadedTestingModel([]);
         $this->subject->setData(
             [
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
                 'topic' => $topic,
             ]
         );
@@ -1068,7 +1069,7 @@ final class EventDateTest extends TestCase
             ->getLoadedTestingModel([]);
         $this->subject->setData(
             [
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
                 'topic' => $topic,
             ]
         );
@@ -1087,7 +1088,7 @@ final class EventDateTest extends TestCase
             ->getLoadedTestingModel(['price_special_early' => '42.42']);
         $this->subject->setData(
             [
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
                 'topic' => $topic,
             ]
         );
@@ -1108,7 +1109,7 @@ final class EventDateTest extends TestCase
             ->getLoadedTestingModel([]);
         $this->subject->setData(
             [
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
                 'topic' => $topic,
             ]
         );
@@ -1128,7 +1129,7 @@ final class EventDateTest extends TestCase
             ->getLoadedTestingModel(['price_special_board' => '42.42']);
         $this->subject->setData(
             [
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
                 'topic' => $topic,
             ]
         );
@@ -1147,7 +1148,7 @@ final class EventDateTest extends TestCase
         $topic = MapperRegistry::get(EventMapper::class)->getLoadedTestingModel([]);
         $this->subject->setData(
             [
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
                 'topic' => $topic,
             ]
         );
@@ -1167,7 +1168,7 @@ final class EventDateTest extends TestCase
         $topic = MapperRegistry::get(EventMapper::class)->getLoadedTestingModel([]);
         $this->subject->setData(
             [
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
                 'topic' => $topic,
             ]
         );
@@ -1188,7 +1189,7 @@ final class EventDateTest extends TestCase
             ->getLoadedTestingModel([]);
         $this->subject->setData(
             [
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
                 'topic' => $topic,
             ]
         );
@@ -1207,7 +1208,7 @@ final class EventDateTest extends TestCase
             ->getLoadedTestingModel(['price_special_board' => '42.42']);
         $this->subject->setData(
             [
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
                 'topic' => $topic,
             ]
         );
@@ -1228,7 +1229,7 @@ final class EventDateTest extends TestCase
             ->getLoadedTestingModel([]);
         $this->subject->setData(
             [
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
                 'topic' => $topic,
             ]
         );
@@ -1250,7 +1251,7 @@ final class EventDateTest extends TestCase
             );
         $this->subject->setData(
             [
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
                 'topic' => $topic,
             ]
         );
@@ -1269,7 +1270,7 @@ final class EventDateTest extends TestCase
         $topic = MapperRegistry::get(EventMapper::class)->getLoadedTestingModel([]);
         $this->subject->setData(
             [
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
                 'topic' => $topic,
             ]
         );
@@ -1290,7 +1291,7 @@ final class EventDateTest extends TestCase
             ->getLoadedTestingModel([]);
         $this->subject->setData(
             [
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
                 'topic' => $topic,
             ]
         );
@@ -1311,7 +1312,7 @@ final class EventDateTest extends TestCase
             );
         $this->subject->setData(
             [
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
                 'topic' => $topic,
             ]
         );
@@ -1332,7 +1333,7 @@ final class EventDateTest extends TestCase
             ->getLoadedTestingModel([]);
         $this->subject->setData(
             [
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
                 'topic' => $topic,
             ]
         );
@@ -1351,7 +1352,7 @@ final class EventDateTest extends TestCase
             ->getLoadedTestingModel(['allows_multiple_registrations' => 1]);
         $this->subject->setData(
             [
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
                 'topic' => $topic,
             ]
         );
@@ -1372,7 +1373,7 @@ final class EventDateTest extends TestCase
             ->getLoadedTestingModel([]);
         $this->subject->setData(
             [
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
                 'topic' => $topic,
             ]
         );
@@ -1390,7 +1391,7 @@ final class EventDateTest extends TestCase
         $topic = MapperRegistry::get(EventMapper::class)->getLoadedTestingModel(['use_terms_2' => 1]);
         $this->subject->setData(
             [
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
                 'topic' => $topic,
             ]
         );
@@ -1411,7 +1412,7 @@ final class EventDateTest extends TestCase
             ->getLoadedTestingModel([]);
         $this->subject->setData(
             [
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
                 'topic' => $topic,
             ]
         );
@@ -1431,7 +1432,7 @@ final class EventDateTest extends TestCase
             ->getLoadedTestingModel(['notes' => 'Don\'t forget this.']);
         $this->subject->setData(
             [
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
                 'topic' => $topic,
             ]
         );
@@ -1450,7 +1451,7 @@ final class EventDateTest extends TestCase
         $topic = MapperRegistry::get(EventMapper::class)->getLoadedTestingModel([]);
         $this->subject->setData(
             [
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
                 'topic' => $topic,
             ]
         );
@@ -1471,7 +1472,7 @@ final class EventDateTest extends TestCase
             ->getLoadedTestingModel([]);
         $this->subject->setData(
             [
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
                 'topic' => $topic,
             ]
         );
@@ -1490,7 +1491,7 @@ final class EventDateTest extends TestCase
             ->getLoadedTestingModel(['notes' => 'Don\'t forget this.']);
         $this->subject->setData(
             [
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
                 'topic' => $topic,
             ]
         );
@@ -1513,7 +1514,7 @@ final class EventDateTest extends TestCase
         $topic->setData(['payment_methods' => $paymentMethods]);
         $this->subject->setData(
             [
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
                 'topic' => $topic,
             ]
         );
@@ -1540,7 +1541,7 @@ final class EventDateTest extends TestCase
         $topic = new Event();
         $this->subject->setData(
             [
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
                 'topic' => $topic,
             ]
         );
@@ -1561,7 +1562,7 @@ final class EventDateTest extends TestCase
         $topic->setData(['price_on_request' => true]);
         $this->subject->setData(
             [
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
                 'topic' => $topic,
             ]
         );

--- a/Tests/LegacyUnit/Model/EventTest.php
+++ b/Tests/LegacyUnit/Model/EventTest.php
@@ -9,6 +9,7 @@ use OliverKlee\Oelib\Configuration\DummyConfiguration;
 use OliverKlee\Oelib\DataStructures\Collection;
 use OliverKlee\Oelib\Mapper\LanguageMapper;
 use OliverKlee\Oelib\Mapper\MapperRegistry;
+use OliverKlee\Seminars\Domain\Model\Event\EventInterface;
 use OliverKlee\Seminars\Mapper\RegistrationMapper;
 use OliverKlee\Seminars\Model\Category;
 use OliverKlee\Seminars\Model\Event;
@@ -64,7 +65,7 @@ final class EventTest extends TestCase
     public function isSingleEventForSingleRecordReturnsTrue(): void
     {
         $this->subject->setData(
-            ['object_type' => Event::TYPE_COMPLETE]
+            ['object_type' => EventInterface::TYPE_SINGLE_EVENT]
         );
 
         self::assertTrue(
@@ -78,7 +79,7 @@ final class EventTest extends TestCase
     public function isSingleEventForTopicRecordReturnsFalse(): void
     {
         $this->subject->setData(
-            ['object_type' => Event::TYPE_TOPIC]
+            ['object_type' => EventInterface::TYPE_EVENT_TOPIC]
         );
 
         self::assertFalse(
@@ -92,7 +93,7 @@ final class EventTest extends TestCase
     public function isSingleEventForDateRecordReturnsFalse(): void
     {
         $this->subject->setData(
-            ['object_type' => Event::TYPE_DATE]
+            ['object_type' => EventInterface::TYPE_EVENT_DATE]
         );
 
         self::assertFalse(
@@ -110,7 +111,7 @@ final class EventTest extends TestCase
     public function isEventDateForSingleRecordReturnsFalse(): void
     {
         $this->subject->setData(
-            ['object_type' => Event::TYPE_COMPLETE]
+            ['object_type' => EventInterface::TYPE_SINGLE_EVENT]
         );
 
         self::assertFalse(
@@ -124,7 +125,7 @@ final class EventTest extends TestCase
     public function isEventDateForTopicRecordReturnsFalse(): void
     {
         $this->subject->setData(
-            ['object_type' => Event::TYPE_TOPIC]
+            ['object_type' => EventInterface::TYPE_EVENT_TOPIC]
         );
 
         self::assertFalse(
@@ -139,7 +140,7 @@ final class EventTest extends TestCase
     {
         $this->subject->setData(
             [
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
                 'topic' => new Event(),
             ]
         );
@@ -156,7 +157,7 @@ final class EventTest extends TestCase
     {
         $this->subject->setData(
             [
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
                 'topic' => null,
             ]
         );
@@ -176,11 +177,11 @@ final class EventTest extends TestCase
     public function getRecordTypeWithRecordTypeCompleteReturnsRecordTypeComplete(): void
     {
         $this->subject->setData(
-            ['object_type' => Event::TYPE_COMPLETE]
+            ['object_type' => EventInterface::TYPE_SINGLE_EVENT]
         );
 
         self::assertEquals(
-            Event::TYPE_COMPLETE,
+            EventInterface::TYPE_SINGLE_EVENT,
             $this->subject->getRecordType()
         );
     }
@@ -191,11 +192,11 @@ final class EventTest extends TestCase
     public function getRecordTypeWithRecordTypeDateReturnsRecordTypeDate(): void
     {
         $this->subject->setData(
-            ['object_type' => Event::TYPE_DATE]
+            ['object_type' => EventInterface::TYPE_EVENT_DATE]
         );
 
         self::assertEquals(
-            Event::TYPE_DATE,
+            EventInterface::TYPE_EVENT_DATE,
             $this->subject->getRecordType()
         );
     }
@@ -206,11 +207,11 @@ final class EventTest extends TestCase
     public function getRecordTypeWithRecordTypeTopicReturnsRecordTypeTopic(): void
     {
         $this->subject->setData(
-            ['object_type' => Event::TYPE_TOPIC]
+            ['object_type' => EventInterface::TYPE_EVENT_TOPIC]
         );
 
         self::assertEquals(
-            Event::TYPE_TOPIC,
+            EventInterface::TYPE_EVENT_TOPIC,
             $this->subject->getRecordType()
         );
     }

--- a/Tests/LegacyUnit/Model/EventTopicTest.php
+++ b/Tests/LegacyUnit/Model/EventTopicTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace OliverKlee\Seminars\Tests\LegacyUnit\Model;
 
 use OliverKlee\Oelib\DataStructures\Collection;
+use OliverKlee\Seminars\Domain\Model\Event\EventInterface;
 use OliverKlee\Seminars\Model\Event;
 use OliverKlee\Seminars\Model\PaymentMethod;
 use PHPUnit\Framework\TestCase;
@@ -68,7 +69,7 @@ final class EventTopicTest extends TestCase
     public function getSubtitleForEventTopicWithoutSubtitleReturnsAnEmptyString(): void
     {
         $this->subject->setData(
-            ['object_type' => Event::TYPE_TOPIC]
+            ['object_type' => EventInterface::TYPE_EVENT_TOPIC]
         );
 
         self::assertEquals(
@@ -84,7 +85,7 @@ final class EventTopicTest extends TestCase
     {
         $this->subject->setData(
             [
-                'object_type' => Event::TYPE_TOPIC,
+                'object_type' => EventInterface::TYPE_EVENT_TOPIC,
                 'subtitle' => 'sub title',
             ]
         );
@@ -101,7 +102,7 @@ final class EventTopicTest extends TestCase
     public function setSubtitleForEventTopicSetsSubtitle(): void
     {
         $this->subject->setData(
-            ['object_type' => Event::TYPE_TOPIC]
+            ['object_type' => EventInterface::TYPE_EVENT_TOPIC]
         );
         $this->subject->setSubtitle('sub title');
 
@@ -117,7 +118,7 @@ final class EventTopicTest extends TestCase
     public function hasSubtitleForEventTopicWithoutSubtitleReturnsFalse(): void
     {
         $this->subject->setData(
-            ['object_type' => Event::TYPE_TOPIC]
+            ['object_type' => EventInterface::TYPE_EVENT_TOPIC]
         );
 
         self::assertFalse(
@@ -131,7 +132,7 @@ final class EventTopicTest extends TestCase
     public function hasSubtitleForEventTopicWithSubtitleReturnsTrue(): void
     {
         $this->subject->setData(
-            ['object_type' => Event::TYPE_TOPIC]
+            ['object_type' => EventInterface::TYPE_EVENT_TOPIC]
         );
         $this->subject->setSubtitle('sub title');
 
@@ -150,7 +151,7 @@ final class EventTopicTest extends TestCase
     public function getTeaserForEventTopicWithoutTeaserReturnsAnEmptyString(): void
     {
         $this->subject->setData(
-            ['object_type' => Event::TYPE_TOPIC]
+            ['object_type' => EventInterface::TYPE_EVENT_TOPIC]
         );
 
         self::assertEquals(
@@ -167,7 +168,7 @@ final class EventTopicTest extends TestCase
         $this->subject->setData(
             [
                 'teaser' => 'wow, this is teasing',
-                'object_type' => Event::TYPE_TOPIC,
+                'object_type' => EventInterface::TYPE_EVENT_TOPIC,
             ]
         );
 
@@ -183,7 +184,7 @@ final class EventTopicTest extends TestCase
     public function setTeaserForEventTopicSetsTeaser(): void
     {
         $this->subject->setData(
-            ['object_type' => Event::TYPE_TOPIC]
+            ['object_type' => EventInterface::TYPE_EVENT_TOPIC]
         );
         $this->subject->setTeaser('wow, this is teasing');
 
@@ -199,7 +200,7 @@ final class EventTopicTest extends TestCase
     public function hasTeaserForEventTopicWithoutTeaserReturnsFalse(): void
     {
         $this->subject->setData(
-            ['object_type' => Event::TYPE_TOPIC]
+            ['object_type' => EventInterface::TYPE_EVENT_TOPIC]
         );
 
         self::assertFalse(
@@ -214,7 +215,7 @@ final class EventTopicTest extends TestCase
     {
         $this->subject->setData(
             [
-                'object_type' => Event::TYPE_TOPIC,
+                'object_type' => EventInterface::TYPE_EVENT_TOPIC,
                 'teaser' => 'wow, this is teasing',
             ]
         );
@@ -234,7 +235,7 @@ final class EventTopicTest extends TestCase
     public function getDescriptionForEventTopicWithoutDescriptionReturnsAnEmptyString(): void
     {
         $this->subject->setData(
-            ['object_type' => Event::TYPE_TOPIC]
+            ['object_type' => EventInterface::TYPE_EVENT_TOPIC]
         );
 
         self::assertEquals(
@@ -250,7 +251,7 @@ final class EventTopicTest extends TestCase
     {
         $this->subject->setData(
             [
-                'object_type' => Event::TYPE_TOPIC,
+                'object_type' => EventInterface::TYPE_EVENT_TOPIC,
                 'description' => 'this is a great event.',
             ]
         );
@@ -267,7 +268,7 @@ final class EventTopicTest extends TestCase
     public function setDescriptionForEventTopicSetsDescription(): void
     {
         $this->subject->setData(
-            ['object_type' => Event::TYPE_TOPIC]
+            ['object_type' => EventInterface::TYPE_EVENT_TOPIC]
         );
         $this->subject->setDescription('this is a great event.');
 
@@ -283,7 +284,7 @@ final class EventTopicTest extends TestCase
     public function hasDescriptionForEventTopicWithoutDescriptionReturnsFalse(): void
     {
         $this->subject->setData(
-            ['object_type' => Event::TYPE_TOPIC]
+            ['object_type' => EventInterface::TYPE_EVENT_TOPIC]
         );
 
         self::assertFalse(
@@ -297,7 +298,7 @@ final class EventTopicTest extends TestCase
     public function hasDescriptionForEventTopicWithDescriptionReturnsTrue(): void
     {
         $this->subject->setData(
-            ['object_type' => Event::TYPE_TOPIC]
+            ['object_type' => EventInterface::TYPE_EVENT_TOPIC]
         );
         $this->subject->setDescription('this is a great event.');
 
@@ -316,7 +317,7 @@ final class EventTopicTest extends TestCase
     public function getCreditPointsForEventTopicWithoutCreditPointsReturnsZero(): void
     {
         $this->subject->setData(
-            ['object_type' => Event::TYPE_TOPIC]
+            ['object_type' => EventInterface::TYPE_EVENT_TOPIC]
         );
 
         self::assertEquals(
@@ -332,7 +333,7 @@ final class EventTopicTest extends TestCase
     {
         $this->subject->setData(
             [
-                'object_type' => Event::TYPE_TOPIC,
+                'object_type' => EventInterface::TYPE_EVENT_TOPIC,
                 'credit_points' => 42,
             ]
         );
@@ -349,7 +350,7 @@ final class EventTopicTest extends TestCase
     public function setCreditPointsForEventTopicWithZeroCreditPointsSetsCreditPoints(): void
     {
         $this->subject->setData(
-            ['object_type' => Event::TYPE_TOPIC]
+            ['object_type' => EventInterface::TYPE_EVENT_TOPIC]
         );
         $this->subject->setCreditPoints(0);
 
@@ -365,7 +366,7 @@ final class EventTopicTest extends TestCase
     public function setCreditPointsForEventTopicWithPositiveCreditPointsSetsCreditPoints(): void
     {
         $this->subject->setData(
-            ['object_type' => Event::TYPE_TOPIC]
+            ['object_type' => EventInterface::TYPE_EVENT_TOPIC]
         );
         $this->subject->setCreditPoints(42);
 
@@ -381,7 +382,7 @@ final class EventTopicTest extends TestCase
     public function hasCreditPointsForEventTopicWithoutCreditPointsReturnsFalse(): void
     {
         $this->subject->setData(
-            ['object_type' => Event::TYPE_TOPIC]
+            ['object_type' => EventInterface::TYPE_EVENT_TOPIC]
         );
 
         self::assertFalse(
@@ -396,7 +397,7 @@ final class EventTopicTest extends TestCase
     {
         $this->subject->setData(
             [
-                'object_type' => Event::TYPE_TOPIC,
+                'object_type' => EventInterface::TYPE_EVENT_TOPIC,
                 'credit_points' => 42,
             ]
         );
@@ -417,7 +418,7 @@ final class EventTopicTest extends TestCase
     {
         $this->subject->setData(
             [
-                'object_type' => Event::TYPE_TOPIC,
+                'object_type' => EventInterface::TYPE_EVENT_TOPIC,
                 'price_regular' => 0.00,
             ]
         );
@@ -435,7 +436,7 @@ final class EventTopicTest extends TestCase
     {
         $this->subject->setData(
             [
-                'object_type' => Event::TYPE_TOPIC,
+                'object_type' => EventInterface::TYPE_EVENT_TOPIC,
                 'price_regular' => 42.42,
             ]
         );
@@ -452,7 +453,7 @@ final class EventTopicTest extends TestCase
     public function setRegularPriceForEventTopicWithZeroRegularPriceSetsRegularPrice(): void
     {
         $this->subject->setData(
-            ['object_type' => Event::TYPE_TOPIC]
+            ['object_type' => EventInterface::TYPE_EVENT_TOPIC]
         );
         $this->subject->setRegularPrice(0.00);
 
@@ -468,7 +469,7 @@ final class EventTopicTest extends TestCase
     public function setRegularPriceForEventTopicWithPositiveRegularPriceSetsRegularPrice(): void
     {
         $this->subject->setData(
-            ['object_type' => Event::TYPE_TOPIC]
+            ['object_type' => EventInterface::TYPE_EVENT_TOPIC]
         );
         $this->subject->setRegularPrice(42.42);
 
@@ -484,7 +485,7 @@ final class EventTopicTest extends TestCase
     public function hasRegularPriceForEventTopicWithoutRegularPriceReturnsFalse(): void
     {
         $this->subject->setData(
-            ['object_type' => Event::TYPE_TOPIC]
+            ['object_type' => EventInterface::TYPE_EVENT_TOPIC]
         );
 
         self::assertFalse(
@@ -499,7 +500,7 @@ final class EventTopicTest extends TestCase
     {
         $this->subject->setData(
             [
-                'object_type' => Event::TYPE_TOPIC,
+                'object_type' => EventInterface::TYPE_EVENT_TOPIC,
                 'price_regular' => 42.42,
             ]
         );
@@ -519,7 +520,7 @@ final class EventTopicTest extends TestCase
     public function getRegularEarlyBirdPriceForEventTopicWithoutRegularEarlyBirdPriceReturnsZero(): void
     {
         $this->subject->setData(
-            ['object_type' => Event::TYPE_TOPIC]
+            ['object_type' => EventInterface::TYPE_EVENT_TOPIC]
         );
 
         self::assertEquals(
@@ -535,7 +536,7 @@ final class EventTopicTest extends TestCase
     {
         $this->subject->setData(
             [
-                'object_type' => Event::TYPE_TOPIC,
+                'object_type' => EventInterface::TYPE_EVENT_TOPIC,
                 'price_regular_early' => 42.42,
             ]
         );
@@ -567,7 +568,7 @@ final class EventTopicTest extends TestCase
     public function setRegularEarlyBirdPriceForEventTopicWithZeroRegularEarlyBirdPriceSetsRegularEarlyBirdPrice(): void
     {
         $this->subject->setData(
-            ['object_type' => Event::TYPE_TOPIC]
+            ['object_type' => EventInterface::TYPE_EVENT_TOPIC]
         );
         $this->subject->setRegularEarlyBirdPrice(0.00);
 
@@ -583,7 +584,7 @@ final class EventTopicTest extends TestCase
     public function setRegularEarlyBirdPriceForEventTopicWithPositiveRegularEarlyBirdPriceSetsRegularEarlyBirdPrice(): void
     {
         $this->subject->setData(
-            ['object_type' => Event::TYPE_TOPIC]
+            ['object_type' => EventInterface::TYPE_EVENT_TOPIC]
         );
         $this->subject->setRegularEarlyBirdPrice(42.42);
 
@@ -599,7 +600,7 @@ final class EventTopicTest extends TestCase
     public function hasRegularEarlyBirdPriceForEventTopicWithoutRegularEarlyBirdPriceReturnsFalse(): void
     {
         $this->subject->setData(
-            ['object_type' => Event::TYPE_TOPIC]
+            ['object_type' => EventInterface::TYPE_EVENT_TOPIC]
         );
 
         self::assertFalse(
@@ -614,7 +615,7 @@ final class EventTopicTest extends TestCase
     {
         $this->subject->setData(
             [
-                'object_type' => Event::TYPE_TOPIC,
+                'object_type' => EventInterface::TYPE_EVENT_TOPIC,
                 'price_regular_early' => 42.42,
             ]
         );
@@ -634,7 +635,7 @@ final class EventTopicTest extends TestCase
     public function getRegularBoardPriceForEventTopicWithoutRegularBoardPriceReturnsZero(): void
     {
         $this->subject->setData(
-            ['object_type' => Event::TYPE_TOPIC]
+            ['object_type' => EventInterface::TYPE_EVENT_TOPIC]
         );
 
         self::assertEquals(
@@ -650,7 +651,7 @@ final class EventTopicTest extends TestCase
     {
         $this->subject->setData(
             [
-                'object_type' => Event::TYPE_TOPIC,
+                'object_type' => EventInterface::TYPE_EVENT_TOPIC,
                 'price_regular_board' => 42.42,
             ]
         );
@@ -667,7 +668,7 @@ final class EventTopicTest extends TestCase
     public function setRegularBoardPriceForEventTopicWithZeroRegularBoardPriceSetsRegularBoardPrice(): void
     {
         $this->subject->setData(
-            ['object_type' => Event::TYPE_TOPIC]
+            ['object_type' => EventInterface::TYPE_EVENT_TOPIC]
         );
         $this->subject->setRegularBoardPrice(0.00);
 
@@ -683,7 +684,7 @@ final class EventTopicTest extends TestCase
     public function setRegularBoardPriceForEventTopicWithPositiveRegularBoardPriceSetsRegularBoardPrice(): void
     {
         $this->subject->setData(
-            ['object_type' => Event::TYPE_TOPIC]
+            ['object_type' => EventInterface::TYPE_EVENT_TOPIC]
         );
         $this->subject->setRegularBoardPrice(42.42);
 
@@ -699,7 +700,7 @@ final class EventTopicTest extends TestCase
     public function hasRegularBoardPriceForEventTopicWithoutRegularBoardPriceReturnsFalse(): void
     {
         $this->subject->setData(
-            ['object_type' => Event::TYPE_TOPIC]
+            ['object_type' => EventInterface::TYPE_EVENT_TOPIC]
         );
 
         self::assertFalse(
@@ -714,7 +715,7 @@ final class EventTopicTest extends TestCase
     {
         $this->subject->setData(
             [
-                'object_type' => Event::TYPE_TOPIC,
+                'object_type' => EventInterface::TYPE_EVENT_TOPIC,
                 'price_regular_board' => 42.42,
             ]
         );
@@ -734,7 +735,7 @@ final class EventTopicTest extends TestCase
     public function getSpecialPriceForEventTopicWithoutSpecialPriceReturnsZero(): void
     {
         $this->subject->setData(
-            ['object_type' => Event::TYPE_TOPIC]
+            ['object_type' => EventInterface::TYPE_EVENT_TOPIC]
         );
 
         self::assertEquals(
@@ -750,7 +751,7 @@ final class EventTopicTest extends TestCase
     {
         $this->subject->setData(
             [
-                'object_type' => Event::TYPE_TOPIC,
+                'object_type' => EventInterface::TYPE_EVENT_TOPIC,
                 'price_special' => 42.42,
             ]
         );
@@ -767,7 +768,7 @@ final class EventTopicTest extends TestCase
     public function setSpecialPriceForEventTopicWithZeroSpecialPriceSetsSpecialPrice(): void
     {
         $this->subject->setData(
-            ['object_type' => Event::TYPE_TOPIC]
+            ['object_type' => EventInterface::TYPE_EVENT_TOPIC]
         );
         $this->subject->setSpecialPrice(0.00);
 
@@ -783,7 +784,7 @@ final class EventTopicTest extends TestCase
     public function setSpecialPriceForEventTopicWithPositiveSpecialPriceSetsSpecialPrice(): void
     {
         $this->subject->setData(
-            ['object_type' => Event::TYPE_TOPIC]
+            ['object_type' => EventInterface::TYPE_EVENT_TOPIC]
         );
         $this->subject->setSpecialPrice(42.42);
 
@@ -799,7 +800,7 @@ final class EventTopicTest extends TestCase
     public function hasSpecialPriceForEventTopicWithoutSpecialPriceReturnsFalse(): void
     {
         $this->subject->setData(
-            ['object_type' => Event::TYPE_TOPIC]
+            ['object_type' => EventInterface::TYPE_EVENT_TOPIC]
         );
 
         self::assertFalse(
@@ -813,7 +814,7 @@ final class EventTopicTest extends TestCase
     public function hasSpecialPriceForEventTopicWithSpecialPriceReturnsTrue(): void
     {
         $this->subject->setData(
-            ['object_type' => Event::TYPE_TOPIC]
+            ['object_type' => EventInterface::TYPE_EVENT_TOPIC]
         );
         $this->subject->setSpecialPrice(42.42);
 
@@ -832,7 +833,7 @@ final class EventTopicTest extends TestCase
     public function getSpecialEarlyBirdPriceForEventTopicWithoutSpecialEarlyBirdPriceReturnsZero(): void
     {
         $this->subject->setData(
-            ['object_type' => Event::TYPE_TOPIC]
+            ['object_type' => EventInterface::TYPE_EVENT_TOPIC]
         );
 
         self::assertEquals(
@@ -848,7 +849,7 @@ final class EventTopicTest extends TestCase
     {
         $this->subject->setData(
             [
-                'object_type' => Event::TYPE_TOPIC,
+                'object_type' => EventInterface::TYPE_EVENT_TOPIC,
                 'price_special_early' => 42.42,
             ]
         );
@@ -865,7 +866,7 @@ final class EventTopicTest extends TestCase
     public function setSpecialEarlyBirdPriceForEventTopicWithZeroSpecialEarlyBirdPriceSetsSpecialEarlyBirdPrice(): void
     {
         $this->subject->setData(
-            ['object_type' => Event::TYPE_TOPIC]
+            ['object_type' => EventInterface::TYPE_EVENT_TOPIC]
         );
         $this->subject->setSpecialEarlyBirdPrice(0.00);
 
@@ -881,7 +882,7 @@ final class EventTopicTest extends TestCase
     public function setSpecialEarlyBirdPriceForEventTopicWithPositiveSpecialEarlyBirdPriceSetsSpecialEarlyBirdPrice(): void
     {
         $this->subject->setData(
-            ['object_type' => Event::TYPE_TOPIC]
+            ['object_type' => EventInterface::TYPE_EVENT_TOPIC]
         );
         $this->subject->setSpecialEarlyBirdPrice(42.42);
 
@@ -897,7 +898,7 @@ final class EventTopicTest extends TestCase
     public function hasSpecialEarlyBirdPriceForEventTopicWithoutSpecialEarlyBirdPriceReturnsFalse(): void
     {
         $this->subject->setData(
-            ['object_type' => Event::TYPE_TOPIC]
+            ['object_type' => EventInterface::TYPE_EVENT_TOPIC]
         );
 
         self::assertFalse(
@@ -912,7 +913,7 @@ final class EventTopicTest extends TestCase
     {
         $this->subject->setData(
             [
-                'object_type' => Event::TYPE_TOPIC,
+                'object_type' => EventInterface::TYPE_EVENT_TOPIC,
                 'price_special_early' => 42.42,
             ]
         );
@@ -932,7 +933,7 @@ final class EventTopicTest extends TestCase
     public function getSpecialBoardPriceForEventTopicWithoutSpecialBoardPriceReturnsZero(): void
     {
         $this->subject->setData(
-            ['object_type' => Event::TYPE_TOPIC]
+            ['object_type' => EventInterface::TYPE_EVENT_TOPIC]
         );
 
         self::assertEquals(
@@ -948,7 +949,7 @@ final class EventTopicTest extends TestCase
     {
         $this->subject->setData(
             [
-                'object_type' => Event::TYPE_TOPIC,
+                'object_type' => EventInterface::TYPE_EVENT_TOPIC,
                 'price_special_board' => 42.42,
             ]
         );
@@ -965,7 +966,7 @@ final class EventTopicTest extends TestCase
     public function setSpecialBoardPriceForEventTopicWithZeroSpecialBoardPriceSetsSpecialBoardPrice(): void
     {
         $this->subject->setData(
-            ['object_type' => Event::TYPE_TOPIC]
+            ['object_type' => EventInterface::TYPE_EVENT_TOPIC]
         );
         $this->subject->setSpecialBoardPrice(0.00);
 
@@ -981,7 +982,7 @@ final class EventTopicTest extends TestCase
     public function setSpecialBoardPriceForEventTopicWithPositiveSpecialBoardPriceSetsSpecialBoardPrice(): void
     {
         $this->subject->setData(
-            ['object_type' => Event::TYPE_TOPIC]
+            ['object_type' => EventInterface::TYPE_EVENT_TOPIC]
         );
         $this->subject->setSpecialBoardPrice(42.42);
 
@@ -997,7 +998,7 @@ final class EventTopicTest extends TestCase
     public function hasSpecialBoardPriceForEventTopicWithoutSpecialBoardPriceReturnsFalse(): void
     {
         $this->subject->setData(
-            ['object_type' => Event::TYPE_TOPIC]
+            ['object_type' => EventInterface::TYPE_EVENT_TOPIC]
         );
 
         self::assertFalse(
@@ -1011,7 +1012,7 @@ final class EventTopicTest extends TestCase
     public function hasSpecialBoardPriceForEventTopicWithSpecialBoardPriceReturnsTrue(): void
     {
         $this->subject->setData(
-            ['object_type' => Event::TYPE_TOPIC]
+            ['object_type' => EventInterface::TYPE_EVENT_TOPIC]
         );
         $this->subject->setSpecialBoardPrice(42.42);
 
@@ -1030,7 +1031,7 @@ final class EventTopicTest extends TestCase
     public function getAdditionalInformationForEventTopicWithoutAdditionalInformationReturnsEmptyString(): void
     {
         $this->subject->setData(
-            ['object_type' => Event::TYPE_TOPIC]
+            ['object_type' => EventInterface::TYPE_EVENT_TOPIC]
         );
 
         self::assertEquals(
@@ -1046,7 +1047,7 @@ final class EventTopicTest extends TestCase
     {
         $this->subject->setData(
             [
-                'object_type' => Event::TYPE_TOPIC,
+                'object_type' => EventInterface::TYPE_EVENT_TOPIC,
                 'additional_information' => 'this is good to know',
             ]
         );
@@ -1063,7 +1064,7 @@ final class EventTopicTest extends TestCase
     public function setAdditionalInformationForEventTopicSetsAdditionalInformation(): void
     {
         $this->subject->setData(
-            ['object_type' => Event::TYPE_TOPIC]
+            ['object_type' => EventInterface::TYPE_EVENT_TOPIC]
         );
         $this->subject->setAdditionalInformation('this is good to know');
 
@@ -1079,7 +1080,7 @@ final class EventTopicTest extends TestCase
     public function hasAdditionalInformationForEventTopicWithoutAdditionalInformationReturnsFalse(): void
     {
         $this->subject->setData(
-            ['object_type' => Event::TYPE_TOPIC]
+            ['object_type' => EventInterface::TYPE_EVENT_TOPIC]
         );
 
         self::assertFalse(
@@ -1094,7 +1095,7 @@ final class EventTopicTest extends TestCase
     {
         $this->subject->setData(
             [
-                'object_type' => Event::TYPE_TOPIC,
+                'object_type' => EventInterface::TYPE_EVENT_TOPIC,
                 'additional_information' => 'this is good to know',
             ]
         );
@@ -1114,7 +1115,7 @@ final class EventTopicTest extends TestCase
     public function allowsMultipleRegistrationForEventTopicWithUnsetAllowsMultipleRegistrationReturnsFalse(): void
     {
         $this->subject->setData(
-            ['object_type' => Event::TYPE_TOPIC]
+            ['object_type' => EventInterface::TYPE_EVENT_TOPIC]
         );
 
         self::assertFalse(
@@ -1129,7 +1130,7 @@ final class EventTopicTest extends TestCase
     {
         $this->subject->setData(
             [
-                'object_type' => Event::TYPE_TOPIC,
+                'object_type' => EventInterface::TYPE_EVENT_TOPIC,
                 'allows_multiple_registrations' => true,
             ]
         );
@@ -1149,7 +1150,7 @@ final class EventTopicTest extends TestCase
     public function usesTerms2ForEventTopicWithUnsetUseTerms2ReturnsFalse(): void
     {
         $this->subject->setData(
-            ['object_type' => Event::TYPE_TOPIC]
+            ['object_type' => EventInterface::TYPE_EVENT_TOPIC]
         );
 
         self::assertFalse(
@@ -1164,7 +1165,7 @@ final class EventTopicTest extends TestCase
     {
         $this->subject->setData(
             [
-                'object_type' => Event::TYPE_TOPIC,
+                'object_type' => EventInterface::TYPE_EVENT_TOPIC,
                 'use_terms_2' => true,
             ]
         );
@@ -1184,7 +1185,7 @@ final class EventTopicTest extends TestCase
     public function getNotesForEventTopicWithoutNotesReturnsEmptyString(): void
     {
         $this->subject->setData(
-            ['object_type' => Event::TYPE_TOPIC]
+            ['object_type' => EventInterface::TYPE_EVENT_TOPIC]
         );
 
         self::assertEquals(
@@ -1200,7 +1201,7 @@ final class EventTopicTest extends TestCase
     {
         $this->subject->setData(
             [
-                'object_type' => Event::TYPE_TOPIC,
+                'object_type' => EventInterface::TYPE_EVENT_TOPIC,
                 'notes' => 'Don\'t forget this.',
             ]
         );
@@ -1217,7 +1218,7 @@ final class EventTopicTest extends TestCase
     public function setNotesForEventTopicSetsNotes(): void
     {
         $this->subject->setData(
-            ['object_type' => Event::TYPE_TOPIC]
+            ['object_type' => EventInterface::TYPE_EVENT_TOPIC]
         );
         $this->subject->setNotes('Don\'t forget this.');
 
@@ -1233,7 +1234,7 @@ final class EventTopicTest extends TestCase
     public function hasNotesForEventTopicWithoutNotesReturnsFalse(): void
     {
         $this->subject->setData(
-            ['object_type' => Event::TYPE_TOPIC]
+            ['object_type' => EventInterface::TYPE_EVENT_TOPIC]
         );
 
         self::assertFalse(
@@ -1248,7 +1249,7 @@ final class EventTopicTest extends TestCase
     {
         $this->subject->setData(
             [
-                'object_type' => Event::TYPE_TOPIC,
+                'object_type' => EventInterface::TYPE_EVENT_TOPIC,
                 'notes' => 'Don\'t forget this.',
             ]
         );

--- a/Tests/LegacyUnit/Model/SingleEventTest.php
+++ b/Tests/LegacyUnit/Model/SingleEventTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace OliverKlee\Seminars\Tests\LegacyUnit\Model;
 
+use OliverKlee\Seminars\Domain\Model\Event\EventInterface;
 use OliverKlee\Seminars\Model\Event;
 use PHPUnit\Framework\TestCase;
 
@@ -32,7 +33,7 @@ final class SingleEventTest extends TestCase
     public function getSubtitleForSingleEventWithoutSubtitleReturnsAnEmptyString(): void
     {
         $this->subject->setData(
-            ['object_type' => Event::TYPE_COMPLETE]
+            ['object_type' => EventInterface::TYPE_SINGLE_EVENT]
         );
 
         self::assertEquals(
@@ -48,7 +49,7 @@ final class SingleEventTest extends TestCase
     {
         $this->subject->setData(
             [
-                'object_type' => Event::TYPE_COMPLETE,
+                'object_type' => EventInterface::TYPE_SINGLE_EVENT,
                 'subtitle' => 'sub title',
             ]
         );
@@ -65,7 +66,7 @@ final class SingleEventTest extends TestCase
     public function setSubtitleForSingleEventSetsSubtitle(): void
     {
         $this->subject->setData(
-            ['object_type' => Event::TYPE_COMPLETE]
+            ['object_type' => EventInterface::TYPE_SINGLE_EVENT]
         );
         $this->subject->setSubtitle('sub title');
 
@@ -81,7 +82,7 @@ final class SingleEventTest extends TestCase
     public function hasSubtitleForSingleEventWithoutSubtitleReturnsFalse(): void
     {
         $this->subject->setData(
-            ['object_type' => Event::TYPE_TOPIC]
+            ['object_type' => EventInterface::TYPE_EVENT_TOPIC]
         );
 
         self::assertFalse(
@@ -95,7 +96,7 @@ final class SingleEventTest extends TestCase
     public function hasSubtitleForSingleEventWithSubtitleReturnsTrue(): void
     {
         $this->subject->setData(
-            ['object_type' => Event::TYPE_TOPIC]
+            ['object_type' => EventInterface::TYPE_EVENT_TOPIC]
         );
         $this->subject->setSubtitle('sub title');
 
@@ -114,7 +115,7 @@ final class SingleEventTest extends TestCase
     public function getTeaserForSingleEventWithoutTeaserReturnsAnEmptyString(): void
     {
         $this->subject->setData(
-            ['object_type' => Event::TYPE_COMPLETE]
+            ['object_type' => EventInterface::TYPE_SINGLE_EVENT]
         );
 
         self::assertEquals(
@@ -131,7 +132,7 @@ final class SingleEventTest extends TestCase
         $this->subject->setData(
             [
                 'teaser' => 'wow, this is teasing',
-                'object_type' => Event::TYPE_COMPLETE,
+                'object_type' => EventInterface::TYPE_SINGLE_EVENT,
             ]
         );
 
@@ -147,7 +148,7 @@ final class SingleEventTest extends TestCase
     public function setTeaserForSingleEventSetsTeaser(): void
     {
         $this->subject->setData(
-            ['object_type' => Event::TYPE_COMPLETE]
+            ['object_type' => EventInterface::TYPE_SINGLE_EVENT]
         );
         $this->subject->setTeaser('wow, this is teasing');
 
@@ -163,7 +164,7 @@ final class SingleEventTest extends TestCase
     public function hasTeaserForSingleEventWithoutTeaserReturnsFalse(): void
     {
         $this->subject->setData(
-            ['object_type' => Event::TYPE_COMPLETE]
+            ['object_type' => EventInterface::TYPE_SINGLE_EVENT]
         );
 
         self::assertFalse(
@@ -178,7 +179,7 @@ final class SingleEventTest extends TestCase
     {
         $this->subject->setData(
             [
-                'object_type' => Event::TYPE_COMPLETE,
+                'object_type' => EventInterface::TYPE_SINGLE_EVENT,
                 'teaser' => 'wow, this is teasing',
             ]
         );
@@ -198,7 +199,7 @@ final class SingleEventTest extends TestCase
     public function getDescriptionForSingleEventWithoutDescriptionReturnsAnEmptyString(): void
     {
         $this->subject->setData(
-            ['object_type' => Event::TYPE_COMPLETE]
+            ['object_type' => EventInterface::TYPE_SINGLE_EVENT]
         );
 
         self::assertEquals(
@@ -214,7 +215,7 @@ final class SingleEventTest extends TestCase
     {
         $this->subject->setData(
             [
-                'object_type' => Event::TYPE_COMPLETE,
+                'object_type' => EventInterface::TYPE_SINGLE_EVENT,
                 'description' => 'this is a great event.',
             ]
         );
@@ -231,7 +232,7 @@ final class SingleEventTest extends TestCase
     public function setDescriptionForSingleEventSetsDescription(): void
     {
         $this->subject->setData(
-            ['object_type' => Event::TYPE_COMPLETE]
+            ['object_type' => EventInterface::TYPE_SINGLE_EVENT]
         );
         $this->subject->setDescription('this is a great event.');
 
@@ -247,7 +248,7 @@ final class SingleEventTest extends TestCase
     public function hasDescriptionForSingleEventWithoutDescriptionReturnsFalse(): void
     {
         $this->subject->setData(
-            ['object_type' => Event::TYPE_COMPLETE]
+            ['object_type' => EventInterface::TYPE_SINGLE_EVENT]
         );
 
         self::assertFalse(
@@ -262,7 +263,7 @@ final class SingleEventTest extends TestCase
     {
         $this->subject->setData(
             [
-                'object_type' => Event::TYPE_COMPLETE,
+                'object_type' => EventInterface::TYPE_SINGLE_EVENT,
                 'description' => 'this is a great event.',
             ]
         );
@@ -282,7 +283,7 @@ final class SingleEventTest extends TestCase
     public function getCreditPointsForSingleEventWithoutCreditPointsReturnsZero(): void
     {
         $this->subject->setData(
-            ['object_type' => Event::TYPE_COMPLETE]
+            ['object_type' => EventInterface::TYPE_SINGLE_EVENT]
         );
 
         self::assertEquals(
@@ -298,7 +299,7 @@ final class SingleEventTest extends TestCase
     {
         $this->subject->setData(
             [
-                'object_type' => Event::TYPE_COMPLETE,
+                'object_type' => EventInterface::TYPE_SINGLE_EVENT,
                 'credit_points' => 42,
             ]
         );
@@ -331,7 +332,7 @@ final class SingleEventTest extends TestCase
     public function setCreditPointsForSingleEventWithZeroCreditPointsSetsCreditPoints(): void
     {
         $this->subject->setData(
-            ['object_type' => Event::TYPE_COMPLETE]
+            ['object_type' => EventInterface::TYPE_SINGLE_EVENT]
         );
         $this->subject->setCreditPoints(0);
 
@@ -347,7 +348,7 @@ final class SingleEventTest extends TestCase
     public function setCreditPointsForSingleEventWithPositiveCreditPointsSetsCreditPoints(): void
     {
         $this->subject->setData(
-            ['object_type' => Event::TYPE_COMPLETE]
+            ['object_type' => EventInterface::TYPE_SINGLE_EVENT]
         );
         $this->subject->setCreditPoints(42);
 
@@ -363,7 +364,7 @@ final class SingleEventTest extends TestCase
     public function hasCreditPointsForSingleEventWithoutCreditPointsReturnsFalse(): void
     {
         $this->subject->setData(
-            ['object_type' => Event::TYPE_COMPLETE]
+            ['object_type' => EventInterface::TYPE_SINGLE_EVENT]
         );
 
         self::assertFalse(
@@ -378,7 +379,7 @@ final class SingleEventTest extends TestCase
     {
         $this->subject->setData(
             [
-                'object_type' => Event::TYPE_COMPLETE,
+                'object_type' => EventInterface::TYPE_SINGLE_EVENT,
                 'credit_points' => 42,
             ]
         );
@@ -399,7 +400,7 @@ final class SingleEventTest extends TestCase
     {
         $this->subject->setData(
             [
-                'object_type' => Event::TYPE_COMPLETE,
+                'object_type' => EventInterface::TYPE_SINGLE_EVENT,
                 'price_regular' => 0.00,
             ]
         );
@@ -417,7 +418,7 @@ final class SingleEventTest extends TestCase
     {
         $this->subject->setData(
             [
-                'object_type' => Event::TYPE_COMPLETE,
+                'object_type' => EventInterface::TYPE_SINGLE_EVENT,
                 'price_regular' => 42.42,
             ]
         );
@@ -449,7 +450,7 @@ final class SingleEventTest extends TestCase
     public function setRegularPriceForSingleEventWithZeroRegularPriceSetsRegularPrice(): void
     {
         $this->subject->setData(
-            ['object_type' => Event::TYPE_COMPLETE]
+            ['object_type' => EventInterface::TYPE_SINGLE_EVENT]
         );
         $this->subject->setRegularPrice(0.00);
 
@@ -465,7 +466,7 @@ final class SingleEventTest extends TestCase
     public function setRegularPriceForSingleEventWithPositiveRegularPriceSetsRegularPrice(): void
     {
         $this->subject->setData(
-            ['object_type' => Event::TYPE_COMPLETE]
+            ['object_type' => EventInterface::TYPE_SINGLE_EVENT]
         );
         $this->subject->setRegularPrice(42.42);
 
@@ -481,7 +482,7 @@ final class SingleEventTest extends TestCase
     public function hasRegularPriceForSingleEventWithoutRegularPriceReturnsFalse(): void
     {
         $this->subject->setData(
-            ['object_type' => Event::TYPE_COMPLETE]
+            ['object_type' => EventInterface::TYPE_SINGLE_EVENT]
         );
 
         self::assertFalse(
@@ -496,7 +497,7 @@ final class SingleEventTest extends TestCase
     {
         $this->subject->setData(
             [
-                'object_type' => Event::TYPE_COMPLETE,
+                'object_type' => EventInterface::TYPE_SINGLE_EVENT,
                 'price_regular' => 42.42,
             ]
         );
@@ -516,7 +517,7 @@ final class SingleEventTest extends TestCase
     public function getRegularEarlyBirdPriceForSingleEventWithoutRegularEarlyBirdPriceReturnsZero(): void
     {
         $this->subject->setData(
-            ['object_type' => Event::TYPE_COMPLETE]
+            ['object_type' => EventInterface::TYPE_SINGLE_EVENT]
         );
 
         self::assertEquals(
@@ -532,7 +533,7 @@ final class SingleEventTest extends TestCase
     {
         $this->subject->setData(
             [
-                'object_type' => Event::TYPE_COMPLETE,
+                'object_type' => EventInterface::TYPE_SINGLE_EVENT,
                 'price_regular_early' => 42.42,
             ]
         );
@@ -564,7 +565,7 @@ final class SingleEventTest extends TestCase
     public function setRegularEarlyBirdPriceForSingleEventWithZeroRegularEarlyBirdPriceSetsRegularEarlyBirdPrice(): void
     {
         $this->subject->setData(
-            ['object_type' => Event::TYPE_COMPLETE]
+            ['object_type' => EventInterface::TYPE_SINGLE_EVENT]
         );
         $this->subject->setRegularEarlyBirdPrice(0.00);
 
@@ -580,7 +581,7 @@ final class SingleEventTest extends TestCase
     public function setRegularEarlyBirdPriceForSingleEventWithPositiveRegularEarlyBirdPriceSetsRegularEarlyBirdPrice(): void
     {
         $this->subject->setData(
-            ['object_type' => Event::TYPE_COMPLETE]
+            ['object_type' => EventInterface::TYPE_SINGLE_EVENT]
         );
         $this->subject->setRegularEarlyBirdPrice(42.42);
 
@@ -596,7 +597,7 @@ final class SingleEventTest extends TestCase
     public function hasRegularEarlyBirdPriceForSingleEventWithoutRegularEarlyBirdPriceReturnsFalse(): void
     {
         $this->subject->setData(
-            ['object_type' => Event::TYPE_COMPLETE]
+            ['object_type' => EventInterface::TYPE_SINGLE_EVENT]
         );
 
         self::assertFalse(
@@ -611,7 +612,7 @@ final class SingleEventTest extends TestCase
     {
         $this->subject->setData(
             [
-                'object_type' => Event::TYPE_COMPLETE,
+                'object_type' => EventInterface::TYPE_SINGLE_EVENT,
                 'price_regular_early' => 42.42,
             ]
         );
@@ -631,7 +632,7 @@ final class SingleEventTest extends TestCase
     public function getRegularBoardPriceForSingleEventWithoutRegularBoardPriceReturnsZero(): void
     {
         $this->subject->setData(
-            ['object_type' => Event::TYPE_COMPLETE]
+            ['object_type' => EventInterface::TYPE_SINGLE_EVENT]
         );
 
         self::assertEquals(
@@ -647,7 +648,7 @@ final class SingleEventTest extends TestCase
     {
         $this->subject->setData(
             [
-                'object_type' => Event::TYPE_COMPLETE,
+                'object_type' => EventInterface::TYPE_SINGLE_EVENT,
                 'price_regular_board' => 42.42,
             ]
         );
@@ -679,7 +680,7 @@ final class SingleEventTest extends TestCase
     public function setRegularBoardPriceForSingleEventWithZeroRegularBoardPriceSetsRegularBoardPrice(): void
     {
         $this->subject->setData(
-            ['object_type' => Event::TYPE_COMPLETE]
+            ['object_type' => EventInterface::TYPE_SINGLE_EVENT]
         );
         $this->subject->setRegularBoardPrice(0.00);
 
@@ -695,7 +696,7 @@ final class SingleEventTest extends TestCase
     public function setRegularBoardPriceForSingleEventWithPositiveRegularBoardPriceSetsRegularBoardPrice(): void
     {
         $this->subject->setData(
-            ['object_type' => Event::TYPE_COMPLETE]
+            ['object_type' => EventInterface::TYPE_SINGLE_EVENT]
         );
         $this->subject->setRegularBoardPrice(42.42);
 
@@ -711,7 +712,7 @@ final class SingleEventTest extends TestCase
     public function hasRegularBoardPriceForSingleEventWithoutRegularBoardPriceReturnsFalse(): void
     {
         $this->subject->setData(
-            ['object_type' => Event::TYPE_COMPLETE]
+            ['object_type' => EventInterface::TYPE_SINGLE_EVENT]
         );
 
         self::assertFalse(
@@ -726,7 +727,7 @@ final class SingleEventTest extends TestCase
     {
         $this->subject->setData(
             [
-                'object_type' => Event::TYPE_COMPLETE,
+                'object_type' => EventInterface::TYPE_SINGLE_EVENT,
                 'price_regular_board' => 42.42,
             ]
         );
@@ -746,7 +747,7 @@ final class SingleEventTest extends TestCase
     public function getSpecialPriceForSingleEventWithoutSpecialPriceReturnsZero(): void
     {
         $this->subject->setData(
-            ['object_type' => Event::TYPE_COMPLETE]
+            ['object_type' => EventInterface::TYPE_SINGLE_EVENT]
         );
 
         self::assertEquals(
@@ -762,7 +763,7 @@ final class SingleEventTest extends TestCase
     {
         $this->subject->setData(
             [
-                'object_type' => Event::TYPE_COMPLETE,
+                'object_type' => EventInterface::TYPE_SINGLE_EVENT,
                 'price_special' => 42.42,
             ]
         );
@@ -794,7 +795,7 @@ final class SingleEventTest extends TestCase
     public function setSpecialPriceForSingleEventWithZeroSpecialPriceSetsSpecialPrice(): void
     {
         $this->subject->setData(
-            ['object_type' => Event::TYPE_COMPLETE]
+            ['object_type' => EventInterface::TYPE_SINGLE_EVENT]
         );
         $this->subject->setSpecialPrice(0.00);
 
@@ -810,7 +811,7 @@ final class SingleEventTest extends TestCase
     public function setSpecialPriceForSingleEventWithPositiveSpecialPriceSetsSpecialPrice(): void
     {
         $this->subject->setData(
-            ['object_type' => Event::TYPE_COMPLETE]
+            ['object_type' => EventInterface::TYPE_SINGLE_EVENT]
         );
         $this->subject->setSpecialPrice(42.42);
 
@@ -826,7 +827,7 @@ final class SingleEventTest extends TestCase
     public function hasSpecialPriceForSingleEventWithoutSpecialPriceReturnsFalse(): void
     {
         $this->subject->setData(
-            ['object_type' => Event::TYPE_COMPLETE]
+            ['object_type' => EventInterface::TYPE_SINGLE_EVENT]
         );
 
         self::assertFalse(
@@ -840,7 +841,7 @@ final class SingleEventTest extends TestCase
     public function hasSpecialPriceForSingleEventWithSpecialPriceReturnsTrue(): void
     {
         $this->subject->setData(
-            ['object_type' => Event::TYPE_COMPLETE]
+            ['object_type' => EventInterface::TYPE_SINGLE_EVENT]
         );
         $this->subject->setSpecialPrice(42.42);
 
@@ -859,7 +860,7 @@ final class SingleEventTest extends TestCase
     public function getSpecialEarlyBirdPriceForSingleEventWithoutSpecialEarlyBirdPriceReturnsZero(): void
     {
         $this->subject->setData(
-            ['object_type' => Event::TYPE_COMPLETE]
+            ['object_type' => EventInterface::TYPE_SINGLE_EVENT]
         );
 
         self::assertEquals(
@@ -875,7 +876,7 @@ final class SingleEventTest extends TestCase
     {
         $this->subject->setData(
             [
-                'object_type' => Event::TYPE_COMPLETE,
+                'object_type' => EventInterface::TYPE_SINGLE_EVENT,
                 'price_special_early' => 42.42,
             ]
         );
@@ -907,7 +908,7 @@ final class SingleEventTest extends TestCase
     public function setSpecialEarlyBirdPriceForSingleEventWithZeroSpecialEarlyBirdPriceSetsSpecialEarlyBirdPrice(): void
     {
         $this->subject->setData(
-            ['object_type' => Event::TYPE_COMPLETE]
+            ['object_type' => EventInterface::TYPE_SINGLE_EVENT]
         );
         $this->subject->setSpecialEarlyBirdPrice(0.00);
 
@@ -923,7 +924,7 @@ final class SingleEventTest extends TestCase
     public function setSpecialEarlyBirdPriceForSingleEventWithPositiveSpecialEarlyBirdPriceSetsSpecialEarlyBirdPrice(): void
     {
         $this->subject->setData(
-            ['object_type' => Event::TYPE_COMPLETE]
+            ['object_type' => EventInterface::TYPE_SINGLE_EVENT]
         );
         $this->subject->setSpecialEarlyBirdPrice(42.42);
 
@@ -939,7 +940,7 @@ final class SingleEventTest extends TestCase
     public function hasSpecialEarlyBirdPriceForSingleEventWithoutSpecialEarlyBirdPriceReturnsFalse(): void
     {
         $this->subject->setData(
-            ['object_type' => Event::TYPE_COMPLETE]
+            ['object_type' => EventInterface::TYPE_SINGLE_EVENT]
         );
 
         self::assertFalse(
@@ -954,7 +955,7 @@ final class SingleEventTest extends TestCase
     {
         $this->subject->setData(
             [
-                'object_type' => Event::TYPE_COMPLETE,
+                'object_type' => EventInterface::TYPE_SINGLE_EVENT,
                 'price_special_early' => 42.42,
             ]
         );
@@ -974,7 +975,7 @@ final class SingleEventTest extends TestCase
     public function getSpecialBoardPriceForSingleEventWithoutSpecialBoardPriceReturnsZero(): void
     {
         $this->subject->setData(
-            ['object_type' => Event::TYPE_COMPLETE]
+            ['object_type' => EventInterface::TYPE_SINGLE_EVENT]
         );
 
         self::assertEquals(
@@ -990,7 +991,7 @@ final class SingleEventTest extends TestCase
     {
         $this->subject->setData(
             [
-                'object_type' => Event::TYPE_COMPLETE,
+                'object_type' => EventInterface::TYPE_SINGLE_EVENT,
                 'price_special_board' => 42.42,
             ]
         );
@@ -1022,7 +1023,7 @@ final class SingleEventTest extends TestCase
     public function setSpecialBoardPriceForSingleEventWithZeroSpecialBoardPriceSetsSpecialBoardPrice(): void
     {
         $this->subject->setData(
-            ['object_type' => Event::TYPE_COMPLETE]
+            ['object_type' => EventInterface::TYPE_SINGLE_EVENT]
         );
         $this->subject->setSpecialBoardPrice(0.00);
 
@@ -1038,7 +1039,7 @@ final class SingleEventTest extends TestCase
     public function setSpecialBoardPriceForSingleEventWithPositiveSpecialBoardPriceSetsSpecialBoardPrice(): void
     {
         $this->subject->setData(
-            ['object_type' => Event::TYPE_COMPLETE]
+            ['object_type' => EventInterface::TYPE_SINGLE_EVENT]
         );
         $this->subject->setSpecialBoardPrice(42.42);
 
@@ -1054,7 +1055,7 @@ final class SingleEventTest extends TestCase
     public function hasSpecialBoardPriceForSingleEventWithoutSpecialBoardPriceReturnsFalse(): void
     {
         $this->subject->setData(
-            ['object_type' => Event::TYPE_COMPLETE]
+            ['object_type' => EventInterface::TYPE_SINGLE_EVENT]
         );
 
         self::assertFalse(
@@ -1068,7 +1069,7 @@ final class SingleEventTest extends TestCase
     public function hasSpecialBoardPriceForSingleEventWithSpecialBoardPriceReturnsTrue(): void
     {
         $this->subject->setData(
-            ['object_type' => Event::TYPE_COMPLETE]
+            ['object_type' => EventInterface::TYPE_SINGLE_EVENT]
         );
         $this->subject->setSpecialBoardPrice(42.42);
 
@@ -1087,7 +1088,7 @@ final class SingleEventTest extends TestCase
     public function getAdditionalInformationForSingleEventWithoutAdditionalInformationReturnsEmptyString(): void
     {
         $this->subject->setData(
-            ['object_type' => Event::TYPE_COMPLETE]
+            ['object_type' => EventInterface::TYPE_SINGLE_EVENT]
         );
 
         self::assertEquals(
@@ -1103,7 +1104,7 @@ final class SingleEventTest extends TestCase
     {
         $this->subject->setData(
             [
-                'object_type' => Event::TYPE_COMPLETE,
+                'object_type' => EventInterface::TYPE_SINGLE_EVENT,
                 'additional_information' => 'this is good to know',
             ]
         );
@@ -1120,7 +1121,7 @@ final class SingleEventTest extends TestCase
     public function setAdditionalInformationForSingleEventSetsAdditionalInformation(): void
     {
         $this->subject->setData(
-            ['object_type' => Event::TYPE_COMPLETE]
+            ['object_type' => EventInterface::TYPE_SINGLE_EVENT]
         );
         $this->subject->setAdditionalInformation('this is good to know');
 
@@ -1136,7 +1137,7 @@ final class SingleEventTest extends TestCase
     public function hasAdditionalInformationForSingleEventWithoutAdditionalInformationReturnsFalse(): void
     {
         $this->subject->setData(
-            ['object_type' => Event::TYPE_COMPLETE]
+            ['object_type' => EventInterface::TYPE_SINGLE_EVENT]
         );
 
         self::assertFalse(
@@ -1151,7 +1152,7 @@ final class SingleEventTest extends TestCase
     {
         $this->subject->setData(
             [
-                'object_type' => Event::TYPE_COMPLETE,
+                'object_type' => EventInterface::TYPE_SINGLE_EVENT,
                 'additional_information' => 'this is good to know',
             ]
         );
@@ -1171,7 +1172,7 @@ final class SingleEventTest extends TestCase
     public function allowsMultipleRegistrationForSingleEventWithUnsetAllowsMultipleRegistrationReturnsFalse(): void
     {
         $this->subject->setData(
-            ['object_type' => Event::TYPE_COMPLETE]
+            ['object_type' => EventInterface::TYPE_SINGLE_EVENT]
         );
 
         self::assertFalse(
@@ -1186,7 +1187,7 @@ final class SingleEventTest extends TestCase
     {
         $this->subject->setData(
             [
-                'object_type' => Event::TYPE_COMPLETE,
+                'object_type' => EventInterface::TYPE_SINGLE_EVENT,
                 'allows_multiple_registrations' => true,
             ]
         );
@@ -1206,7 +1207,7 @@ final class SingleEventTest extends TestCase
     public function usesTerms2ForSingleEventWithUnsetUseTerms2ReturnsFalse(): void
     {
         $this->subject->setData(
-            ['object_type' => Event::TYPE_COMPLETE]
+            ['object_type' => EventInterface::TYPE_SINGLE_EVENT]
         );
 
         self::assertFalse(
@@ -1221,7 +1222,7 @@ final class SingleEventTest extends TestCase
     {
         $this->subject->setData(
             [
-                'object_type' => Event::TYPE_COMPLETE,
+                'object_type' => EventInterface::TYPE_SINGLE_EVENT,
                 'use_terms_2' => true,
             ]
         );
@@ -1241,7 +1242,7 @@ final class SingleEventTest extends TestCase
     public function getNotesForSingleEventWithoutNotesReturnsEmptyString(): void
     {
         $this->subject->setData(
-            ['object_type' => Event::TYPE_COMPLETE]
+            ['object_type' => EventInterface::TYPE_SINGLE_EVENT]
         );
 
         self::assertEquals(
@@ -1257,7 +1258,7 @@ final class SingleEventTest extends TestCase
     {
         $this->subject->setData(
             [
-                'object_type' => Event::TYPE_COMPLETE,
+                'object_type' => EventInterface::TYPE_SINGLE_EVENT,
                 'notes' => 'Don\'t forget this.',
             ]
         );
@@ -1274,7 +1275,7 @@ final class SingleEventTest extends TestCase
     public function setNotesForSingleEventSetsNotes(): void
     {
         $this->subject->setData(
-            ['object_type' => Event::TYPE_COMPLETE]
+            ['object_type' => EventInterface::TYPE_SINGLE_EVENT]
         );
         $this->subject->setNotes('Don\'t forget this.');
 
@@ -1290,7 +1291,7 @@ final class SingleEventTest extends TestCase
     public function hasNotesForSingleEventWithoutNotesReturnsFalse(): void
     {
         $this->subject->setData(
-            ['object_type' => Event::TYPE_COMPLETE]
+            ['object_type' => EventInterface::TYPE_SINGLE_EVENT]
         );
 
         self::assertFalse(
@@ -1305,7 +1306,7 @@ final class SingleEventTest extends TestCase
     {
         $this->subject->setData(
             [
-                'object_type' => Event::TYPE_COMPLETE,
+                'object_type' => EventInterface::TYPE_SINGLE_EVENT,
                 'notes' => 'Don\'t forget this.',
             ]
         );

--- a/Tests/LegacyUnit/OldModel/LegacyEventTest.php
+++ b/Tests/LegacyUnit/OldModel/LegacyEventTest.php
@@ -11,6 +11,7 @@ use OliverKlee\Oelib\Model\FrontEndUser as OelibFrontEndUser;
 use OliverKlee\Oelib\Testing\TestingFramework;
 use OliverKlee\Seminars\Bag\EventBag;
 use OliverKlee\Seminars\Bag\OrganizerBag;
+use OliverKlee\Seminars\Domain\Model\Event\EventInterface;
 use OliverKlee\Seminars\FrontEnd\DefaultController;
 use OliverKlee\Seminars\Model\Event;
 use OliverKlee\Seminars\OldModel\LegacyEvent;
@@ -990,7 +991,7 @@ final class LegacyEventTest extends TestCase
         $topicRecordUid = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
             [
-                'object_type' => Event::TYPE_TOPIC,
+                'object_type' => EventInterface::TYPE_EVENT_TOPIC,
                 'title' => 'a test topic',
             ]
         );
@@ -1010,14 +1011,14 @@ final class LegacyEventTest extends TestCase
         $topicRecordUid = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
             [
-                'object_type' => Event::TYPE_TOPIC,
+                'object_type' => EventInterface::TYPE_EVENT_TOPIC,
                 'title' => 'a test topic',
             ]
         );
         $dateRecordUid = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
             [
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
                 'topic' => $topicRecordUid,
                 'title' => 'a test date',
             ]
@@ -1622,7 +1623,7 @@ final class LegacyEventTest extends TestCase
         $dateRecordUid = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
             [
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
                 'topic' => $topicRecordUid,
                 'language' => 'it',
             ]
@@ -1655,7 +1656,7 @@ final class LegacyEventTest extends TestCase
         $singleRecordUid = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
             [
-                'object_type' => Event::TYPE_COMPLETE,
+                'object_type' => EventInterface::TYPE_SINGLE_EVENT,
                 'topic' => $topicRecordUid,
                 'language' => 'it',
             ]
@@ -2935,7 +2936,7 @@ final class LegacyEventTest extends TestCase
         $topicRecordUid = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
             [
-                'object_type' => Event::TYPE_TOPIC,
+                'object_type' => EventInterface::TYPE_EVENT_TOPIC,
                 'event_type' => $this->testingFramework->createRecord(
                     'tx_seminars_event_types',
                     ['title' => 'foo type']
@@ -2945,7 +2946,7 @@ final class LegacyEventTest extends TestCase
         $dateRecordUid = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
             [
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
                 'topic' => $topicRecordUid,
             ]
         );
@@ -2965,7 +2966,7 @@ final class LegacyEventTest extends TestCase
         $topicRecordUid = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
             [
-                'object_type' => Event::TYPE_TOPIC,
+                'object_type' => EventInterface::TYPE_EVENT_TOPIC,
                 'event_type' => $this->testingFramework->createRecord(
                     'tx_seminars_event_types',
                     ['title' => 'foo type']
@@ -2989,14 +2990,14 @@ final class LegacyEventTest extends TestCase
         $topicRecordUid = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
             [
-                'object_type' => Event::TYPE_TOPIC,
+                'object_type' => EventInterface::TYPE_EVENT_TOPIC,
                 'event_type' => 99999,
             ]
         );
         $dateRecordUid = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
             [
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
                 'topic' => $topicRecordUid,
                 'event_type' => 199999,
             ]
@@ -4809,7 +4810,7 @@ final class LegacyEventTest extends TestCase
      */
     public function usesCorrectIconForSingleEvent(): void
     {
-        $this->subject->setRecordType(Event::TYPE_COMPLETE);
+        $this->subject->setRecordType(EventInterface::TYPE_SINGLE_EVENT);
 
         self::assertStringContainsString(
             'EventComplete.',
@@ -4822,7 +4823,7 @@ final class LegacyEventTest extends TestCase
      */
     public function usesCorrectIconForTopic(): void
     {
-        $this->subject->setRecordType(Event::TYPE_TOPIC);
+        $this->subject->setRecordType(EventInterface::TYPE_EVENT_TOPIC);
 
         self::assertStringContainsString(
             'EventTopic.',
@@ -4835,7 +4836,7 @@ final class LegacyEventTest extends TestCase
      */
     public function usesCorrectIconForDateRecord(): void
     {
-        $this->subject->setRecordType(Event::TYPE_DATE);
+        $this->subject->setRecordType(EventInterface::TYPE_EVENT_DATE);
 
         self::assertStringContainsString(
             'EventDate.',
@@ -4848,7 +4849,7 @@ final class LegacyEventTest extends TestCase
      */
     public function usesCorrectIconForHiddenSingleEvent(): void
     {
-        $this->subject->setRecordType(Event::TYPE_COMPLETE);
+        $this->subject->setRecordType(EventInterface::TYPE_SINGLE_EVENT);
         $this->subject->setHidden(true);
 
         self::assertStringContainsString('overlay-hidden', $this->subject->getRecordIcon());
@@ -4859,7 +4860,7 @@ final class LegacyEventTest extends TestCase
      */
     public function usesCorrectIconForHiddenTopic(): void
     {
-        $this->subject->setRecordType(Event::TYPE_TOPIC);
+        $this->subject->setRecordType(EventInterface::TYPE_EVENT_TOPIC);
         $this->subject->setHidden(true);
 
         self::assertStringContainsString('overlay-hidden', $this->subject->getRecordIcon());
@@ -4870,7 +4871,7 @@ final class LegacyEventTest extends TestCase
      */
     public function usesCorrectIconForHiddenDate(): void
     {
-        $this->subject->setRecordType(Event::TYPE_DATE);
+        $this->subject->setRecordType(EventInterface::TYPE_EVENT_DATE);
         $this->subject->setHidden(true);
 
         self::assertStringContainsString('overlay-hidden', $this->subject->getRecordIcon());
@@ -4881,7 +4882,7 @@ final class LegacyEventTest extends TestCase
      */
     public function usesCorrectIconForVisibleTimedSingleEvent(): void
     {
-        $this->subject->setRecordType(Event::TYPE_COMPLETE);
+        $this->subject->setRecordType(EventInterface::TYPE_SINGLE_EVENT);
         $this->subject->setRecordStartTime($GLOBALS['SIM_EXEC_TIME'] - 1000);
 
         self::assertStringContainsString(
@@ -4895,7 +4896,7 @@ final class LegacyEventTest extends TestCase
      */
     public function usesCorrectIconForVisibleTimedTopic(): void
     {
-        $this->subject->setRecordType(Event::TYPE_TOPIC);
+        $this->subject->setRecordType(EventInterface::TYPE_EVENT_TOPIC);
         $this->subject->setRecordStartTime($GLOBALS['SIM_EXEC_TIME'] - 1000);
 
         self::assertStringContainsString(
@@ -4909,7 +4910,7 @@ final class LegacyEventTest extends TestCase
      */
     public function usesCorrectIconForVisibleTimedDate(): void
     {
-        $this->subject->setRecordType(Event::TYPE_DATE);
+        $this->subject->setRecordType(EventInterface::TYPE_EVENT_DATE);
         $this->subject->setRecordStartTime($GLOBALS['SIM_EXEC_TIME'] - 1000);
 
         self::assertStringContainsString(
@@ -4923,7 +4924,7 @@ final class LegacyEventTest extends TestCase
      */
     public function usesCorrectIconForExpiredSingleEvent(): void
     {
-        $this->subject->setRecordType(Event::TYPE_COMPLETE);
+        $this->subject->setRecordType(EventInterface::TYPE_SINGLE_EVENT);
         $this->subject->setRecordEndTime($GLOBALS['SIM_EXEC_TIME'] - 1000);
 
         self::assertStringContainsString('overlay-endtime', $this->subject->getRecordIcon());
@@ -4934,7 +4935,7 @@ final class LegacyEventTest extends TestCase
      */
     public function usesCorrectIconForExpiredTimedTopic(): void
     {
-        $this->subject->setRecordType(Event::TYPE_TOPIC);
+        $this->subject->setRecordType(EventInterface::TYPE_EVENT_TOPIC);
         $this->subject->setRecordEndTime($GLOBALS['SIM_EXEC_TIME'] - 1000);
 
         self::assertStringContainsString('overlay-endtime', $this->subject->getRecordIcon());
@@ -4945,7 +4946,7 @@ final class LegacyEventTest extends TestCase
      */
     public function usesCorrectIconForExpiredTimedDate(): void
     {
-        $this->subject->setRecordType(Event::TYPE_DATE);
+        $this->subject->setRecordType(EventInterface::TYPE_EVENT_DATE);
         $this->subject->setRecordEndTime($GLOBALS['SIM_EXEC_TIME'] - 1000);
 
         self::assertStringContainsString('overlay-endtime', $this->subject->getRecordIcon());
@@ -5500,7 +5501,7 @@ final class LegacyEventTest extends TestCase
             $this->testingFramework->createRecord(
                 'tx_seminars_seminars',
                 [
-                    'object_type' => Event::TYPE_TOPIC,
+                    'object_type' => EventInterface::TYPE_EVENT_TOPIC,
                     'requirements' => 0,
                 ]
             )
@@ -5519,7 +5520,7 @@ final class LegacyEventTest extends TestCase
         $topicUid = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
             [
-                'object_type' => Event::TYPE_TOPIC,
+                'object_type' => EventInterface::TYPE_EVENT_TOPIC,
                 'requirements' => 0,
             ]
         );
@@ -5527,7 +5528,7 @@ final class LegacyEventTest extends TestCase
             $this->testingFramework->createRecord(
                 'tx_seminars_seminars',
                 [
-                    'object_type' => Event::TYPE_DATE,
+                    'object_type' => EventInterface::TYPE_EVENT_DATE,
                     'topic' => $topicUid,
                 ]
             )
@@ -5545,11 +5546,11 @@ final class LegacyEventTest extends TestCase
     {
         $topicUid = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
-            ['object_type' => Event::TYPE_TOPIC]
+            ['object_type' => EventInterface::TYPE_EVENT_TOPIC]
         );
         $requiredTopicUid = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
-            ['object_type' => Event::TYPE_TOPIC]
+            ['object_type' => EventInterface::TYPE_EVENT_TOPIC]
         );
         $this->testingFramework->createRelationAndUpdateCounter(
             'tx_seminars_seminars',
@@ -5571,11 +5572,11 @@ final class LegacyEventTest extends TestCase
     {
         $topicUid = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
-            ['object_type' => Event::TYPE_TOPIC]
+            ['object_type' => EventInterface::TYPE_EVENT_TOPIC]
         );
         $requiredTopicUid = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
-            ['object_type' => Event::TYPE_TOPIC]
+            ['object_type' => EventInterface::TYPE_EVENT_TOPIC]
         );
         $this->testingFramework->createRelationAndUpdateCounter(
             'tx_seminars_seminars',
@@ -5587,7 +5588,7 @@ final class LegacyEventTest extends TestCase
             $this->testingFramework->createRecord(
                 'tx_seminars_seminars',
                 [
-                    'object_type' => Event::TYPE_DATE,
+                    'object_type' => EventInterface::TYPE_EVENT_DATE,
                     'topic' => $topicUid,
                 ]
             )
@@ -5605,11 +5606,11 @@ final class LegacyEventTest extends TestCase
     {
         $topicUid = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
-            ['object_type' => Event::TYPE_TOPIC]
+            ['object_type' => EventInterface::TYPE_EVENT_TOPIC]
         );
         $requiredTopicUid1 = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
-            ['object_type' => Event::TYPE_TOPIC]
+            ['object_type' => EventInterface::TYPE_EVENT_TOPIC]
         );
         $this->testingFramework->createRelationAndUpdateCounter(
             'tx_seminars_seminars',
@@ -5619,7 +5620,7 @@ final class LegacyEventTest extends TestCase
         );
         $requiredTopicUid2 = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
-            ['object_type' => Event::TYPE_TOPIC]
+            ['object_type' => EventInterface::TYPE_EVENT_TOPIC]
         );
         $this->testingFramework->createRelationAndUpdateCounter(
             'tx_seminars_seminars',
@@ -5645,7 +5646,7 @@ final class LegacyEventTest extends TestCase
             $this->testingFramework->createRecord(
                 'tx_seminars_seminars',
                 [
-                    'object_type' => Event::TYPE_TOPIC,
+                    'object_type' => EventInterface::TYPE_EVENT_TOPIC,
                     'dependencies' => 0,
                 ]
             )
@@ -5664,7 +5665,7 @@ final class LegacyEventTest extends TestCase
         $topicUid = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
             [
-                'object_type' => Event::TYPE_TOPIC,
+                'object_type' => EventInterface::TYPE_EVENT_TOPIC,
                 'dependencies' => 0,
             ]
         );
@@ -5672,7 +5673,7 @@ final class LegacyEventTest extends TestCase
             $this->testingFramework->createRecord(
                 'tx_seminars_seminars',
                 [
-                    'object_type' => Event::TYPE_DATE,
+                    'object_type' => EventInterface::TYPE_EVENT_DATE,
                     'topic' => $topicUid,
                 ]
             )
@@ -5691,14 +5692,14 @@ final class LegacyEventTest extends TestCase
         $topicUid = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
             [
-                'object_type' => Event::TYPE_TOPIC,
+                'object_type' => EventInterface::TYPE_EVENT_TOPIC,
                 'dependencies' => 1,
             ]
         );
         $dependentTopicUid = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
             [
-                'object_type' => Event::TYPE_TOPIC,
+                'object_type' => EventInterface::TYPE_EVENT_TOPIC,
                 'requirements' => 1,
             ]
         );
@@ -5722,14 +5723,14 @@ final class LegacyEventTest extends TestCase
         $topicUid = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
             [
-                'object_type' => Event::TYPE_TOPIC,
+                'object_type' => EventInterface::TYPE_EVENT_TOPIC,
                 'dependencies' => 1,
             ]
         );
         $dependentTopicUid = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
             [
-                'object_type' => Event::TYPE_TOPIC,
+                'object_type' => EventInterface::TYPE_EVENT_TOPIC,
                 'requirements' => 1,
             ]
         );
@@ -5742,7 +5743,7 @@ final class LegacyEventTest extends TestCase
             $this->testingFramework->createRecord(
                 'tx_seminars_seminars',
                 [
-                    'object_type' => Event::TYPE_DATE,
+                    'object_type' => EventInterface::TYPE_EVENT_DATE,
                     'topic' => $topicUid,
                 ]
             )
@@ -5761,14 +5762,14 @@ final class LegacyEventTest extends TestCase
         $topicUid = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
             [
-                'object_type' => Event::TYPE_TOPIC,
+                'object_type' => EventInterface::TYPE_EVENT_TOPIC,
                 'dependencies' => 2,
             ]
         );
         $dependentTopicUid1 = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
             [
-                'object_type' => Event::TYPE_TOPIC,
+                'object_type' => EventInterface::TYPE_EVENT_TOPIC,
                 'requirements' => 1,
             ]
         );
@@ -5780,7 +5781,7 @@ final class LegacyEventTest extends TestCase
         $dependentTopicUid2 = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
             [
-                'object_type' => Event::TYPE_TOPIC,
+                'object_type' => EventInterface::TYPE_EVENT_TOPIC,
                 'requirements' => 1,
             ]
         );
@@ -5824,11 +5825,11 @@ final class LegacyEventTest extends TestCase
     {
         $topicUid = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
-            ['object_type' => Event::TYPE_TOPIC]
+            ['object_type' => EventInterface::TYPE_EVENT_TOPIC]
         );
         $requiredTopicUid = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
-            ['object_type' => Event::TYPE_TOPIC]
+            ['object_type' => EventInterface::TYPE_EVENT_TOPIC]
         );
         $this->testingFramework->createRelationAndUpdateCounter(
             'tx_seminars_seminars',
@@ -5856,11 +5857,11 @@ final class LegacyEventTest extends TestCase
     {
         $topicUid = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
-            ['object_type' => Event::TYPE_TOPIC]
+            ['object_type' => EventInterface::TYPE_EVENT_TOPIC]
         );
         $requiredTopicUid = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
-            ['object_type' => Event::TYPE_TOPIC]
+            ['object_type' => EventInterface::TYPE_EVENT_TOPIC]
         );
         $this->testingFramework->createRelationAndUpdateCounter(
             'tx_seminars_seminars',
@@ -5872,7 +5873,7 @@ final class LegacyEventTest extends TestCase
             $this->testingFramework->createRecord(
                 'tx_seminars_seminars',
                 [
-                    'object_type' => Event::TYPE_DATE,
+                    'object_type' => EventInterface::TYPE_EVENT_DATE,
                     'topic' => $topicUid,
                 ]
             )
@@ -5897,11 +5898,11 @@ final class LegacyEventTest extends TestCase
     {
         $topicUid = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
-            ['object_type' => Event::TYPE_TOPIC]
+            ['object_type' => EventInterface::TYPE_EVENT_TOPIC]
         );
         $requiredTopicUid1 = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
-            ['object_type' => Event::TYPE_TOPIC]
+            ['object_type' => EventInterface::TYPE_EVENT_TOPIC]
         );
         $this->testingFramework->createRelationAndUpdateCounter(
             'tx_seminars_seminars',
@@ -5911,7 +5912,7 @@ final class LegacyEventTest extends TestCase
         );
         $requiredTopicUid2 = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
-            ['object_type' => Event::TYPE_TOPIC]
+            ['object_type' => EventInterface::TYPE_EVENT_TOPIC]
         );
         $this->testingFramework->createRelationAndUpdateCounter(
             'tx_seminars_seminars',
@@ -5956,14 +5957,14 @@ final class LegacyEventTest extends TestCase
         $topicUid = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
             [
-                'object_type' => Event::TYPE_TOPIC,
+                'object_type' => EventInterface::TYPE_EVENT_TOPIC,
                 'dependencies' => 1,
             ]
         );
         $dependentTopicUid = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
             [
-                'object_type' => Event::TYPE_TOPIC,
+                'object_type' => EventInterface::TYPE_EVENT_TOPIC,
                 'requirements' => 1,
             ]
         );
@@ -5993,14 +5994,14 @@ final class LegacyEventTest extends TestCase
         $topicUid = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
             [
-                'object_type' => Event::TYPE_TOPIC,
+                'object_type' => EventInterface::TYPE_EVENT_TOPIC,
                 'dependencies' => 1,
             ]
         );
         $dependentTopicUid = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
             [
-                'object_type' => Event::TYPE_TOPIC,
+                'object_type' => EventInterface::TYPE_EVENT_TOPIC,
                 'requirements' => 1,
             ]
         );
@@ -6013,7 +6014,7 @@ final class LegacyEventTest extends TestCase
             $this->testingFramework->createRecord(
                 'tx_seminars_seminars',
                 [
-                    'object_type' => Event::TYPE_DATE,
+                    'object_type' => EventInterface::TYPE_EVENT_DATE,
                     'topic' => $topicUid,
                 ]
             )
@@ -6039,14 +6040,14 @@ final class LegacyEventTest extends TestCase
         $topicUid = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
             [
-                'object_type' => Event::TYPE_TOPIC,
+                'object_type' => EventInterface::TYPE_EVENT_TOPIC,
                 'dependencies' => 2,
             ]
         );
         $dependentTopicUid1 = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
             [
-                'object_type' => Event::TYPE_TOPIC,
+                'object_type' => EventInterface::TYPE_EVENT_TOPIC,
                 'requirements' => 1,
             ]
         );
@@ -6058,7 +6059,7 @@ final class LegacyEventTest extends TestCase
         $dependentTopicUid2 = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
             [
-                'object_type' => Event::TYPE_TOPIC,
+                'object_type' => EventInterface::TYPE_EVENT_TOPIC,
                 'requirements' => 1,
             ]
         );
@@ -7147,14 +7148,14 @@ final class LegacyEventTest extends TestCase
         $topicRecordUid = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
             [
-                'object_type' => Event::TYPE_TOPIC,
+                'object_type' => EventInterface::TYPE_EVENT_TOPIC,
                 'credit_points' => 42,
             ]
         );
         $dateRecordUid = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
             [
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
                 'topic' => $topicRecordUid,
             ]
         );
@@ -7213,14 +7214,14 @@ final class LegacyEventTest extends TestCase
         $topicRecordUid = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
             [
-                'object_type' => Event::TYPE_TOPIC,
+                'object_type' => EventInterface::TYPE_EVENT_TOPIC,
                 'credit_points' => 0,
             ]
         );
         $dateRecordUid = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
             [
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
                 'topic' => $topicRecordUid,
             ]
         );
@@ -7240,14 +7241,14 @@ final class LegacyEventTest extends TestCase
         $topicRecordUid = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
             [
-                'object_type' => Event::TYPE_TOPIC,
+                'object_type' => EventInterface::TYPE_EVENT_TOPIC,
                 'credit_points' => 1,
             ]
         );
         $dateRecordUid = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
             [
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
                 'topic' => $topicRecordUid,
             ]
         );
@@ -8578,11 +8579,11 @@ final class LegacyEventTest extends TestCase
     {
         $topicUid = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
-            ['object_type' => Event::TYPE_TOPIC, 'price_on_request' => false]
+            ['object_type' => EventInterface::TYPE_EVENT_TOPIC, 'price_on_request' => false]
         );
         $dateUid = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
-            ['object_type' => Event::TYPE_DATE, 'topic' => $topicUid]
+            ['object_type' => EventInterface::TYPE_EVENT_DATE, 'topic' => $topicUid]
         );
         $date = new LegacyEvent($dateUid);
 
@@ -8596,11 +8597,11 @@ final class LegacyEventTest extends TestCase
     {
         $topicUid = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
-            ['object_type' => Event::TYPE_TOPIC, 'price_on_request' => true]
+            ['object_type' => EventInterface::TYPE_EVENT_TOPIC, 'price_on_request' => true]
         );
         $dateUid = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
-            ['object_type' => Event::TYPE_DATE, 'topic' => $topicUid]
+            ['object_type' => EventInterface::TYPE_EVENT_DATE, 'topic' => $topicUid]
         );
         $date = new LegacyEvent($dateUid);
 

--- a/Tests/LegacyUnit/Service/RegistrationManagerTest.php
+++ b/Tests/LegacyUnit/Service/RegistrationManagerTest.php
@@ -17,6 +17,7 @@ use OliverKlee\Oelib\Model\FrontEndUser as OelibFrontEndUser;
 use OliverKlee\Oelib\Templating\Template;
 use OliverKlee\Oelib\Testing\TestingFramework;
 use OliverKlee\Seminars\Bag\EventBag;
+use OliverKlee\Seminars\Domain\Model\Event\EventInterface;
 use OliverKlee\Seminars\FrontEnd\DefaultController;
 use OliverKlee\Seminars\Hooks\Interfaces\RegistrationEmail;
 use OliverKlee\Seminars\Mapper\EventMapper;
@@ -964,13 +965,13 @@ final class RegistrationManagerTest extends TestCase
 
         $topicUid = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
-            ['object_type' => Event::TYPE_TOPIC]
+            ['object_type' => EventInterface::TYPE_EVENT_TOPIC]
         );
         $this->cachedSeminar = new TestingLegacyEvent(
             $this->testingFramework->createRecord(
                 'tx_seminars_seminars',
                 [
-                    'object_type' => Event::TYPE_DATE,
+                    'object_type' => EventInterface::TYPE_EVENT_DATE,
                     'topic' => $topicUid,
                 ]
             )
@@ -988,12 +989,12 @@ final class RegistrationManagerTest extends TestCase
     {
         $requiredTopicUid = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
-            ['object_type' => Event::TYPE_TOPIC]
+            ['object_type' => EventInterface::TYPE_EVENT_TOPIC]
         );
         $requiredDateUid = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
             [
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
                 'topic' => $requiredTopicUid,
             ]
         );
@@ -1007,7 +1008,7 @@ final class RegistrationManagerTest extends TestCase
 
         $topicUid = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
-            ['object_type' => Event::TYPE_TOPIC]
+            ['object_type' => EventInterface::TYPE_EVENT_TOPIC]
         );
         $this->testingFramework->createRelationAndUpdateCounter(
             'tx_seminars_seminars',
@@ -1020,7 +1021,7 @@ final class RegistrationManagerTest extends TestCase
             $this->testingFramework->createRecord(
                 'tx_seminars_seminars',
                 [
-                    'object_type' => Event::TYPE_DATE,
+                    'object_type' => EventInterface::TYPE_EVENT_DATE,
                     'topic' => $topicUid,
                 ]
             )
@@ -1039,18 +1040,18 @@ final class RegistrationManagerTest extends TestCase
         $this->testingFramework->createAndLoginFrontEndUser();
         $requiredTopicUid = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
-            ['object_type' => Event::TYPE_TOPIC]
+            ['object_type' => EventInterface::TYPE_EVENT_TOPIC]
         );
         $this->testingFramework->createRecord(
             'tx_seminars_seminars',
             [
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
                 'topic' => $requiredTopicUid,
             ]
         );
         $topicUid = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
-            ['object_type' => Event::TYPE_TOPIC]
+            ['object_type' => EventInterface::TYPE_EVENT_TOPIC]
         );
         $this->testingFramework->createRelationAndUpdateCounter(
             'tx_seminars_seminars',
@@ -1063,7 +1064,7 @@ final class RegistrationManagerTest extends TestCase
             $this->testingFramework->createRecord(
                 'tx_seminars_seminars',
                 [
-                    'object_type' => Event::TYPE_DATE,
+                    'object_type' => EventInterface::TYPE_EVENT_DATE,
                     'topic' => $topicUid,
                 ]
             )
@@ -1095,18 +1096,18 @@ final class RegistrationManagerTest extends TestCase
         $this->testingFramework->createAndLoginFrontEndUser();
         $requiredTopicUid = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
-            ['object_type' => Event::TYPE_TOPIC]
+            ['object_type' => EventInterface::TYPE_EVENT_TOPIC]
         );
         $this->testingFramework->createRecord(
             'tx_seminars_seminars',
             [
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
                 'topic' => $requiredTopicUid,
             ]
         );
         $topicUid = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
-            ['object_type' => Event::TYPE_TOPIC]
+            ['object_type' => EventInterface::TYPE_EVENT_TOPIC]
         );
         $this->testingFramework->createRelationAndUpdateCounter(
             'tx_seminars_seminars',
@@ -1119,7 +1120,7 @@ final class RegistrationManagerTest extends TestCase
             $this->testingFramework->createRecord(
                 'tx_seminars_seminars',
                 [
-                    'object_type' => Event::TYPE_DATE,
+                    'object_type' => EventInterface::TYPE_EVENT_DATE,
                     'topic' => $topicUid,
                 ]
             )
@@ -1142,18 +1143,18 @@ final class RegistrationManagerTest extends TestCase
         $this->testingFramework->createAndLoginFrontEndUser();
         $requiredTopicUid = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
-            ['object_type' => Event::TYPE_TOPIC]
+            ['object_type' => EventInterface::TYPE_EVENT_TOPIC]
         );
         $this->testingFramework->createRecord(
             'tx_seminars_seminars',
             [
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
                 'topic' => $requiredTopicUid,
             ]
         );
         $topicUid = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
-            ['object_type' => Event::TYPE_TOPIC]
+            ['object_type' => EventInterface::TYPE_EVENT_TOPIC]
         );
         $this->testingFramework->createRelationAndUpdateCounter(
             'tx_seminars_seminars',
@@ -1166,7 +1167,7 @@ final class RegistrationManagerTest extends TestCase
             $this->testingFramework->createRecord(
                 'tx_seminars_seminars',
                 [
-                    'object_type' => Event::TYPE_DATE,
+                    'object_type' => EventInterface::TYPE_EVENT_DATE,
                     'topic' => $topicUid,
                 ]
             )
@@ -1189,17 +1190,17 @@ final class RegistrationManagerTest extends TestCase
         $this->testingFramework->createAndLoginFrontEndUser();
         $topicUid = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
-            ['object_type' => Event::TYPE_TOPIC]
+            ['object_type' => EventInterface::TYPE_EVENT_TOPIC]
         );
 
         $requiredTopicUid1 = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
-            ['object_type' => Event::TYPE_TOPIC]
+            ['object_type' => EventInterface::TYPE_EVENT_TOPIC]
         );
         $this->testingFramework->createRecord(
             'tx_seminars_seminars',
             [
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
                 'topic' => $requiredTopicUid1,
             ]
         );
@@ -1212,12 +1213,12 @@ final class RegistrationManagerTest extends TestCase
 
         $requiredTopicUid2 = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
-            ['object_type' => Event::TYPE_TOPIC]
+            ['object_type' => EventInterface::TYPE_EVENT_TOPIC]
         );
         $this->testingFramework->createRecord(
             'tx_seminars_seminars',
             [
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
                 'topic' => $requiredTopicUid2,
             ]
         );
@@ -1232,7 +1233,7 @@ final class RegistrationManagerTest extends TestCase
             $this->testingFramework->createRecord(
                 'tx_seminars_seminars',
                 [
-                    'object_type' => Event::TYPE_DATE,
+                    'object_type' => EventInterface::TYPE_EVENT_DATE,
                     'topic' => $topicUid,
                 ]
             )
@@ -1255,17 +1256,17 @@ final class RegistrationManagerTest extends TestCase
         $userUid = $this->testingFramework->createAndLoginFrontEndUser();
         $topicUid = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
-            ['object_type' => Event::TYPE_TOPIC]
+            ['object_type' => EventInterface::TYPE_EVENT_TOPIC]
         );
 
         $requiredTopicUid1 = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
-            ['object_type' => Event::TYPE_TOPIC]
+            ['object_type' => EventInterface::TYPE_EVENT_TOPIC]
         );
         $requiredDateUid1 = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
             [
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
                 'topic' => $requiredTopicUid1,
             ]
         );
@@ -1282,7 +1283,7 @@ final class RegistrationManagerTest extends TestCase
 
         $requiredTopicUid2 = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
-            ['object_type' => Event::TYPE_TOPIC]
+            ['object_type' => EventInterface::TYPE_EVENT_TOPIC]
         );
         $this->testingFramework->createRelationAndUpdateCounter(
             'tx_seminars_seminars',
@@ -1295,7 +1296,7 @@ final class RegistrationManagerTest extends TestCase
             $this->testingFramework->createRecord(
                 'tx_seminars_seminars',
                 [
-                    'object_type' => Event::TYPE_DATE,
+                    'object_type' => EventInterface::TYPE_EVENT_DATE,
                     'topic' => $topicUid,
                 ]
             )
@@ -1318,17 +1319,17 @@ final class RegistrationManagerTest extends TestCase
         $userUid = $this->testingFramework->createAndLoginFrontEndUser();
         $topicUid = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
-            ['object_type' => Event::TYPE_TOPIC]
+            ['object_type' => EventInterface::TYPE_EVENT_TOPIC]
         );
 
         $requiredTopicUid1 = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
-            ['object_type' => Event::TYPE_TOPIC]
+            ['object_type' => EventInterface::TYPE_EVENT_TOPIC]
         );
         $requiredDateUid1 = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
             [
-                'object_type' => Event::TYPE_DATE,
+                'object_type' => EventInterface::TYPE_EVENT_DATE,
                 'topic' => $requiredTopicUid1,
             ]
         );
@@ -1345,7 +1346,7 @@ final class RegistrationManagerTest extends TestCase
 
         $requiredTopicUid2 = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
-            ['object_type' => Event::TYPE_TOPIC]
+            ['object_type' => EventInterface::TYPE_EVENT_TOPIC]
         );
         $this->testingFramework->createRelationAndUpdateCounter(
             'tx_seminars_seminars',
@@ -1358,7 +1359,7 @@ final class RegistrationManagerTest extends TestCase
             $this->testingFramework->createRecord(
                 'tx_seminars_seminars',
                 [
-                    'object_type' => Event::TYPE_DATE,
+                    'object_type' => EventInterface::TYPE_EVENT_DATE,
                     'topic' => $topicUid,
                 ]
             )

--- a/Tests/Unit/OldModel/LegacyEventTest.php
+++ b/Tests/Unit/OldModel/LegacyEventTest.php
@@ -7,7 +7,7 @@ namespace OliverKlee\Seminars\Tests\Unit\OldModel;
 use Nimut\TestingFramework\TestCase\UnitTestCase;
 use OliverKlee\Oelib\Email\SystemEmailFromBuilder;
 use OliverKlee\Seminars\Bag\OrganizerBag;
-use OliverKlee\Seminars\Model\Event;
+use OliverKlee\Seminars\Domain\Model\Event\EventInterface;
 use OliverKlee\Seminars\OldModel\AbstractModel;
 use OliverKlee\Seminars\OldModel\LegacyEvent;
 use OliverKlee\Seminars\OldModel\LegacyOrganizer;
@@ -175,11 +175,11 @@ final class LegacyEventTest extends UnitTestCase
     public function hasCheckboxesForDateWithOneCheckboxReturnsTrue(): void
     {
         $data = [
-            'object_type' => Event::TYPE_DATE,
+            'object_type' => EventInterface::TYPE_EVENT_DATE,
             'checkboxes' => 1,
         ];
         $subject = LegacyEvent::fromData($data);
-        $topic = LegacyEvent::fromData(['object_type' => Event::TYPE_TOPIC]);
+        $topic = LegacyEvent::fromData(['object_type' => EventInterface::TYPE_EVENT_TOPIC]);
         $subject->setTopic($topic);
 
         self::assertTrue($subject->hasCheckboxes());
@@ -322,8 +322,8 @@ final class LegacyEventTest extends UnitTestCase
      */
     public function hasAttachedFilesForDateWithoutFilesAndTopicWithOneFileReturnsTrue(): void
     {
-        $topic = LegacyEvent::fromData(['object_type' => Event::TYPE_TOPIC, 'attached_files' => 1]);
-        $date = LegacyEvent::fromData(['object_type' => Event::TYPE_DATE]);
+        $topic = LegacyEvent::fromData(['object_type' => EventInterface::TYPE_EVENT_TOPIC, 'attached_files' => 1]);
+        $date = LegacyEvent::fromData(['object_type' => EventInterface::TYPE_EVENT_DATE]);
         $date->setTopic($topic);
 
         self::assertTrue($date->hasAttachedFiles());
@@ -334,8 +334,8 @@ final class LegacyEventTest extends UnitTestCase
      */
     public function hasAttachedFilesForDateWithOneFileAndTopicWithoutFilesReturnsTrue(): void
     {
-        $topic = LegacyEvent::fromData(['object_type' => Event::TYPE_TOPIC]);
-        $date = LegacyEvent::fromData(['object_type' => Event::TYPE_DATE, 'attached_files' => 1]);
+        $topic = LegacyEvent::fromData(['object_type' => EventInterface::TYPE_EVENT_TOPIC]);
+        $date = LegacyEvent::fromData(['object_type' => EventInterface::TYPE_EVENT_DATE, 'attached_files' => 1]);
         $date->setTopic($topic);
 
         self::assertTrue($date->hasAttachedFiles());
@@ -346,8 +346,8 @@ final class LegacyEventTest extends UnitTestCase
      */
     public function hasAttachedFilesForDateAndTopicWithoutFilesReturnsFalse(): void
     {
-        $topic = LegacyEvent::fromData(['object_type' => Event::TYPE_TOPIC]);
-        $date = LegacyEvent::fromData(['object_type' => Event::TYPE_DATE]);
+        $topic = LegacyEvent::fromData(['object_type' => EventInterface::TYPE_EVENT_TOPIC]);
+        $date = LegacyEvent::fromData(['object_type' => EventInterface::TYPE_EVENT_DATE]);
         $date->setTopic($topic);
 
         self::assertFalse($date->hasAttachedFiles());


### PR DESCRIPTION
Part of #1607