### PR TITLE
[TASK] Rename `Event.owner` to `.ownerUid`

### DIFF
--- a/Classes/Domain/Repository/Event/EventRepository.php
+++ b/Classes/Domain/Repository/Event/EventRepository.php
@@ -37,7 +37,7 @@ class EventRepository extends Repository implements DirectPersist
         $query->setOrderings(['title' => QueryInterface::ORDER_ASCENDING]);
 
         $objectTypeMatcher = $query->equals('objectType', EventInterface::TYPE_SINGLE_EVENT);
-        $ownerMatcher = $query->equals('owner', $ownerUid);
+        $ownerMatcher = $query->equals('ownerUid', $ownerUid);
         $query->matching($query->logicalAnd($objectTypeMatcher, $ownerMatcher));
 
         return $query->execute()->toArray();

--- a/Configuration/Extbase/Persistence/Classes.php
+++ b/Configuration/Extbase/Persistence/Classes.php
@@ -15,7 +15,7 @@ return [
             => \OliverKlee\Seminars\Domain\Model\Event\EventDate::class,
         ],
         'properties' => [
-            'owner' => ['fieldName' => 'owner_feuser'],
+            'ownerUid' => ['fieldName' => 'owner_feuser'],
         ],
     ],
     \OliverKlee\Seminars\Domain\Model\Event\SingleEvent::class => [

--- a/ext_typoscript_setup.txt
+++ b/ext_typoscript_setup.txt
@@ -4,7 +4,7 @@ config.tx_extbase.persistence.classes {
         mapping {
             tableName = tx_seminars_seminars
             columns {
-                owner_feuser.mapOnProperty = owner
+                owner_feuser.mapOnProperty = ownerUid
             }
         }
 


### PR DESCRIPTION
This helps communicate that this property holds only a record UID, but not actually a relation to the record.

Part of #1646