### PR TITLE
[BUGFIX] Drop extraneous whitespace in a configuration check message

### DIFF
--- a/Classes/Configuration/SharedConfigurationCheck.php
+++ b/Classes/Configuration/SharedConfigurationCheck.php
@@ -49,7 +49,7 @@ class SharedConfigurationCheck extends AbstractConfigurationCheck
 
         $this->checkIfSingleInSetNotEmpty(
             'currency',
-            'The specified currency setting is either empty or not a valid  ISO 4217 alpha 3 code.',
+            'The specified currency setting is either empty or not a valid ISO 4217 alpha 3 code.',
             $allowedValues
         );
     }


### PR DESCRIPTION
[ci skip]