### PR TITLE
[BUGFIX] Allow setting `Event.eventType` to null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Removed
 
 ### Fixed
+- Allow saving events without event type in the FE editor (#1712)
 
 ## 4.2.0
 

--- a/Classes/Domain/Model/Event/EventTopicTrait.php
+++ b/Classes/Domain/Model/Event/EventTopicTrait.php
@@ -93,7 +93,7 @@ trait EventTopicTrait
         return $eventType;
     }
 
-    public function setEventType(EventType $eventType): void
+    public function setEventType(?EventType $eventType): void
     {
         $this->eventType = $eventType;
     }

--- a/Tests/Functional/Domain/Repository/Event/EventRepositoryTest.php
+++ b/Tests/Functional/Domain/Repository/Event/EventRepositoryTest.php
@@ -73,6 +73,7 @@ final class EventRepositoryTest extends FunctionalTestCase
         self::assertEqualsWithDelta(150.0, $result->getStandardPrice(), 0.0001);
         self::assertEqualsWithDelta(125.0, $result->getEarlyBirdPrice(), 0.0001);
         self::assertSame(15, $result->getOwnerUid());
+        self::assertNull($result->getEventType());
     }
 
     /**
@@ -107,6 +108,7 @@ final class EventRepositoryTest extends FunctionalTestCase
         self::assertEqualsWithDelta(150.0, $result->getStandardPrice(), 0.0001);
         self::assertEqualsWithDelta(125.0, $result->getEarlyBirdPrice(), 0.0001);
         self::assertSame(15, $result->getOwnerUid());
+        self::assertNull($result->getEventType());
     }
 
     /**

--- a/Tests/Unit/Domain/Model/Event/EventTopicTest.php
+++ b/Tests/Unit/Domain/Model/Event/EventTopicTest.php
@@ -208,6 +208,16 @@ final class EventTopicTest extends UnitTestCase
     /**
      * @test
      */
+    public function setEventTypeCanSetEventTypeToNull(): void
+    {
+        $this->subject->setEventType(null);
+
+        self::assertNull($this->subject->getEventType());
+    }
+
+    /**
+     * @test
+     */
     public function getOwnerUidInitiallyReturnsZero(): void
     {
         self::assertSame(0, $this->subject->getOwnerUid());

--- a/Tests/Unit/Domain/Model/Event/SingleEventTest.php
+++ b/Tests/Unit/Domain/Model/Event/SingleEventTest.php
@@ -412,6 +412,16 @@ final class SingleEventTest extends UnitTestCase
     /**
      * @test
      */
+    public function setEventTypeCanSetEventTypeToNull(): void
+    {
+        $this->subject->setEventType(null);
+
+        self::assertNull($this->subject->getEventType());
+    }
+
+    /**
+     * @test
+     */
     public function getVenuesInitiallyReturnsEmptyStorage(): void
     {
         $associatedModels = $this->subject->getVenues();


### PR DESCRIPTION
Part of #1701