### PR TITLE
[BUGFIX] Make the value field for `NullEventType` auto-recognizable

### DIFF
--- a/Classes/Domain/Model/NullEventType.php
+++ b/Classes/Domain/Model/NullEventType.php
@@ -4,10 +4,12 @@ declare(strict_types=1);
 
 namespace OliverKlee\Seminars\Domain\Model;
 
+use TYPO3\CMS\Extbase\DomainObject\AbstractDomainObject;
+
 /**
  * Dummy event type to be used as empty option in selects.
  */
-class NullEventType implements EventTypeInterface
+class NullEventType extends AbstractDomainObject implements EventTypeInterface
 {
     /**
      * @return 0

--- a/Resources/Private/Partials/FrontEndEditor/Form.html
+++ b/Resources/Private/Partials/FrontEndEditor/Form.html
@@ -29,7 +29,7 @@
             </label>
             <div class="col-sm-10">
                 <f:form.select property="eventType" id="{idPrefix}-eventType"
-                               options="{eventTypes}" optionLabelField="title" optionValueField="uid"
+                               options="{eventTypes}" optionLabelField="title"
                                class="form-select" errorClass="is-invalid"/>
             </div>
         </div>

--- a/Tests/Unit/Domain/Model/NullEventTypeTest.php
+++ b/Tests/Unit/Domain/Model/NullEventTypeTest.php
@@ -7,6 +7,7 @@ namespace OliverKlee\Seminars\Tests\Unit\Domain\Model;
 use Nimut\TestingFramework\TestCase\UnitTestCase;
 use OliverKlee\Seminars\Domain\Model\EventTypeInterface;
 use OliverKlee\Seminars\Domain\Model\NullEventType;
+use TYPO3\CMS\Extbase\DomainObject\AbstractDomainObject;
 
 /**
  * @covers \OliverKlee\Seminars\Domain\Model\NullEventType
@@ -23,6 +24,14 @@ final class NullEventTypeTest extends UnitTestCase
         parent::setUp();
 
         $this->subject = new NullEventType();
+    }
+
+    /**
+     * @test
+     */
+    public function isDomainObject(): void
+    {
+        self::assertInstanceOf(AbstractDomainObject::class, $this->subject);
     }
 
     /**


### PR DESCRIPTION
Fixes #1691