### PR TITLE
[TASK] Drop the `Event.getOrganizer()` alias method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Deprecated
 
 ### Removed
+- Drop the `Event.getOrganizer()` alias method (#1727)
 
 ### Fixed
 

--- a/Classes/Domain/Model/Event/EventDateInterface.php
+++ b/Classes/Domain/Model/Event/EventDateInterface.php
@@ -51,13 +51,5 @@ interface EventDateInterface
      */
     public function getOrganizers(): ObjectStorage;
 
-    /**
-     * @deprecated will be removed in seminars 6.0.
-     */
     public function getFirstOrganizer(): ?Organizer;
-
-    /**
-     * Alias for `getFirstOrganizer()`.
-     */
-    public function getOrganizer(): ?Organizer;
 }

--- a/Classes/Domain/Model/Event/EventDateTrait.php
+++ b/Classes/Domain/Model/Event/EventDateTrait.php
@@ -224,21 +224,10 @@ trait EventDateTrait
         $this->organizers = $organizers;
     }
 
-    /**
-     * @deprecated will be removed in seminars 6.0.
-     */
     public function getFirstOrganizer(): ?Organizer
     {
         $organizers = $this->getOrganizers();
 
         return \count($organizers) > 0 ? $organizers->current() : null;
-    }
-
-    /**
-     * Alias for `getFirstOrganizer()`.
-     */
-    public function getOrganizer(): ?Organizer
-    {
-        return $this->getFirstOrganizer();
     }
 }

--- a/Tests/Unit/Domain/Model/Event/EventDateTest.php
+++ b/Tests/Unit/Domain/Model/Event/EventDateTest.php
@@ -499,30 +499,6 @@ final class EventDateTest extends UnitTestCase
     /**
      * @test
      */
-    public function getOrganizerWithNoOrganizersReturnsNull(): void
-    {
-        self::assertNull($this->subject->getOrganizer());
-    }
-
-    /**
-     * @test
-     */
-    public function getOrganizerWithTwoOrganizersReturnsFirstOrganizer(): void
-    {
-        /** @var ObjectStorage<Organizer> $organizers */
-        $organizers = new ObjectStorage();
-        $organizer1 = new Organizer();
-        $organizers->attach($organizer1);
-        $organizer2 = new Organizer();
-        $organizers->attach($organizer2);
-        $this->subject->setOrganizers($organizers);
-
-        self::assertSame($organizer1, $this->subject->getOrganizer());
-    }
-
-    /**
-     * @test
-     */
     public function getOwnerUidInitiallyReturnsZero(): void
     {
         self::assertSame(0, $this->subject->getOwnerUid());

--- a/Tests/Unit/Domain/Model/Event/SingleEventTest.php
+++ b/Tests/Unit/Domain/Model/Event/SingleEventTest.php
@@ -515,30 +515,6 @@ final class SingleEventTest extends UnitTestCase
     /**
      * @test
      */
-    public function getOrganizerWithNoOrganizersReturnsNull(): void
-    {
-        self::assertNull($this->subject->getOrganizer());
-    }
-
-    /**
-     * @test
-     */
-    public function getOrganizerWithTwoOrganizersReturnsFirstOrganizer(): void
-    {
-        /** @var ObjectStorage<Organizer> $organizers */
-        $organizers = new ObjectStorage();
-        $organizer1 = new Organizer();
-        $organizers->attach($organizer1);
-        $organizer2 = new Organizer();
-        $organizers->attach($organizer2);
-        $this->subject->setOrganizers($organizers);
-
-        self::assertSame($organizer1, $this->subject->getOrganizer());
-    }
-
-    /**
-     * @test
-     */
     public function getOwnerUidInitiallyReturnsZero(): void
     {
         self::assertSame(0, $this->subject->getOwnerUid());


### PR DESCRIPTION
This method was an alias for `Event.getFirstOrganizer()`.

According to the survey, there are enough installations that have events with more than one organizer.

Fixes #1722