### PR TITLE
[BUGFIX] Fix `Event.getFirstOrganizer()` for not-rewound storages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Drop the `Event.getOrganizer()` alias method (#1727)
 
 ### Fixed
+- Fix `Event.getFirstOrganizer()` for not-rewound storages (#1729)
 
 ## 4.2.1
 

--- a/Classes/Domain/Model/Event/EventDateTrait.php
+++ b/Classes/Domain/Model/Event/EventDateTrait.php
@@ -227,6 +227,7 @@ trait EventDateTrait
     public function getFirstOrganizer(): ?Organizer
     {
         $organizers = $this->getOrganizers();
+        $organizers->rewind();
 
         return \count($organizers) > 0 ? $organizers->current() : null;
     }

--- a/Tests/Unit/Domain/Model/Event/EventDateTest.php
+++ b/Tests/Unit/Domain/Model/Event/EventDateTest.php
@@ -499,6 +499,24 @@ final class EventDateTest extends UnitTestCase
     /**
      * @test
      */
+    public function getFirstOrganizerWithTwoOrganizersNotRewoundReturnsFirstOrganizer(): void
+    {
+        /** @var ObjectStorage<Organizer> $organizers */
+        $organizers = new ObjectStorage();
+        $organizer1 = new Organizer();
+        $organizers->attach($organizer1);
+        $organizer2 = new Organizer();
+        $organizers->attach($organizer2);
+        $organizers->rewind();
+        $organizers->next();
+        $this->subject->setOrganizers($organizers);
+
+        self::assertSame($organizer1, $this->subject->getFirstOrganizer());
+    }
+
+    /**
+     * @test
+     */
     public function getOwnerUidInitiallyReturnsZero(): void
     {
         self::assertSame(0, $this->subject->getOwnerUid());

--- a/Tests/Unit/Domain/Model/Event/SingleEventTest.php
+++ b/Tests/Unit/Domain/Model/Event/SingleEventTest.php
@@ -515,6 +515,24 @@ final class SingleEventTest extends UnitTestCase
     /**
      * @test
      */
+    public function getFirstOrganizerWithTwoOrganizersNotRewoundReturnsFirstOrganizer(): void
+    {
+        /** @var ObjectStorage<Organizer> $organizers */
+        $organizers = new ObjectStorage();
+        $organizer1 = new Organizer();
+        $organizers->attach($organizer1);
+        $organizer2 = new Organizer();
+        $organizers->attach($organizer2);
+        $organizers->rewind();
+        $organizers->next();
+        $this->subject->setOrganizers($organizers);
+
+        self::assertSame($organizer1, $this->subject->getFirstOrganizer());
+    }
+
+    /**
+     * @test
+     */
     public function getOwnerUidInitiallyReturnsZero(): void
     {
         self::assertSame(0, $this->subject->getOwnerUid());


### PR DESCRIPTION
Fixes #1728