### PR TITLE
[BUGFIX] Update the `.editorconfig` and TypoScript lint settings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,5 +1,3 @@
-# EditorConfig is awesome: http://EditorConfig.org
-
 # top-most EditorConfig file
 root = true
 
@@ -12,49 +10,47 @@ indent_size = 4
 insert_final_newline = true
 trim_trailing_whitespace = true
 
-# TS/JS-Files
-[*.{ts,js}]
+# JS files
+[*.js]
 indent_size = 2
 
-# JSON-Files
+# JSON files
 [*.json]
-indent_style = tab
-
-# ReST-Files
-[*.{rst,rst.txt}]
-indent_size = 4
-max_line_length = 80
-
-# Markdown-Files
-[*.md]
-max_line_length = 80
-
-# YAML-Files
-[*.{yaml,yml}]
-indent_size = 2
-
-# NEON-Files
-[*.neon]
-indent_size = 2
 indent_style = tab
 
 # package.json
 [package.json]
 indent_size = 2
 
-# TypoScript
-[*.{typoscript,tsconfig}]
-indent_size = 2
+# ReST files
+[{*.rst,*.rst.txt}]
+indent_size = 4
+max_line_length = 80
 
-# XLF-Files
-[*.xlf]
-indent_style = tab
-
-# SQL-Files
+# SQL files
 [*.sql]
 indent_style = tab
 indent_size = 2
 
-# .htaccess
-[{_.htaccess,.htaccess}]
+# TypoScript files
+[*.{typoscript,tsconfig}]
+indent_size = 2
+
+[ext_typoscript_setup.txt]
+indent_size = 2
+
+# YAML files
+[{*.yml,*.yaml}]
+indent_size = 2
+
+# XLF files
+[*.xlf]
 indent_style = tab
+
+# .htaccess
+[.htaccess]
+indent_style = tab
+
+# Markdown files
+[*.md]
+max_line_length = 80

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Drop the `Event.getOrganizer()` alias method (#1727)
 
 ### Fixed
+- Update the `.editorconfig` and TypoScript lint settings (1875)
 - Fix renderings warnings in the documentation (#1826)
 - Stop using deprecated oelib functionality (#1819)
 - Fix a typo in a `Registration` model setter (#1754)

--- a/Configuration/TsLint.yml
+++ b/Configuration/TsLint.yml
@@ -1,9 +1,10 @@
+---
 sniffs:
   - class: Indentation
     parameters:
-      useSpaces: true
-      indentPerLevel: 4
       indentConditions: true
+      indentPerLevel: 2
+      useSpaces: true
   - class: DeadCode
   - class: OperatorWhitespace
   - class: RepeatingRValue

--- a/Configuration/TypoScript/Config.typoscript
+++ b/Configuration/TypoScript/Config.typoscript
@@ -1,16 +1,16 @@
 config {
-    uniqueLinkVars = 1
+  uniqueLinkVars = 1
 
-    tx_mkforms {
-        loadJsFramework = 1
-        mayLoadScriptaculous = 1
-        jsframework {
-            jscore = jquery
-            jscore {
-                tx_mkforms_base = EXT:mkforms/Resources/Public/JavaScript/prototype/addons/base/Base.js
-                basewrapper = EXT:mkforms/Resources/Public/JavaScript/wrapper.js
-                wrapper = EXT:mkforms/Resources/Public/JavaScript/jquery/wrapper.js
-            }
-        }
+  tx_mkforms {
+    loadJsFramework = 1
+    mayLoadScriptaculous = 1
+    jsframework {
+      jscore = jquery
+      jscore {
+        tx_mkforms_base = EXT:mkforms/Resources/Public/JavaScript/prototype/addons/base/Base.js
+        basewrapper = EXT:mkforms/Resources/Public/JavaScript/wrapper.js
+        wrapper = EXT:mkforms/Resources/Public/JavaScript/jquery/wrapper.js
+      }
     }
+  }
 }

--- a/Configuration/TypoScript/CsvExport.typoscript
+++ b/Configuration/TypoScript/CsvExport.typoscript
@@ -1,25 +1,25 @@
 tx_seminars_pi2 = PAGE
 tx_seminars_pi2 {
-    # The page type number for the CSV export. Do not change this!
-    typeNum = 736
+  # The page type number for the CSV export. Do not change this!
+  typeNum = 736
 
-    config {
-        disableCharsetHeader = 1
-        enableContentLengthHeader = 0
-        no_cache = 1
-        disableAllHeaderCode = 1
-        admPanel = 0
+  config {
+    disableCharsetHeader = 1
+    enableContentLengthHeader = 0
+    no_cache = 1
+    disableAllHeaderCode = 1
+    admPanel = 0
 
-        xhtml_cleaning >
-    }
+    xhtml_cleaning >
+  }
 
-    includeLibs.tx_seminars_pi2 = EXT:seminars/Classes/Csv/CsvDownloader.php
+  includeLibs.tx_seminars_pi2 = EXT:seminars/Classes/Csv/CsvDownloader.php
 
-    10 = USER
-    10 {
-        userFunc = \OliverKlee\Seminars\Csv\CsvDownloader->main
+  10 = USER
+  10 {
+    userFunc = \OliverKlee\Seminars\Csv\CsvDownloader->main
 
-        # pro forma salutation mode for the FE; has no effect whatsoever
-        salutation = formal
-    }
+    # pro forma salutation mode for the FE; has no effect whatsoever
+    salutation = formal
+  }
 }

--- a/Configuration/TypoScript/Forms/EventEditor.typoscript
+++ b/Configuration/TypoScript/Forms/EventEditor.typoscript
@@ -1,2025 +1,2030 @@
 # Front-end specific configuration.
 # @deprecated #1544 will be removed in seminars 5.0
 plugin.tx_seminars_pi1.form.eventEditor {
-    meta {
-        name = Seminar Manager FE Editor
-        description = This editor provides a FE editing feature for events.
-        form.formid = tx_seminars_pi1_seminars
-        debug = false
-        displaylabels = false
-        codeBehind {
-            name = eventeditor
-            path = this
-        }
+  meta {
+    name = Seminar Manager FE Editor
+    description = This editor provides a FE editing feature for events.
+    form.formid = tx_seminars_pi1_seminars
+    debug = false
+    displaylabels = false
+    codeBehind {
+      name = eventeditor
+      path = this
     }
+  }
 
-    control {
-        datahandler = datahandler:DBMM
-        datahandler {
-            tablename = tx_seminars_seminars
-            keyname = uid
-            labelname = title
-            mmrelations {
-                categories {
-                    field = categories
-                    mmtable = tx_seminars_seminars_categories_mm
-                }
-
-                place {
-                    field = place
-                    mmtable = tx_seminars_seminars_place_mm
-                }
-
-                lodgings {
-                    field = lodgings
-                    mmtable = tx_seminars_seminars_lodgings_mm
-                }
-
-                foods {
-                    field = foods
-                    mmtable = tx_seminars_seminars_foods_mm
-                }
-
-                speakers {
-                    field = speakers
-                    mmtable = tx_seminars_seminars_speakers_mm
-                }
-
-                partners {
-                    field = partners
-                    mmtable = tx_seminars_seminars_speakers_mm_partners
-                }
-
-                tutors {
-                    field = tutors
-                    mmtable = tx_seminars_seminars_speakers_mm_tutors
-                }
-
-                leaders {
-                    field = leaders
-                    mmtable = tx_seminars_seminars_speakers_mm_leaders
-                }
-
-                target_groups {
-                    field = target_groups
-                    mmtable = tx_seminars_seminars_target_groups_mm
-                }
-
-                payment_methods {
-                    field = payment_methods
-                    mmtable = tx_seminars_seminars_payment_methods_mm
-                }
-
-                organizers {
-                    field = organizers
-                    mmtable = tx_seminars_seminars_organizers_mm
-                }
-            }
-
-            process.beforeinsertion.userobj {
-                extension = this
-                method = modifyDataToInsert
-            }
-        }
-
-        datasources {
-            listSpeakers = datasource:PHPARRAY
-            listSpeakers {
-                name = listSpeakers
-                bindsto {
-                    exec = eventeditor.populateListSpeakers
-                    params {
-                        10 {
-                            name = type
-                            value = Speaker
-                        }
-                        20 {
-                            name = lister
-                            value = 1
-                        }
-                    }
-                }
-            }
-        }
-
-        renderer = renderer:TEMPLATE
-        renderer.template {
-            path.userobj.php (
-                return \OliverKlee\Oelib\Configuration\ConfigurationRegistry::get('plugin.tx_seminars_pi1')->getAsString('eventEditorTemplateFile');
-            )
-            subpart = ###seminars_FORM###
-            errortag = errors
-        }
-
-        actionlets {
-            10 = actionlet:USEROBJ
-            10.userobj {
-                extension = this
-                method = sendEMailToReviewer
-            }
-
-            20 = actionlet:USEROBJ
-            20.userobj {
-                extension = this
-                method = sendAdditionalNotificationEmailToReviewer
-            }
-
-            30 = actionlet:REDIRECT
-            30.url.userobj {
-                extension = this
-                method = getEventSuccessfullySavedUrl
-            }
-        }
-    }
-
-    elements {
-        title = renderlet:TEXT
-        title {
-            name = title
-            label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_seminars.title
-            sanitize = false
-            validators {
-                10 = validator:STANDARD
-                10.required.message = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:message_emptyTitle
-            }
-        }
-
-        subtitle = renderlet:TEXT
-        subtitle {
-            name = subtitle
-            label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_seminars.subtitle
-            sanitize = false
-            validators {
-                10 = validator:STANDARD
-                10.custom {
-                    message = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:message_emptySubtitle
-                    userobj {
-                        extension = this
-                        method = validateString
-                        params.10 {
-                            name = elementName
-                            value = subtitle
-                        }
-                    }
-                }
-            }
-        }
-
-        categories = renderlet:CHECKBOX
+  control {
+    datahandler = datahandler:DBMM
+    datahandler {
+      tablename = tx_seminars_seminars
+      keyname = uid
+      labelname = title
+      mmrelations {
         categories {
-            name = categories
-            label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_seminars.categories
-            class = tx-seminars-pi1-event-editor-checkbox
-            data.userobj {
-                extension = this
-                method = populateListCategories
-            }
-
-            validators {
-                10 = validator:STANDARD
-                10.custom {
-                    message = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:message_noCategoryChosen
-                    userobj {
-                        extension = this
-                        method = validateCheckboxes
-                        params.10 {
-                            name = elementName
-                            value = categories
-                        }
-                    }
-                }
-            }
+          field = categories
+          mmtable = tx_seminars_seminars_categories_mm
         }
 
-        teaser = renderlet:TEXTAREA
-        teaser {
-            name = teaser
-            label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_seminars.teaser
-            sanitize = false
-            validators {
-                10 = validator:STANDARD
-                10.custom {
-                    message = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:message_emptyTeaser
-                    userobj {
-                        extension = this
-                        method = validateString
-                        params.10 {
-                            name = elementName
-                            value = teaser
-                        }
-                    }
-                }
-            }
-        }
-
-        description = renderlet:TEXTAREA
-        description {
-            name = description
-            label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_seminars.description
-            sanitize = false
-            validators {
-                10 = validator:STANDARD
-                10.custom {
-                    message = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:message_emptyDescription
-                    userobj {
-                        extension = this
-                        method = validateString
-                        params.10 {
-                            name = elementName
-                            value = description
-                        }
-                    }
-                }
-            }
-        }
-
-        event_type = renderlet:LISTBOX
-        event_type {
-            name = event_type
-            label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_seminars.event_type
-            data {
-                items {
-                    item {
-                        caption =
-                        value = 0
-                    }
-                }
-
-                userobj {
-                    extension = this
-                    method = populateListEventTypes
-                }
-            }
-
-            validators {
-                10 = validator:STANDARD
-                10.custom {
-                    message = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:message_noEventTypeChosen
-                    userobj {
-                        extension = this
-                        method = validateInteger
-                        params.10 {
-                            name = elementName
-                            value = event_type
-                        }
-                    }
-                }
-            }
-        }
-
-        accreditation_number = renderlet:TEXT
-        accreditation_number {
-            name = accreditation_number
-            label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_seminars.accreditation_number
-            sanitize = false
-            validators {
-                10 = validator:STANDARD
-                10.custom {
-                    message = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:message_accreditationNumberZero
-                    userobj {
-                        extension = this
-                        method = validateString
-                        params.10 {
-                            name = elementName
-                            value = accreditation_number
-                        }
-                    }
-                }
-            }
-        }
-
-        credit_points = renderlet:TEXT
-        credit_points {
-            name = credit_points
-            label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_seminars.credit_points
-            sanitize = false
-            validators {
-                10 = validator:STANDARD
-                10.custom {
-                    message = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:message_creditPointsZero
-                    userobj {
-                        extension = this
-                        method = validateInteger
-                        params.10 {
-                            name = elementName
-                            value = credit_points
-                        }
-                    }
-                }
-            }
-        }
-
-        begin_date = renderlet:DATE
-        begin_date {
-            name = begin_date
-            label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_seminars.begin_date
-            data.datetime {
-                format = %H:%M %d-%m-%Y
-                displaytime = true
-                converttotimestamp = true
-                allowmanualedition = true
-            }
-
-            validators {
-                10 = validator:STANDARD
-                10.custom {
-                    message = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:message_invalidBeginDate
-                    userobj {
-                        extension = this
-                        method = validateDate
-                        params.10 {
-                            name = elementName
-                            value = begin_date
-                        }
-                    }
-                }
-            }
-        }
-
-        end_date = renderlet:DATE
-        end_date {
-            name = end_date
-            label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_seminars.end_date
-            data.datetime {
-                format = %H:%M %d-%m-%Y
-                displaytime = true
-                converttotimestamp = true
-                allowmanualedition = true
-            }
-
-            validators {
-                10 = validator:STANDARD
-                10.custom {
-                    message = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:message_invalidEndDate
-                    userobj {
-                        extension = this
-                        method = validateDate
-                        params.10 {
-                            name = elementName
-                            value = end_date
-                        }
-                    }
-                }
-            }
-        }
-
-        begin_date_registration = renderlet:DATE
-        begin_date_registration {
-            name = begin_date_registration
-            label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_seminars.begin_date_registration
-            data.datetime {
-                format = %H:%M %d-%m-%Y
-                displaytime = true
-                converttotimestamp = true
-                allowmanualedition = true
-            }
-
-            validators {
-                10 = validator:STANDARD
-                10.custom {
-                    message = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:message_invalidBeginDateRegistration
-                    userobj {
-                        extension = this
-                        method = validateDate
-                        params.10 {
-                            name = elementName
-                            value = begin_date_registration
-                        }
-                    }
-                }
-            }
-        }
-
-        deadline_registration = renderlet:DATE
-        deadline_registration {
-            name = deadline_registration
-            label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_seminars.deadline_registration
-            data.datetime {
-                format = %H:%M %d-%m-%Y
-                displaytime = true
-                converttotimestamp = true
-                allowmanualedition = true
-            }
-
-            validators {
-                10 = validator:STANDARD
-                10.custom {
-                    message = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:message_invalidDeadlineRegistration
-                    userobj {
-                        extension = this
-                        method = validateDate
-                        params.10 {
-                            name = elementName
-                            value = deadline_registration
-                        }
-                    }
-                }
-            }
-        }
-
-        deadline_early_bird = renderlet:DATE
-        deadline_early_bird {
-            name = deadline_early_bird
-            label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_seminars.deadline_early_bird
-            data.datetime {
-                format = %H:%M %d-%m-%Y
-                displaytime = true
-                converttotimestamp = true
-                allowmanualedition = true
-            }
-
-            validators {
-                10 = validator:STANDARD
-                10.custom {
-                    message = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:message_invalidDeadlineEarlyBird
-                    userobj {
-                        extension = this
-                        method = validateDate
-                        params.10 {
-                            name = elementName
-                            value = deadline_early_bird
-                        }
-                    }
-                }
-            }
-        }
-
-        deadline_unregistration = renderlet:DATE
-        deadline_unregistration {
-            name = deadline_unregistration
-            label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_seminars.deadline_unregistration
-            data.datetime {
-                format = %H:%M %d-%m-%Y
-                displaytime = true
-                converttotimestamp = true
-                allowmanualedition = true
-            }
-
-            validators {
-                10 = validator:STANDARD
-                10.custom {
-                    message = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:message_invalidDeadlineUnregistration
-                    userobj {
-                        extension = this
-                        method = validateDate
-                        params.10 {
-                            name = elementName
-                            value = deadline_unregistration
-                        }
-                    }
-                }
-            }
-        }
-
-        place = renderlet:CHECKBOX
         place {
-            name = place
-            label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_seminars.place
-            class = tx-seminars-pi1-event-editor-checkbox
-            wrapitem = <tr><td>|</td></tr>
-            wrap = <table class="checkboxTable" summary=""><tbody>|</tbody></table>
-            separator =
-            data.userobj {
-                extension = this
-                method = populateListPlaces
-            }
-
-            validators {
-                10 = validator:STANDARD
-                10.custom {
-                    message = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:message_noPlaceChosen
-                    userobj {
-                        extension = this
-                        method = validateCheckboxes
-                        params.10 {
-                            name = elementName
-                            value = place
-                        }
-                    }
-                }
-            }
+          field = place
+          mmtable = tx_seminars_seminars_place_mm
         }
 
-        newPlaceButton = renderlet:BUTTON
-        newPlaceButton {
-            name = newPlaceButton
-            label = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:newPlaceButton
-            process.userobj {
-                extension = this
-                method = isFrontEndEditingOfRelatedRecordsAllowed
-                params.10 {
-                    name = relatedRecordType
-                    value = Places
-                }
+        lodgings {
+          field = lodgings
+          mmtable = tx_seminars_seminars_lodgings_mm
+        }
+
+        foods {
+          field = foods
+          mmtable = tx_seminars_seminars_foods_mm
+        }
+
+        speakers {
+          field = speakers
+          mmtable = tx_seminars_seminars_speakers_mm
+        }
+
+        partners {
+          field = partners
+          mmtable = tx_seminars_seminars_speakers_mm_partners
+        }
+
+        tutors {
+          field = tutors
+          mmtable = tx_seminars_seminars_speakers_mm_tutors
+        }
+
+        leaders {
+          field = leaders
+          mmtable = tx_seminars_seminars_speakers_mm_leaders
+        }
+
+        target_groups {
+          field = target_groups
+          mmtable = tx_seminars_seminars_target_groups_mm
+        }
+
+        payment_methods {
+          field = payment_methods
+          mmtable = tx_seminars_seminars_payment_methods_mm
+        }
+
+        organizers {
+          field = organizers
+          mmtable = tx_seminars_seminars_organizers_mm
+        }
+      }
+
+      process.beforeinsertion.userobj {
+        extension = this
+        method = modifyDataToInsert
+      }
+    }
+
+    datasources {
+      listSpeakers = datasource:PHPARRAY
+      listSpeakers {
+        name = listSpeakers
+        bindsto {
+          exec = eventeditor.populateListSpeakers
+          params {
+            10 {
+              name = type
+              value = Speaker
             }
 
-            onclick {
-                runat = ajax
-                cache = false
-                userobj.php (
+            20 {
+              name = lister
+              value = 1
+            }
+          }
+        }
+      }
+    }
+
+    renderer = renderer:TEMPLATE
+    renderer.template {
+      path.userobj.php (
+                return \OliverKlee\Oelib\Configuration\ConfigurationRegistry::get('plugin.tx_seminars_pi1')->getAsString('eventEditorTemplateFile');
+      )
+      subpart = ###seminars_FORM###
+      errortag = errors
+    }
+
+    actionlets {
+      10 = actionlet:USEROBJ
+      10.userobj {
+        extension = this
+        method = sendEMailToReviewer
+      }
+
+      20 = actionlet:USEROBJ
+      20.userobj {
+        extension = this
+        method = sendAdditionalNotificationEmailToReviewer
+      }
+
+      30 = actionlet:REDIRECT
+      30.url.userobj {
+        extension = this
+        method = getEventSuccessfullySavedUrl
+      }
+    }
+  }
+
+  elements {
+    title = renderlet:TEXT
+    title {
+      name = title
+      label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_seminars.title
+      sanitize = false
+      validators {
+        10 = validator:STANDARD
+        10.required.message = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:message_emptyTitle
+      }
+    }
+
+    subtitle = renderlet:TEXT
+    subtitle {
+      name = subtitle
+      label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_seminars.subtitle
+      sanitize = false
+      validators {
+        10 = validator:STANDARD
+        10.custom {
+          message = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:message_emptySubtitle
+          userobj {
+            extension = this
+            method = validateString
+            params.10 {
+              name = elementName
+              value = subtitle
+            }
+          }
+        }
+      }
+    }
+
+    categories = renderlet:CHECKBOX
+    categories {
+      name = categories
+      label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_seminars.categories
+      class = tx-seminars-pi1-event-editor-checkbox
+      data.userobj {
+        extension = this
+        method = populateListCategories
+      }
+
+      validators {
+        10 = validator:STANDARD
+        10.custom {
+          message = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:message_noCategoryChosen
+          userobj {
+            extension = this
+            method = validateCheckboxes
+            params.10 {
+              name = elementName
+              value = categories
+            }
+          }
+        }
+      }
+    }
+
+    teaser = renderlet:TEXTAREA
+    teaser {
+      name = teaser
+      label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_seminars.teaser
+      sanitize = false
+      validators {
+        10 = validator:STANDARD
+        10.custom {
+          message = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:message_emptyTeaser
+          userobj {
+            extension = this
+            method = validateString
+            params.10 {
+              name = elementName
+              value = teaser
+            }
+          }
+        }
+      }
+    }
+
+    description = renderlet:TEXTAREA
+    description {
+      name = description
+      label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_seminars.description
+      sanitize = false
+      validators {
+        10 = validator:STANDARD
+        10.custom {
+          message = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:message_emptyDescription
+          userobj {
+            extension = this
+            method = validateString
+            params.10 {
+              name = elementName
+              value = description
+            }
+          }
+        }
+      }
+    }
+
+    event_type = renderlet:LISTBOX
+    event_type {
+      name = event_type
+      label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_seminars.event_type
+      data {
+        items {
+          item {
+            caption =
+            value = 0
+          }
+        }
+
+        userobj {
+          extension = this
+          method = populateListEventTypes
+        }
+      }
+
+      validators {
+        10 = validator:STANDARD
+        10.custom {
+          message = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:message_noEventTypeChosen
+          userobj {
+            extension = this
+            method = validateInteger
+            params.10 {
+              name = elementName
+              value = event_type
+            }
+          }
+        }
+      }
+    }
+
+    accreditation_number = renderlet:TEXT
+    accreditation_number {
+      name = accreditation_number
+      label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_seminars.accreditation_number
+      sanitize = false
+      validators {
+        10 = validator:STANDARD
+        10.custom {
+          message = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:message_accreditationNumberZero
+          userobj {
+            extension = this
+            method = validateString
+            params.10 {
+              name = elementName
+              value = accreditation_number
+            }
+          }
+        }
+      }
+    }
+
+    credit_points = renderlet:TEXT
+    credit_points {
+      name = credit_points
+      label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_seminars.credit_points
+      sanitize = false
+      validators {
+        10 = validator:STANDARD
+        10.custom {
+          message = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:message_creditPointsZero
+          userobj {
+            extension = this
+            method = validateInteger
+            params.10 {
+              name = elementName
+              value = credit_points
+            }
+          }
+        }
+      }
+    }
+
+    begin_date = renderlet:DATE
+    begin_date {
+      name = begin_date
+      label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_seminars.begin_date
+      data.datetime {
+        format = %H:%M %d-%m-%Y
+        displaytime = true
+        converttotimestamp = true
+        allowmanualedition = true
+      }
+
+      validators {
+        10 = validator:STANDARD
+        10.custom {
+          message = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:message_invalidBeginDate
+          userobj {
+            extension = this
+            method = validateDate
+            params.10 {
+              name = elementName
+              value = begin_date
+            }
+          }
+        }
+      }
+    }
+
+    end_date = renderlet:DATE
+    end_date {
+      name = end_date
+      label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_seminars.end_date
+      data.datetime {
+        format = %H:%M %d-%m-%Y
+        displaytime = true
+        converttotimestamp = true
+        allowmanualedition = true
+      }
+
+      validators {
+        10 = validator:STANDARD
+        10.custom {
+          message = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:message_invalidEndDate
+          userobj {
+            extension = this
+            method = validateDate
+            params.10 {
+              name = elementName
+              value = end_date
+            }
+          }
+        }
+      }
+    }
+
+    begin_date_registration = renderlet:DATE
+    begin_date_registration {
+      name = begin_date_registration
+      label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_seminars.begin_date_registration
+      data.datetime {
+        format = %H:%M %d-%m-%Y
+        displaytime = true
+        converttotimestamp = true
+        allowmanualedition = true
+      }
+
+      validators {
+        10 = validator:STANDARD
+        10.custom {
+          message = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:message_invalidBeginDateRegistration
+          userobj {
+            extension = this
+            method = validateDate
+            params.10 {
+              name = elementName
+              value = begin_date_registration
+            }
+          }
+        }
+      }
+    }
+
+    deadline_registration = renderlet:DATE
+    deadline_registration {
+      name = deadline_registration
+      label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_seminars.deadline_registration
+      data.datetime {
+        format = %H:%M %d-%m-%Y
+        displaytime = true
+        converttotimestamp = true
+        allowmanualedition = true
+      }
+
+      validators {
+        10 = validator:STANDARD
+        10.custom {
+          message = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:message_invalidDeadlineRegistration
+          userobj {
+            extension = this
+            method = validateDate
+            params.10 {
+              name = elementName
+              value = deadline_registration
+            }
+          }
+        }
+      }
+    }
+
+    deadline_early_bird = renderlet:DATE
+    deadline_early_bird {
+      name = deadline_early_bird
+      label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_seminars.deadline_early_bird
+      data.datetime {
+        format = %H:%M %d-%m-%Y
+        displaytime = true
+        converttotimestamp = true
+        allowmanualedition = true
+      }
+
+      validators {
+        10 = validator:STANDARD
+        10.custom {
+          message = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:message_invalidDeadlineEarlyBird
+          userobj {
+            extension = this
+            method = validateDate
+            params.10 {
+              name = elementName
+              value = deadline_early_bird
+            }
+          }
+        }
+      }
+    }
+
+    deadline_unregistration = renderlet:DATE
+    deadline_unregistration {
+      name = deadline_unregistration
+      label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_seminars.deadline_unregistration
+      data.datetime {
+        format = %H:%M %d-%m-%Y
+        displaytime = true
+        converttotimestamp = true
+        allowmanualedition = true
+      }
+
+      validators {
+        10 = validator:STANDARD
+        10.custom {
+          message = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:message_invalidDeadlineUnregistration
+          userobj {
+            extension = this
+            method = validateDate
+            params.10 {
+              name = elementName
+              value = deadline_unregistration
+            }
+          }
+        }
+      }
+    }
+
+    place = renderlet:CHECKBOX
+    place {
+      name = place
+      label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_seminars.place
+      class = tx-seminars-pi1-event-editor-checkbox
+      wrapitem = <tr><td>|</td></tr>
+      wrap = <table class="checkboxTable" summary=""><tbody>|</tbody></table>
+      separator =
+      data.userobj {
+        extension = this
+        method = populateListPlaces
+      }
+
+      validators {
+        10 = validator:STANDARD
+        10.custom {
+          message = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:message_noPlaceChosen
+          userobj {
+            extension = this
+            method = validateCheckboxes
+            params.10 {
+              name = elementName
+              value = place
+            }
+          }
+        }
+      }
+    }
+
+    newPlaceButton = renderlet:BUTTON
+    newPlaceButton {
+      name = newPlaceButton
+      label = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:newPlaceButton
+      process.userobj {
+        extension = this
+        method = isFrontEndEditingOfRelatedRecordsAllowed
+        params.10 {
+          name = relatedRecordType
+          value = Places
+        }
+      }
+
+      onclick {
+        runat = ajax
+        cache = false
+        userobj.php (
                     $this->getRenderer()->_setDisplayLabels(true);
                     $result = $this->aORenderlets['newPlaceModalBox']->majixShowFreshBox();
                     $this->getRenderer()->_setDisplayLabels(false);
                     return $result;
-                )
-            }
+        )
+      }
+    }
+
+    newPlaceModalBox = renderlet:MODALBOX
+    newPlaceModalBox {
+      name = newPlaceModalBox
+      childs {
+        newPlace_title = renderlet:TEXT
+        newPlace_title {
+          name = newPlace_title
+          label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_sites.title
+          sanitize = false
+          wrap = <div class="formidable-rdrstd-rdtwrap">|</div>
         }
 
-        newPlaceModalBox = renderlet:MODALBOX
-        newPlaceModalBox {
-            name = newPlaceModalBox
-            childs {
-                newPlace_title = renderlet:TEXT
-                newPlace_title {
-                    name = newPlace_title
-                    label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_sites.title
-                    sanitize = false
-                    wrap = <div class="formidable-rdrstd-rdtwrap">|</div>
-                }
+        newPlace_address = renderlet:TEXTAREA
+        newPlace_address {
+          name = newPlace_address
+          label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_sites.address
+          sanitize = false
+          wrap = <div class="formidable-rdrstd-rdtwrap">|</div>
+        }
 
-                newPlace_address = renderlet:TEXTAREA
-                newPlace_address {
-                    name = newPlace_address
-                    label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_sites.address
-                    sanitize = false
-                    wrap = <div class="formidable-rdrstd-rdtwrap">|</div>
-                }
+        newPlace_zip = renderlet:TEXT
+        newPlace_zip {
+          name = newPlace_zip
+          label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_sites.zip
+          sanitize = false
+          wrap = <div class="formidable-rdrstd-rdtwrap">|</div>
+        }
 
-                newPlace_zip = renderlet:TEXT
-                newPlace_zip {
-                    name = newPlace_zip
-                    label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_sites.zip
-                    sanitize = false
-                    wrap = <div class="formidable-rdrstd-rdtwrap">|</div>
-                }
+        newPlace_city = renderlet:TEXT
+        newPlace_city {
+          name = newPlace_city
+          label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_sites.city
+          sanitize = false
+          wrap = <div class="formidable-rdrstd-rdtwrap">|</div>
+        }
 
-                newPlace_city = renderlet:TEXT
-                newPlace_city {
-                    name = newPlace_city
-                    label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_sites.city
-                    sanitize = false
-                    wrap = <div class="formidable-rdrstd-rdtwrap">|</div>
-                }
+        newPlace_country = renderlet:LISTBOX
+        newPlace_country {
+          name = newPlace_country
+          label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_sites.country
+          wrap = <div class="formidable-rdrstd-rdtwrap">|</div>
+          data {
+            items.10 {
+              value = 0
+              caption =
+            }
 
-                newPlace_country = renderlet:LISTBOX
-                newPlace_country {
-                    name = newPlace_country
-                    label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_sites.country
-                    wrap = <div class="formidable-rdrstd-rdtwrap">|</div>
-                    data {
-                        items.10 {
-                            value = 0
-                            caption =
-                        }
-
-                        userobj.php (
+            userobj.php (
                             return \OliverKlee\Seminars\FrontEnd\EventEditor::populateListCountries();
-                        )
-                    }
-                }
+            )
+          }
+        }
 
-                newPlace_homepage = renderlet:TEXT
-                newPlace_homepage {
-                    name = newPlace_homepage
-                    label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_sites.homepage
-                    sanitize = false
-                    wrap = <div class="formidable-rdrstd-rdtwrap">|</div>
-                }
+        newPlace_homepage = renderlet:TEXT
+        newPlace_homepage {
+          name = newPlace_homepage
+          label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_sites.homepage
+          sanitize = false
+          wrap = <div class="formidable-rdrstd-rdtwrap">|</div>
+        }
 
-                newPlace_directions = renderlet:TEXTAREA
-                newPlace_directions {
-                    name = newPlace_directions
-                    label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_sites.directions
-                    sanitize = false
-                    wrap = <div class="formidable-rdrstd-rdtwrap">|</div>
-                }
+        newPlace_directions = renderlet:TEXTAREA
+        newPlace_directions {
+          name = newPlace_directions
+          label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_sites.directions
+          sanitize = false
+          wrap = <div class="formidable-rdrstd-rdtwrap">|</div>
+        }
 
-                newPlace_notes = renderlet:TEXTAREA
-                newPlace_notes {
-                    name = newPlace_notes
-                    label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_sites.notes
-                    sanitize = false
-                    wrap = <div class="formidable-rdrstd-rdtwrap">|</div>
-                }
+        newPlace_notes = renderlet:TEXTAREA
+        newPlace_notes {
+          name = newPlace_notes
+          label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_sites.notes
+          sanitize = false
+          wrap = <div class="formidable-rdrstd-rdtwrap">|</div>
+        }
 
-                newPlace_cancelButton = renderlet:BUTTON
-                newPlace_cancelButton {
-                    name = newPlace_cancelButton
-                    label = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:label_cancel
-                    wrap = <div class="formidable-rdrstd-rdtwrap modalbox-buttons">|
-                    onclick {
-                        runat = client
-                        userobj.php (
+        newPlace_cancelButton = renderlet:BUTTON
+        newPlace_cancelButton {
+          name = newPlace_cancelButton
+          label = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:label_cancel
+          wrap = <div class="formidable-rdrstd-rdtwrap modalbox-buttons">|
+          onclick {
+            runat = client
+            userobj.php (
                             return $this->aORenderlets['newPlaceModalBox']->majixCloseBox();
-                        )
-                    }
-                }
+            )
+          }
+        }
 
-                newPlace_saveButton = renderlet:BUTTON
-                newPlace_saveButton {
-                    name = newPlace_saveButton
-                    label = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:label_save
-                    wrap = |</div>
-                    onclick {
-                        runat = ajax
-                        cache = false
-                        params = newPlace_title, newPlace_address, newPlace_zip, newPlace_city, newPlace_country, newPlace_homepage, newPlace_directions, newPlace_notes
-                        userobj.php (
+        newPlace_saveButton = renderlet:BUTTON
+        newPlace_saveButton {
+          name = newPlace_saveButton
+          label = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:label_save
+          wrap = |</div>
+          onclick {
+            runat = ajax
+            cache = false
+            params = newPlace_title, newPlace_address, newPlace_zip, newPlace_city, newPlace_country, newPlace_homepage, newPlace_directions, newPlace_notes
+            userobj.php (
                             return \OliverKlee\Seminars\FrontEnd\EventEditor::createNewPlace($this);
-                        )
-                    }
-                }
-            }
+            )
+          }
         }
+      }
+    }
 
-        editPlaceButton = renderlet:BUTTON
-        editPlaceButton {
-            name = editPlaceButton
-            label = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:label_edit
-            class = tx-seminars-pi1-event-editor-edit-button
-            onclick {
-                runat = ajax
-                cache = false
-                userobj.php (
+    editPlaceButton = renderlet:BUTTON
+    editPlaceButton {
+      name = editPlaceButton
+      label = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:label_edit
+      class = tx-seminars-pi1-event-editor-edit-button
+      onclick {
+        runat = ajax
+        cache = false
+        userobj.php (
                     return \OliverKlee\Seminars\FrontEnd\EventEditor::showEditPlaceModalBox($this);
-                )
-            }
+        )
+      }
+    }
+
+    editPlaceModalBox = renderlet:MODALBOX
+    editPlaceModalBox {
+      name = editPlaceModalBox
+      childs {
+        editPlace_title = renderlet:TEXT
+        editPlace_title {
+          name = editPlace_title
+          label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_sites.title
+          sanitize = false
+          wrap = <div class="formidable-rdrstd-rdtwrap">|</div>
         }
 
-        editPlaceModalBox = renderlet:MODALBOX
-        editPlaceModalBox {
-            name = editPlaceModalBox
-            childs {
-                editPlace_title = renderlet:TEXT
-                editPlace_title {
-                    name = editPlace_title
-                    label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_sites.title
-                    sanitize = false
-                    wrap = <div class="formidable-rdrstd-rdtwrap">|</div>
-                }
+        editPlace_address = renderlet:TEXTAREA
+        editPlace_address {
+          name = editPlace_address
+          label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_sites.address
+          sanitize = false
+          wrap = <div class="formidable-rdrstd-rdtwrap">|</div>
+        }
 
-                editPlace_address = renderlet:TEXTAREA
-                editPlace_address {
-                    name = editPlace_address
-                    label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_sites.address
-                    sanitize = false
-                    wrap = <div class="formidable-rdrstd-rdtwrap">|</div>
-                }
+        editPlace_zip = renderlet:TEXT
+        editPlace_zip {
+          name = editPlace_zip
+          label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_sites.zip
+          sanitize = false
+          wrap = <div class="formidable-rdrstd-rdtwrap">|</div>
+        }
 
-                editPlace_zip = renderlet:TEXT
-                editPlace_zip {
-                    name = editPlace_zip
-                    label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_sites.zip
-                    sanitize = false
-                    wrap = <div class="formidable-rdrstd-rdtwrap">|</div>
-                }
+        editPlace_city = renderlet:TEXT
+        editPlace_city {
+          name = editPlace_city
+          label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_sites.city
+          sanitize = false
+          wrap = <div class="formidable-rdrstd-rdtwrap">|</div>
+        }
 
-                editPlace_city = renderlet:TEXT
-                editPlace_city {
-                    name = editPlace_city
-                    label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_sites.city
-                    sanitize = false
-                    wrap = <div class="formidable-rdrstd-rdtwrap">|</div>
-                }
+        editPlace_country = renderlet:LISTBOX
+        editPlace_country {
+          name = editPlace_country
+          label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_sites.country
+          wrap = <div class="formidable-rdrstd-rdtwrap">|</div>
+          data {
+            items.10 {
+              value = 0
+              caption =
+            }
 
-                editPlace_country = renderlet:LISTBOX
-                editPlace_country {
-                    name = editPlace_country
-                    label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_sites.country
-                    wrap = <div class="formidable-rdrstd-rdtwrap">|</div>
-                    data {
-                        items.10 {
-                            value = 0
-                            caption =
-                        }
-
-                        userobj.php (
+            userobj.php (
                             return \OliverKlee\Seminars\FrontEnd\EventEditor::populateListCountries();
-                        )
-                    }
-                }
+            )
+          }
+        }
 
-                editPlace_homepage = renderlet:TEXT
-                editPlace_homepage {
-                    name = editPlace_homepage
-                    label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_sites.homepage
-                    sanitize = false
-                    wrap = <div class="formidable-rdrstd-rdtwrap">|</div>
-                }
+        editPlace_homepage = renderlet:TEXT
+        editPlace_homepage {
+          name = editPlace_homepage
+          label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_sites.homepage
+          sanitize = false
+          wrap = <div class="formidable-rdrstd-rdtwrap">|</div>
+        }
 
-                editPlace_directions = renderlet:TEXTAREA
-                editPlace_directions {
-                    name = editPlace_directions
-                    label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_sites.directions
-                    sanitize = false
-                    wrap = <div class="formidable-rdrstd-rdtwrap">|</div>
-                }
+        editPlace_directions = renderlet:TEXTAREA
+        editPlace_directions {
+          name = editPlace_directions
+          label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_sites.directions
+          sanitize = false
+          wrap = <div class="formidable-rdrstd-rdtwrap">|</div>
+        }
 
-                editPlace_notes = renderlet:TEXTAREA
-                editPlace_notes {
-                    name = editPlace_notes
-                    label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_sites.notes
-                    sanitize = false
-                    wrap = <div class="formidable-rdrstd-rdtwrap">|</div>
-                }
+        editPlace_notes = renderlet:TEXTAREA
+        editPlace_notes {
+          name = editPlace_notes
+          label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_sites.notes
+          sanitize = false
+          wrap = <div class="formidable-rdrstd-rdtwrap">|</div>
+        }
 
-                editPlace_uid = renderlet:HIDDEN
-                editPlace_uid {
-                    name = editPlace_uid
-                }
+        editPlace_uid = renderlet:HIDDEN
+        editPlace_uid {
+          name = editPlace_uid
+        }
 
-                editPlace_cancelButton = renderlet:BUTTON
-                editPlace_cancelButton {
-                    name = editPlace_cancelButton
-                    label = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:label_cancel
-                    wrap = <div class="formidable-rdrstd-rdtwrap modalbox-buttons">|
-                    onclick {
-                        runat = client
-                        userobj.php (
+        editPlace_cancelButton = renderlet:BUTTON
+        editPlace_cancelButton {
+          name = editPlace_cancelButton
+          label = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:label_cancel
+          wrap = <div class="formidable-rdrstd-rdtwrap modalbox-buttons">|
+          onclick {
+            runat = client
+            userobj.php (
                             return $this->aORenderlets['editPlaceModalBox']->majixCloseBox();
-                        )
-                    }
-                }
+            )
+          }
+        }
 
-                editPlace_saveButton = renderlet:BUTTON
-                editPlace_saveButton {
-                    name = editPlace_saveButton
-                    label = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:label_save
-                    wrap = |</div>
-                    onclick {
-                        runat = ajax
-                        cache = false
-                        params = editPlace_title, editPlace_address, editPlace_zip, editPlace_city, editPlace_country, editPlace_homepage, editPlace_directions, editPlace_notes, editPlace_uid
-                        userobj.php (
+        editPlace_saveButton = renderlet:BUTTON
+        editPlace_saveButton {
+          name = editPlace_saveButton
+          label = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:label_save
+          wrap = |</div>
+          onclick {
+            runat = ajax
+            cache = false
+            params = editPlace_title, editPlace_address, editPlace_zip, editPlace_city, editPlace_country, editPlace_homepage, editPlace_directions, editPlace_notes, editPlace_uid
+            userobj.php (
                             return \OliverKlee\Seminars\FrontEnd\EventEditor::updatePlace($this);
-                        )
-                    }
-                }
+            )
+          }
+        }
+      }
+    }
+
+    room = renderlet:TEXT
+    room {
+      name = room
+      label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_seminars.room
+      sanitize = false
+      validators {
+        10 = validator:STANDARD
+        10.custom {
+          message = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:message_emptyRoom
+          userobj {
+            extension = this
+            method = validateString
+            params.10 {
+              name = elementName
+              value = room
             }
+          }
+        }
+      }
+    }
+
+    lodgings = renderlet:CHECKBOX
+    lodgings {
+      name = lodgings
+      label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_seminars.lodgings
+      class = tx-seminars-pi1-event-editor-checkbox
+      data.userobj {
+        extension = this
+        method = populateListLodgings
+      }
+
+      validators {
+        10 = validator:STANDARD
+        10.custom {
+          message = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:message_noLodgingsChosen
+          userobj {
+            extension = this
+            method = validateCheckboxes
+            params.10 {
+              name = elementName
+              value = lodgings
+            }
+          }
+        }
+      }
+    }
+
+    foods = renderlet:CHECKBOX
+    foods {
+      name = foods
+      label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_seminars.foods
+      class = tx-seminars-pi1-event-editor-checkbox
+      data.userobj {
+        extension = this
+        method = populateListFoods
+      }
+
+      validators {
+        10 = validator:STANDARD
+        10.custom {
+          message = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:message_noFoodsChosen
+          userobj {
+            extension = this
+            method = validateCheckboxes
+            params.10 {
+              name = elementName
+              value = foods
+            }
+          }
+        }
+      }
+    }
+
+    speakers = renderlet:LISTER
+    speakers {
+      name = speakers
+      label = LLL:EXT:seminars/locallang_db.xlf:tx_seminars_seminars.speakers
+      uidColumn = uid
+      usegp = 0
+      datasource.use = listSpeakers
+      # disable the pager, list all speakers
+      pager.rows.perpage = -1
+      columns {
+        uid {
+          name = uid
+          type = renderlet:HIDDEN
         }
 
-        room = renderlet:TEXT
-        room {
-            name = room
-            label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_seminars.room
-            sanitize = false
-            validators {
-                10 = validator:STANDARD
-                10.custom {
-                    message = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:message_emptyRoom
-                    userobj {
-                        extension = this
-                        method = validateString
-                        params.10 {
-                            name = elementName
-                            value = room
-                        }
-                    }
-                }
-            }
+        selected {
+          name = selected
+          type = renderlet:CHECKSINGLE
+          activelistable = true
         }
 
-        lodgings = renderlet:CHECKBOX
-        lodgings {
-            name = lodgings
-            label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_seminars.lodgings
-            class = tx-seminars-pi1-event-editor-checkbox
-            data.userobj {
-                extension = this
-                method = populateListLodgings
-            }
-
-            validators {
-                10 = validator:STANDARD
-                10.custom {
-                    message = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:message_noLodgingsChosen
-                    userobj {
-                        extension = this
-                        method = validateCheckboxes
-                        params.10 {
-                            name = elementName
-                            value = lodgings
-                        }
-                    }
-                }
-            }
+        name {
+          name = name
+          type = renderlet:TEXT
+          sanitize = false
         }
 
-        foods = renderlet:CHECKBOX
-        foods {
-            name = foods
-            label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_seminars.foods
-            class = tx-seminars-pi1-event-editor-checkbox
-            data.userobj {
-                extension = this
-                method = populateListFoods
-            }
-
-            validators {
-                10 = validator:STANDARD
-                10.custom {
-                    message = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:message_noFoodsChosen
-                    userobj {
-                        extension = this
-                        method = validateCheckboxes
-                        params.10 {
-                            name = elementName
-                            value = foods
-                        }
-                    }
-                }
-            }
+        edit {
+          name = edit
+          type = renderlet:BUTTON
+          label = LLL:label_edit
+          visible.userobj.php = return !$this->getCurrentRdt() || $this->getCurrentRdt()->getValue();
+          onclick {
+            runat = ajax
+            params = rowData::uid
+            cache = false
+            exec = eventeditor.openEditSpeakerModalBox()
+          }
         }
+      }
+    }
 
-        speakers = renderlet:LISTER
-        speakers {
-            name = speakers
-            label = LLL:EXT:seminars/locallang_db.xlf:tx_seminars_seminars.speakers
-            uidColumn = uid
-            usegp = 0
-            datasource.use = listSpeakers
-            # disable the pager, list all speakers
-            pager.rows.perpage = -1
-            columns {
-                uid {
-                    name = uid
-                    type = renderlet:HIDDEN
-                }
-
-                selected {
-                    name = selected
-                    type = renderlet:CHECKSINGLE
-                    activelistable = true
-                }
-
-                name {
-                    name = name
-                    type = renderlet:TEXT
-                    sanitize = false
-                }
-
-                edit {
-                    name = edit
-                    type = renderlet:BUTTON
-                    label = LLL:label_edit
-                    visible.userobj.php = return !$this->getCurrentRdt() || $this->getCurrentRdt()->getValue();
-                    onclick {
-                        runat = ajax
-                        params = rowData::uid
-                        cache = false
-                        exec = eventeditor.openEditSpeakerModalBox()
-                    }
-                }
-            }
+    newSpeakerButton = renderlet:BUTTON
+    newSpeakerButton {
+      name = newSpeakerButton
+      label = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:newSpeakerButton
+      process.userobj {
+        extension = this
+        method = isFrontEndEditingOfRelatedRecordsAllowed
+        params.10 {
+          name = relatedRecordType
+          value = Speakers
         }
+      }
 
-        newSpeakerButton = renderlet:BUTTON
-        newSpeakerButton {
-            name = newSpeakerButton
-            label = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:newSpeakerButton
-            process.userobj {
-                extension = this
-                method = isFrontEndEditingOfRelatedRecordsAllowed
-                params.10 {
-                    name = relatedRecordType
-                    value = Speakers
-                }
-            }
-
-            onclick {
-                runat = ajax
-                userobj.php (
+      onclick {
+        runat = ajax
+        userobj.php (
                     $this->getRenderer()->_setDisplayLabels(true);
                     $result = $this->aORenderlets['newSpeakerModalBox']->majixShowFreshBox();
                     $this->getRenderer()->_setDisplayLabels(false);
                     return $result;
-                )
-            }
+        )
+      }
+    }
+
+    newLeaderButton < .newSpeakerButton
+    newLeaderButton.name = newLeaderButton
+
+    newPartnerButton < .newSpeakerButton
+    newPartnerButton.name = newPartnerButton
+
+    newTutorButton < .newSpeakerButton
+    newTutorButton.name = newTutorButton
+
+    newSpeakerModalBox = renderlet:MODALBOX
+    newSpeakerModalBox {
+      name = newSpeakerModalBox
+      childs {
+        newSpeaker_title = renderlet:TEXT
+        newSpeaker_title {
+          name = newSpeaker_title
+          label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_speakers.title
+          sanitize = false
+          wrap = <div class="modalbox-column1"><div class="formidable-rdrstd-rdtwrap">|</div>
         }
 
-        newLeaderButton < .newSpeakerButton
-        newLeaderButton.name = newLeaderButton
+        newSpeaker_gender = renderlet:LISTBOX
+        newSpeaker_gender {
+          name = newSpeaker_gender
+          label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_speakers.gender
+          wrap = <div class="formidable-rdrstd-rdtwrap">|</div>
+          data {
+            items {
+              10 {
+                caption =
+                value = 0
+              }
 
-        newPartnerButton < .newSpeakerButton
-        newPartnerButton.name = newPartnerButton
+              20 {
+                caption = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_speakers.gender_male
+                value = 1
+              }
 
-        newTutorButton < .newSpeakerButton
-        newTutorButton.name = newTutorButton
+              30 {
+                caption = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_speakers.gender_female
+                value = 2
+              }
+            }
+          }
+        }
 
-        newSpeakerModalBox = renderlet:MODALBOX
-        newSpeakerModalBox {
-            name = newSpeakerModalBox
-            childs {
-                newSpeaker_title = renderlet:TEXT
-                newSpeaker_title {
-                    name = newSpeaker_title
-                    label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_speakers.title
-                    sanitize = false
-                    wrap = <div class="modalbox-column1"><div class="formidable-rdrstd-rdtwrap">|</div>
-                }
+        newSpeaker_organization = renderlet:TEXT
+        newSpeaker_organization {
+          name = newSpeaker_organization
+          label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_speakers.organization
+          sanitize = false
+          wrap = <div class="formidable-rdrstd-rdtwrap">|</div>
+        }
 
-                newSpeaker_gender = renderlet:LISTBOX
-                newSpeaker_gender {
-                    name = newSpeaker_gender
-                    label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_speakers.gender
-                    wrap = <div class="formidable-rdrstd-rdtwrap">|</div>
-                    data {
-                        items {
-                            10 {
-                                caption =
-                                value = 0
-                            }
-                            20 {
-                                caption = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_speakers.gender_male
-                                value = 1
-                            }
-                            30 {
-                                caption = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_speakers.gender_female
-                                value = 2
-                            }
-                        }
-                    }
-                }
+        newSpeaker_homepage = renderlet:TEXT
+        newSpeaker_homepage {
+          name = newSpeaker_homepage
+          label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_speakers.homepage
+          sanitize = false
+          wrap = <div class="formidable-rdrstd-rdtwrap">|</div>
+        }
 
-                newSpeaker_organization = renderlet:TEXT
-                newSpeaker_organization {
-                    name = newSpeaker_organization
-                    label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_speakers.organization
-                    sanitize = false
-                    wrap = <div class="formidable-rdrstd-rdtwrap">|</div>
-                }
+        newSpeaker_description = renderlet:TEXTAREA
+        newSpeaker_description {
+          name = newSpeaker_description
+          label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_speakers.description
+          sanitize = false
+          wrap = <div class="formidable-rdrstd-rdtwrap">|</div>
+        }
 
-                newSpeaker_homepage = renderlet:TEXT
-                newSpeaker_homepage {
-                    name = newSpeaker_homepage
-                    label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_speakers.homepage
-                    sanitize = false
-                    wrap = <div class="formidable-rdrstd-rdtwrap">|</div>
-                }
-
-                newSpeaker_description = renderlet:TEXTAREA
-                newSpeaker_description {
-                    name = newSpeaker_description
-                    label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_speakers.description
-                    sanitize = false
-                    wrap = <div class="formidable-rdrstd-rdtwrap">|</div>
-                }
-
-                newSpeaker_skills = renderlet:CHECKBOX
-                newSpeaker_skills {
-                    name = newSpeaker_skills
-                    label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_speakers.skills
-                    class = tx-seminars-pi1-event-editor-checkbox
-                    wrap = <div class="formidable-rdrstd-rdtwrap formidable-checkboxes">|</div></div>
-                    data.userobj.php (
+        newSpeaker_skills = renderlet:CHECKBOX
+        newSpeaker_skills {
+          name = newSpeaker_skills
+          label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_speakers.skills
+          class = tx-seminars-pi1-event-editor-checkbox
+          wrap = <div class="formidable-rdrstd-rdtwrap formidable-checkboxes">|</div></div>
+          data.userobj.php (
                         return \OliverKlee\Seminars\FrontEnd\EventEditor::populateListSkills();
-                    )
-                }
+          )
+        }
 
-                newSpeaker_notes = renderlet:TEXTAREA
-                newSpeaker_notes {
-                    name = newSpeaker_notes
-                    label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_speakers.notes
-                    sanitize = false
-                    wrap = <div class="modalbox-column2"><div class="formidable-rdrstd-rdtwrap">|</div>
-                }
+        newSpeaker_notes = renderlet:TEXTAREA
+        newSpeaker_notes {
+          name = newSpeaker_notes
+          label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_speakers.notes
+          sanitize = false
+          wrap = <div class="modalbox-column2"><div class="formidable-rdrstd-rdtwrap">|</div>
+        }
 
-                newSpeaker_address = renderlet:TEXTAREA
-                newSpeaker_address {
-                    name = newSpeaker_address
-                    label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_speakers.address
-                    sanitize = false
-                    wrap = <div class="formidable-rdrstd-rdtwrap">|</div>
-                }
+        newSpeaker_address = renderlet:TEXTAREA
+        newSpeaker_address {
+          name = newSpeaker_address
+          label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_speakers.address
+          sanitize = false
+          wrap = <div class="formidable-rdrstd-rdtwrap">|</div>
+        }
 
-                newSpeaker_phone_work = renderlet:TEXT
-                newSpeaker_phone_work {
-                    name = newSpeaker_phone_work
-                    label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_speakers.phone_work
-                    sanitize = false
-                    wrap = <div class="formidable-rdrstd-rdtwrap">|</div>
-                }
+        newSpeaker_phone_work = renderlet:TEXT
+        newSpeaker_phone_work {
+          name = newSpeaker_phone_work
+          label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_speakers.phone_work
+          sanitize = false
+          wrap = <div class="formidable-rdrstd-rdtwrap">|</div>
+        }
 
-                newSpeaker_phone_home = renderlet:TEXT
-                newSpeaker_phone_home {
-                    name = newSpeaker_phone_home
-                    label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_speakers.phone_home
-                    sanitize = false
-                    wrap = <div class="formidable-rdrstd-rdtwrap">|</div>
-                }
+        newSpeaker_phone_home = renderlet:TEXT
+        newSpeaker_phone_home {
+          name = newSpeaker_phone_home
+          label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_speakers.phone_home
+          sanitize = false
+          wrap = <div class="formidable-rdrstd-rdtwrap">|</div>
+        }
 
-                newSpeaker_phone_mobile = renderlet:TEXT
-                newSpeaker_phone_mobile {
-                    name = newSpeaker_phone_mobile
-                    label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_speakers.phone_mobile
-                    sanitize = false
-                    wrap = <div class="formidable-rdrstd-rdtwrap">|</div>
-                }
+        newSpeaker_phone_mobile = renderlet:TEXT
+        newSpeaker_phone_mobile {
+          name = newSpeaker_phone_mobile
+          label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_speakers.phone_mobile
+          sanitize = false
+          wrap = <div class="formidable-rdrstd-rdtwrap">|</div>
+        }
 
-                newSpeaker_email = renderlet:TEXT
-                newSpeaker_email {
-                    name = newSpeaker_email
-                    label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_speakers.email
-                    sanitize = false
-                    wrap = <div class="formidable-rdrstd-rdtwrap">|</div>
-                }
+        newSpeaker_email = renderlet:TEXT
+        newSpeaker_email {
+          name = newSpeaker_email
+          label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_speakers.email
+          sanitize = false
+          wrap = <div class="formidable-rdrstd-rdtwrap">|</div>
+        }
 
-                newSpeaker_cancelation_period = renderlet:TEXT
-                newSpeaker_cancelation_period {
-                    name = newSpeaker_cancelation_period
-                    label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_speakers.cancelation_period
-                    sanitize = false
-                    wrap = <div class="formidable-rdrstd-rdtwrap">|</div></div>
-                }
+        newSpeaker_cancelation_period = renderlet:TEXT
+        newSpeaker_cancelation_period {
+          name = newSpeaker_cancelation_period
+          label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_speakers.cancelation_period
+          sanitize = false
+          wrap = <div class="formidable-rdrstd-rdtwrap">|</div></div>
+        }
 
-                newSpeaker_cancelButton = renderlet:BUTTON
-                newSpeaker_cancelButton {
-                    name = newSpeaker_cancelButton
-                    label = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:label_cancel
-                    wrap = <div class="formidable-rdrstd-rdtwrap modalbox-buttons">|
-                    onclick {
-                        runat = client
-                        userobj.php (
+        newSpeaker_cancelButton = renderlet:BUTTON
+        newSpeaker_cancelButton {
+          name = newSpeaker_cancelButton
+          label = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:label_cancel
+          wrap = <div class="formidable-rdrstd-rdtwrap modalbox-buttons">|
+          onclick {
+            runat = client
+            userobj.php (
                             return $this->aORenderlets['newSpeakerModalBox']->majixCloseBox();
-                        )
-                    }
-                }
-
-                newSpeaker_saveButton = renderlet:BUTTON
-                newSpeaker_saveButton {
-                    name = newSpeaker_saveButton
-                    label = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:label_save
-                    wrap = |</div>
-                    onclick {
-                        runat = ajax
-                        params = newSpeakerModalBox__*
-                        cache = false
-                        exec = eventeditor.createNewSpeaker()
-                    }
-                }
-            }
+            )
+          }
         }
 
-        editSpeakerButton = renderlet:BUTTON
-        editSpeakerButton {
-            name = editSpeakerButton
-            label = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:label_edit
-            class = tx-seminars-pi1-event-editor-edit-button
-            onclick {
-                runat = ajax
-                cache = false
-                userobj.php (
+        newSpeaker_saveButton = renderlet:BUTTON
+        newSpeaker_saveButton {
+          name = newSpeaker_saveButton
+          label = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:label_save
+          wrap = |</div>
+          onclick {
+            runat = ajax
+            params = newSpeakerModalBox__*
+            cache = false
+            exec = eventeditor.createNewSpeaker()
+          }
+        }
+      }
+    }
+
+    editSpeakerButton = renderlet:BUTTON
+    editSpeakerButton {
+      name = editSpeakerButton
+      label = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:label_edit
+      class = tx-seminars-pi1-event-editor-edit-button
+      onclick {
+        runat = ajax
+        cache = false
+        userobj.php (
                     return \OliverKlee\Seminars\FrontEnd\EventEditor::showEditSpeakerModalBox($this);
-                )
-            }
+        )
+      }
+    }
+
+    editSpeakerModalBox = renderlet:MODALBOX
+    editSpeakerModalBox {
+      name = editSpeakerModalBox
+      childs {
+        editSpeaker_title = renderlet:TEXT
+        editSpeaker_title {
+          name = editSpeaker_title
+          label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_speakers.title
+          sanitize = false
+          wrap = <div class="modalbox-column1"><div class="formidable-rdrstd-rdtwrap">|</div>
         }
 
-        editSpeakerModalBox = renderlet:MODALBOX
-        editSpeakerModalBox {
-            name = editSpeakerModalBox
-            childs {
-                editSpeaker_title = renderlet:TEXT
-                editSpeaker_title {
-                    name = editSpeaker_title
-                    label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_speakers.title
-                    sanitize = false
-                    wrap = <div class="modalbox-column1"><div class="formidable-rdrstd-rdtwrap">|</div>
-                }
+        editSpeaker_gender = renderlet:LISTBOX
+        editSpeaker_gender {
+          name = editSpeaker_gender
+          label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_speakers.gender
+          wrap = <div class="formidable-rdrstd-rdtwrap">|</div>
+          data {
+            items {
+              10 {
+                caption =
+                value = 0
+              }
 
-                editSpeaker_gender = renderlet:LISTBOX
-                editSpeaker_gender {
-                    name = editSpeaker_gender
-                    label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_speakers.gender
-                    wrap = <div class="formidable-rdrstd-rdtwrap">|</div>
-                    data {
-                        items {
-                            10 {
-                                caption =
-                                value = 0
-                            }
-                            20 {
-                                caption = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_speakers.gender_male
-                                value = 1
-                            }
-                            30 {
-                                caption = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_speakers.gender_female
-                                value = 2
-                            }
-                        }
-                    }
-                }
+              20 {
+                caption = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_speakers.gender_male
+                value = 1
+              }
 
-                editSpeaker_organization = renderlet:TEXT
-                editSpeaker_organization {
-                    name = editSpeaker_organization
-                    label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_speakers.organization
-                    sanitize = false
-                    wrap = <div class="formidable-rdrstd-rdtwrap">|</div>
-                }
+              30 {
+                caption = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_speakers.gender_female
+                value = 2
+              }
+            }
+          }
+        }
 
-                editSpeaker_homepage = renderlet:TEXT
-                editSpeaker_homepage {
-                    name = editSpeaker_homepage
-                    label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_speakers.homepage
-                    sanitize = false
-                    wrap = <div class="formidable-rdrstd-rdtwrap">|</div>
-                }
+        editSpeaker_organization = renderlet:TEXT
+        editSpeaker_organization {
+          name = editSpeaker_organization
+          label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_speakers.organization
+          sanitize = false
+          wrap = <div class="formidable-rdrstd-rdtwrap">|</div>
+        }
 
-                editSpeaker_description = renderlet:TEXTAREA
-                editSpeaker_description {
-                    name = editSpeaker_description
-                    label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_speakers.description
-                    sanitize = false
-                    wrap = <div class="formidable-rdrstd-rdtwrap">|</div>
-                }
+        editSpeaker_homepage = renderlet:TEXT
+        editSpeaker_homepage {
+          name = editSpeaker_homepage
+          label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_speakers.homepage
+          sanitize = false
+          wrap = <div class="formidable-rdrstd-rdtwrap">|</div>
+        }
 
-                editSpeaker_skills = renderlet:CHECKBOX
-                editSpeaker_skills {
-                    name = editSpeaker_skills
-                    label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_speakers.skills
-                    class = tx-seminars-pi1-event-editor-checkbox
-                    wrap = <div class="formidable-rdrstd-rdtwrap formidable-checkboxes">|</div></div>
-                    data.userobj.php (
+        editSpeaker_description = renderlet:TEXTAREA
+        editSpeaker_description {
+          name = editSpeaker_description
+          label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_speakers.description
+          sanitize = false
+          wrap = <div class="formidable-rdrstd-rdtwrap">|</div>
+        }
+
+        editSpeaker_skills = renderlet:CHECKBOX
+        editSpeaker_skills {
+          name = editSpeaker_skills
+          label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_speakers.skills
+          class = tx-seminars-pi1-event-editor-checkbox
+          wrap = <div class="formidable-rdrstd-rdtwrap formidable-checkboxes">|</div></div>
+          data.userobj.php (
                         return \OliverKlee\Seminars\FrontEnd\EventEditor::populateListSkills();
-                    )
-                }
+          )
+        }
 
-                editSpeaker_notes = renderlet:TEXTAREA
-                editSpeaker_notes {
-                    name = editSpeaker_notes
-                    label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_speakers.notes
-                    sanitize = false
-                    wrap = <div class="modalbox-column2"><div class="formidable-rdrstd-rdtwrap">|</div>
-                }
+        editSpeaker_notes = renderlet:TEXTAREA
+        editSpeaker_notes {
+          name = editSpeaker_notes
+          label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_speakers.notes
+          sanitize = false
+          wrap = <div class="modalbox-column2"><div class="formidable-rdrstd-rdtwrap">|</div>
+        }
 
-                editSpeaker_address = renderlet:TEXTAREA
-                editSpeaker_address {
-                    name = editSpeaker_address
-                    label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_speakers.address
-                    sanitize = false
-                    wrap = <div class="formidable-rdrstd-rdtwrap">|</div>
-                }
+        editSpeaker_address = renderlet:TEXTAREA
+        editSpeaker_address {
+          name = editSpeaker_address
+          label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_speakers.address
+          sanitize = false
+          wrap = <div class="formidable-rdrstd-rdtwrap">|</div>
+        }
 
-                editSpeaker_phone_work = renderlet:TEXT
-                editSpeaker_phone_work {
-                    name = editSpeaker_phone_work
-                    label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_speakers.phone_work
-                    sanitize = false
-                    wrap = <div class="formidable-rdrstd-rdtwrap">|</div>
-                }
+        editSpeaker_phone_work = renderlet:TEXT
+        editSpeaker_phone_work {
+          name = editSpeaker_phone_work
+          label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_speakers.phone_work
+          sanitize = false
+          wrap = <div class="formidable-rdrstd-rdtwrap">|</div>
+        }
 
-                editSpeaker_phone_home = renderlet:TEXT
-                editSpeaker_phone_home {
-                    name = editSpeaker_phone_home
-                    label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_speakers.phone_home
-                    sanitize = false
-                    wrap = <div class="formidable-rdrstd-rdtwrap">|</div>
-                }
+        editSpeaker_phone_home = renderlet:TEXT
+        editSpeaker_phone_home {
+          name = editSpeaker_phone_home
+          label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_speakers.phone_home
+          sanitize = false
+          wrap = <div class="formidable-rdrstd-rdtwrap">|</div>
+        }
 
-                editSpeaker_phone_mobile = renderlet:TEXT
-                editSpeaker_phone_mobile {
-                    name = editSpeaker_phone_mobile
-                    label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_speakers.phone_mobile
-                    sanitize = false
-                    wrap = <div class="formidable-rdrstd-rdtwrap">|</div>
-                }
+        editSpeaker_phone_mobile = renderlet:TEXT
+        editSpeaker_phone_mobile {
+          name = editSpeaker_phone_mobile
+          label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_speakers.phone_mobile
+          sanitize = false
+          wrap = <div class="formidable-rdrstd-rdtwrap">|</div>
+        }
 
-                editSpeaker_email = renderlet:TEXT
-                editSpeaker_email {
-                    name = editSpeaker_email
-                    label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_speakers.email
-                    sanitize = false
-                    wrap = <div class="formidable-rdrstd-rdtwrap">|</div>
-                }
+        editSpeaker_email = renderlet:TEXT
+        editSpeaker_email {
+          name = editSpeaker_email
+          label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_speakers.email
+          sanitize = false
+          wrap = <div class="formidable-rdrstd-rdtwrap">|</div>
+        }
 
-                editSpeaker_cancelation_period = renderlet:TEXT
-                editSpeaker_cancelation_period {
-                    name = editSpeaker_cancelation_period
-                    label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_speakers.cancelation_period
-                    sanitize = false
-                    wrap = <div class="formidable-rdrstd-rdtwrap">|</div></div>
-                }
+        editSpeaker_cancelation_period = renderlet:TEXT
+        editSpeaker_cancelation_period {
+          name = editSpeaker_cancelation_period
+          label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_speakers.cancelation_period
+          sanitize = false
+          wrap = <div class="formidable-rdrstd-rdtwrap">|</div></div>
+        }
 
-                editSpeaker_uid = renderlet:HIDDEN
-                editSpeaker_uid {
-                    name = editSpeaker_uid
-                }
+        editSpeaker_uid = renderlet:HIDDEN
+        editSpeaker_uid {
+          name = editSpeaker_uid
+        }
 
-                editSpeaker_cancelButton = renderlet:BUTTON
-                editSpeaker_cancelButton {
-                    name = editSpeaker_cancelButton
-                    label = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:label_cancel
-                    wrap = <div class="formidable-rdrstd-rdtwrap modalbox-buttons">|
-                    onclick {
-                        runat = client
-                        userobj.php (
+        editSpeaker_cancelButton = renderlet:BUTTON
+        editSpeaker_cancelButton {
+          name = editSpeaker_cancelButton
+          label = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:label_cancel
+          wrap = <div class="formidable-rdrstd-rdtwrap modalbox-buttons">|
+          onclick {
+            runat = client
+            userobj.php (
                             return $this->aORenderlets['editSpeakerModalBox']->majixCloseBox();
-                        )
-                    }
-                }
-
-                editSpeaker_saveButton = renderlet:BUTTON
-                editSpeaker_saveButton {
-                    name = editSpeaker_saveButton
-                    label = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:label_save
-                    wrap = |</div>
-                    onclick {
-                        runat = ajax
-                        params = editSpeakerModalBox__*
-                        cache = false
-                        exec = eventeditor.updateSpeaker()
-                    }
-                }
-            }
+            )
+          }
         }
 
-        partners = renderlet:CHECKBOX
-        partners {
-            name = partners
-            label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_seminars.partners
-            class = tx-seminars-pi1-event-editor-checkbox
-            wrapitem = <tr><td>|</td></tr>
-            wrap = <table class="checkboxTable" summary=""><tbody>|</tbody></table>
-            separator =
-            data.userobj {
-                extension = this
-                method = populateListSpeakers
-                params.10 {
-                    name = type
-                    value = Partner
-                }
-            }
-
-            validators {
-                10 = validator:STANDARD
-                10.custom {
-                    message = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:message_noPartnersChosen
-                    userobj {
-                        extension = this
-                        method = validateCheckboxes
-                        params.10 {
-                            name = elementName
-                            value = partners
-                        }
-                    }
-                }
-            }
+        editSpeaker_saveButton = renderlet:BUTTON
+        editSpeaker_saveButton {
+          name = editSpeaker_saveButton
+          label = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:label_save
+          wrap = |</div>
+          onclick {
+            runat = ajax
+            params = editSpeakerModalBox__*
+            cache = false
+            exec = eventeditor.updateSpeaker()
+          }
         }
+      }
+    }
 
-        tutors = renderlet:CHECKBOX
-        tutors {
-            name = tutors
-            label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_seminars.tutors
-            class = tx-seminars-pi1-event-editor-checkbox
-            wrapitem = <tr><td>|</td></tr>
-            wrap = <table class="checkboxTable" summary=""><tbody>|</tbody></table>
-            separator =
-            data.userobj {
-                extension = this
-                method = populateListSpeakers
-                params.10 {
-                    name = type
-                    value = Tutor
-                }
-            }
-
-            validators {
-                10 = validator:STANDARD
-                10.custom {
-                    message = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:message_noTutorsChosen
-                    userobj {
-                        extension = this
-                        method = validateCheckboxes
-                        params.10 {
-                            name = elementName
-                            value = tutors
-                        }
-                    }
-                }
-            }
+    partners = renderlet:CHECKBOX
+    partners {
+      name = partners
+      label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_seminars.partners
+      class = tx-seminars-pi1-event-editor-checkbox
+      wrapitem = <tr><td>|</td></tr>
+      wrap = <table class="checkboxTable" summary=""><tbody>|</tbody></table>
+      separator =
+      data.userobj {
+        extension = this
+        method = populateListSpeakers
+        params.10 {
+          name = type
+          value = Partner
         }
+      }
 
-        leaders = renderlet:CHECKBOX
-        leaders {
-            name = leaders
-            label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_seminars.leaders
-            class = tx-seminars-pi1-event-editor-checkbox
-            wrapitem = <tr><td>|</td></tr>
-            wrap = <table class="checkboxTable" summary=""><tbody>|</tbody></table>
-            separator =
-            data.userobj {
-                extension = this
-                method = populateListSpeakers
-                params.10 {
-                    name = type
-                    value = Leader
-                }
+      validators {
+        10 = validator:STANDARD
+        10.custom {
+          message = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:message_noPartnersChosen
+          userobj {
+            extension = this
+            method = validateCheckboxes
+            params.10 {
+              name = elementName
+              value = partners
             }
-
-            validators {
-                10 = validator:STANDARD
-                10.custom {
-                    message = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:message_noLeadersChosen
-                    userobj {
-                        extension = this
-                        method = validateCheckboxes
-                        params.10 {
-                            name = elementName
-                            value = leaders
-                        }
-                    }
-                }
-            }
+          }
         }
+      }
+    }
 
-        price_regular = renderlet:TEXT
-        price_regular {
-            name = price_regular
-            label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_seminars.price_regular
-            sanitize = false
-            validators {
-                10 = validator:STANDARD
-                10.custom {
-                    message = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:message_invalidPriceRegular
-                    userobj {
-                        extension = this
-                        method = validatePrice
-                        params.10 {
-                            name = elementName
-                            value = price_regular
-                        }
-                    }
-                }
-            }
+    tutors = renderlet:CHECKBOX
+    tutors {
+      name = tutors
+      label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_seminars.tutors
+      class = tx-seminars-pi1-event-editor-checkbox
+      wrapitem = <tr><td>|</td></tr>
+      wrap = <table class="checkboxTable" summary=""><tbody>|</tbody></table>
+      separator =
+      data.userobj {
+        extension = this
+        method = populateListSpeakers
+        params.10 {
+          name = type
+          value = Tutor
         }
+      }
 
-        price_regular_early = renderlet:TEXT
-        price_regular_early {
-            name = price_regular_early
-            label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_seminars.price_regular_early
-            sanitize = false
-            validators {
-                10 = validator:STANDARD
-                10.custom {
-                    message = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:message_invalidPriceRegularEarly
-                    userobj {
-                        extension = this
-                        method = validatePrice
-                        params.10 {
-                            name = elementName
-                            value = price_regular_early
-                        }
-                    }
-                }
+      validators {
+        10 = validator:STANDARD
+        10.custom {
+          message = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:message_noTutorsChosen
+          userobj {
+            extension = this
+            method = validateCheckboxes
+            params.10 {
+              name = elementName
+              value = tutors
             }
+          }
         }
+      }
+    }
 
-        price_regular_board = renderlet:TEXT
-        price_regular_board {
-            name = price_regular_board
-            label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_seminars.price_regular_board
-            sanitize = false
-            validators {
-                10 = validator:STANDARD
-                10.custom {
-                    message = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:message_invalidPriceRegularBoard
-                    userobj {
-                        extension = this
-                        method = validatePrice
-                        params.10 {
-                            name = elementName
-                            value = price_regular_board
-                        }
-                    }
-                }
-            }
+    leaders = renderlet:CHECKBOX
+    leaders {
+      name = leaders
+      label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_seminars.leaders
+      class = tx-seminars-pi1-event-editor-checkbox
+      wrapitem = <tr><td>|</td></tr>
+      wrap = <table class="checkboxTable" summary=""><tbody>|</tbody></table>
+      separator =
+      data.userobj {
+        extension = this
+        method = populateListSpeakers
+        params.10 {
+          name = type
+          value = Leader
         }
+      }
 
-        price_special = renderlet:TEXT
-        price_special {
-            name = price_special
-            label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_seminars.price_special
-            sanitize = false
-            validators {
-                10 = validator:STANDARD
-                10.custom {
-                    message = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:message_invalidPriceSpecial
-                    userobj {
-                        extension = this
-                        method = validatePrice
-                        params.10 {
-                            name = elementName
-                            value = price_special
-                        }
-                    }
-                }
+      validators {
+        10 = validator:STANDARD
+        10.custom {
+          message = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:message_noLeadersChosen
+          userobj {
+            extension = this
+            method = validateCheckboxes
+            params.10 {
+              name = elementName
+              value = leaders
             }
+          }
         }
+      }
+    }
 
-        price_special_early = renderlet:TEXT
-        price_special_early {
-            name = price_special_early
-            label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_seminars.price_special_early
-            sanitize = false
-            validators {
-                10 = validator:STANDARD
-                10.custom {
-                    message = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:message_invalidPriceSpecialEarly
-                    userobj {
-                        extension = this
-                        method = validatePrice
-                        params.10 {
-                            name = elementName
-                            value = price_special_early
-                        }
-                    }
-                }
+    price_regular = renderlet:TEXT
+    price_regular {
+      name = price_regular
+      label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_seminars.price_regular
+      sanitize = false
+      validators {
+        10 = validator:STANDARD
+        10.custom {
+          message = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:message_invalidPriceRegular
+          userobj {
+            extension = this
+            method = validatePrice
+            params.10 {
+              name = elementName
+              value = price_regular
             }
+          }
         }
+      }
+    }
 
-        price_special_board = renderlet:TEXT
-        price_special_board {
-            name = price_special_board
-            label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_seminars.price_special_board
-            sanitize = false
-            validators {
-                10 = validator:STANDARD
-                10.custom {
-                    message = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:message_invalidPriceSpecialBoard
-                    userobj {
-                        extension = this
-                        method = validatePrice
-                        params.10 {
-                            name = elementName
-                            value = price_special_board
-                        }
-                    }
-                }
+    price_regular_early = renderlet:TEXT
+    price_regular_early {
+      name = price_regular_early
+      label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_seminars.price_regular_early
+      sanitize = false
+      validators {
+        10 = validator:STANDARD
+        10.custom {
+          message = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:message_invalidPriceRegularEarly
+          userobj {
+            extension = this
+            method = validatePrice
+            params.10 {
+              name = elementName
+              value = price_regular_early
             }
+          }
         }
+      }
+    }
 
-        additional_information = renderlet:TEXTAREA
-        additional_information {
-            name = additional_information
-            label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_seminars.additional_information
-            sanitize = false
-            validators {
-                10 = validator:STANDARD
-                10.custom {
-                    message = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:message_emptyAdditionalInformation
-                    userobj {
-                        extension = this
-                        method = validateString
-                        params.10 {
-                            name = elementName
-                            value = additional_information
-                        }
-                    }
-                }
+    price_regular_board = renderlet:TEXT
+    price_regular_board {
+      name = price_regular_board
+      label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_seminars.price_regular_board
+      sanitize = false
+      validators {
+        10 = validator:STANDARD
+        10.custom {
+          message = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:message_invalidPriceRegularBoard
+          userobj {
+            extension = this
+            method = validatePrice
+            params.10 {
+              name = elementName
+              value = price_regular_board
             }
+          }
         }
+      }
+    }
 
-        checkboxes = renderlet:CHECKBOX
-        checkboxes {
-            name = checkboxes
-            label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_seminars.checkboxes
-            class = tx-seminars-pi1-event-editor-checkbox
-            wrapitem = <tr><td>|</td></tr>
-            wrap = <table class="checkboxTable" summary=""><tbody>|</tbody></table>
-            separator =
-            data.userobj {
-                extension = this
-                method = populateListCheckboxes
+    price_special = renderlet:TEXT
+    price_special {
+      name = price_special
+      label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_seminars.price_special
+      sanitize = false
+      validators {
+        10 = validator:STANDARD
+        10.custom {
+          message = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:message_invalidPriceSpecial
+          userobj {
+            extension = this
+            method = validatePrice
+            params.10 {
+              name = elementName
+              value = price_special
             }
-
-            validators {
-                10 = validator:STANDARD
-                10.custom {
-                    message = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:message_noCheckboxesChosen
-                    userobj {
-                        extension = this
-                        method = validateCheckboxes
-                        params.10 {
-                            name = elementName
-                            value = checkboxes
-                        }
-                    }
-                }
-            }
+          }
         }
+      }
+    }
 
-        newCheckboxButton = renderlet:BUTTON
-        newCheckboxButton {
-            name = newCheckboxButton
-            label = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:newCheckboxButton
-            process.userobj {
-                extension = this
-                method = isFrontEndEditingOfRelatedRecordsAllowed
-                params.10 {
-                    name = relatedRecordType
-                    value = Checkboxes
-                }
+    price_special_early = renderlet:TEXT
+    price_special_early {
+      name = price_special_early
+      label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_seminars.price_special_early
+      sanitize = false
+      validators {
+        10 = validator:STANDARD
+        10.custom {
+          message = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:message_invalidPriceSpecialEarly
+          userobj {
+            extension = this
+            method = validatePrice
+            params.10 {
+              name = elementName
+              value = price_special_early
             }
+          }
+        }
+      }
+    }
 
-            onclick {
-                runat = ajax
-                cache = false
-                userobj.php (
+    price_special_board = renderlet:TEXT
+    price_special_board {
+      name = price_special_board
+      label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_seminars.price_special_board
+      sanitize = false
+      validators {
+        10 = validator:STANDARD
+        10.custom {
+          message = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:message_invalidPriceSpecialBoard
+          userobj {
+            extension = this
+            method = validatePrice
+            params.10 {
+              name = elementName
+              value = price_special_board
+            }
+          }
+        }
+      }
+    }
+
+    additional_information = renderlet:TEXTAREA
+    additional_information {
+      name = additional_information
+      label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_seminars.additional_information
+      sanitize = false
+      validators {
+        10 = validator:STANDARD
+        10.custom {
+          message = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:message_emptyAdditionalInformation
+          userobj {
+            extension = this
+            method = validateString
+            params.10 {
+              name = elementName
+              value = additional_information
+            }
+          }
+        }
+      }
+    }
+
+    checkboxes = renderlet:CHECKBOX
+    checkboxes {
+      name = checkboxes
+      label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_seminars.checkboxes
+      class = tx-seminars-pi1-event-editor-checkbox
+      wrapitem = <tr><td>|</td></tr>
+      wrap = <table class="checkboxTable" summary=""><tbody>|</tbody></table>
+      separator =
+      data.userobj {
+        extension = this
+        method = populateListCheckboxes
+      }
+
+      validators {
+        10 = validator:STANDARD
+        10.custom {
+          message = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:message_noCheckboxesChosen
+          userobj {
+            extension = this
+            method = validateCheckboxes
+            params.10 {
+              name = elementName
+              value = checkboxes
+            }
+          }
+        }
+      }
+    }
+
+    newCheckboxButton = renderlet:BUTTON
+    newCheckboxButton {
+      name = newCheckboxButton
+      label = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:newCheckboxButton
+      process.userobj {
+        extension = this
+        method = isFrontEndEditingOfRelatedRecordsAllowed
+        params.10 {
+          name = relatedRecordType
+          value = Checkboxes
+        }
+      }
+
+      onclick {
+        runat = ajax
+        cache = false
+        userobj.php (
                     $this->getRenderer()->_setDisplayLabels(true);
                     $result = $this->aORenderlets['newCheckboxModalBox']->majixShowFreshBox();
                     $this->getRenderer()->_setDisplayLabels(false);
                     return $result;
-                )
-            }
+        )
+      }
+    }
+
+    newCheckboxModalBox = renderlet:MODALBOX
+    newCheckboxModalBox {
+      name = newCheckboxModalBox
+      childs {
+        newCheckbox_title = renderlet:TEXT
+        newCheckbox_title {
+          name = newCheckbox_title
+          label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_checkboxes.title
+          sanitize = false
+          wrap = <div class="formidable-rdrstd-rdtwrap">|</div>
         }
 
-        newCheckboxModalBox = renderlet:MODALBOX
-        newCheckboxModalBox {
-            name = newCheckboxModalBox
-            childs {
-                newCheckbox_title = renderlet:TEXT
-                newCheckbox_title {
-                    name = newCheckbox_title
-                    label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_checkboxes.title
-                    sanitize = false
-                    wrap = <div class="formidable-rdrstd-rdtwrap">|</div>
-                }
-
-                newCheckbox_cancelButton = renderlet:BUTTON
-                newCheckbox_cancelButton {
-                    name = newCheckbox_cancelButton
-                    label = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:label_cancel
-                    wrap = <div class="formidable-rdrstd-rdtwrap modalbox-buttons">|
-                    onclick {
-                        runat = client
-                        userobj.php (
+        newCheckbox_cancelButton = renderlet:BUTTON
+        newCheckbox_cancelButton {
+          name = newCheckbox_cancelButton
+          label = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:label_cancel
+          wrap = <div class="formidable-rdrstd-rdtwrap modalbox-buttons">|
+          onclick {
+            runat = client
+            userobj.php (
                             return $this->aORenderlets['newCheckboxModalBox']->majixCloseBox();
-                        )
-                    }
-                }
+            )
+          }
+        }
 
-                newCheckbox_saveButton = renderlet:BUTTON
-                newCheckbox_saveButton {
-                    name = newCheckbox_saveButton
-                    label = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:label_save
-                    wrap = |</div>
-                    onclick {
-                        runat = ajax
-                        cache = false
-                        params = newCheckbox_title
-                        userobj.php (
+        newCheckbox_saveButton = renderlet:BUTTON
+        newCheckbox_saveButton {
+          name = newCheckbox_saveButton
+          label = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:label_save
+          wrap = |</div>
+          onclick {
+            runat = ajax
+            cache = false
+            params = newCheckbox_title
+            userobj.php (
                             return \OliverKlee\Seminars\FrontEnd\EventEditor::createNewCheckbox($this);
-                        )
-                    }
-                }
-            }
+            )
+          }
         }
+      }
+    }
 
-        editCheckboxButton = renderlet:BUTTON
-        editCheckboxButton {
-            name = editCheckboxButton
-            label = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:label_edit
-            class = tx-seminars-pi1-event-editor-edit-button
-            onclick {
-                runat = ajax
-                cache = false
-                userobj.php (
+    editCheckboxButton = renderlet:BUTTON
+    editCheckboxButton {
+      name = editCheckboxButton
+      label = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:label_edit
+      class = tx-seminars-pi1-event-editor-edit-button
+      onclick {
+        runat = ajax
+        cache = false
+        userobj.php (
                     return \OliverKlee\Seminars\FrontEnd\EventEditor::showEditCheckboxModalBox($this);
-                )
-            }
+        )
+      }
+    }
+
+    editCheckboxModalBox = renderlet:MODALBOX
+    editCheckboxModalBox {
+      name = editCheckboxModalBox
+      childs {
+        editCheckbox_title = renderlet:TEXT
+        editCheckbox_title {
+          name = editCheckbox_title
+          label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_checkboxes.title
+          sanitize = false
+          wrap = <div class="formidable-rdrstd-rdtwrap">|</div>
         }
 
-        editCheckboxModalBox = renderlet:MODALBOX
-        editCheckboxModalBox {
-            name = editCheckboxModalBox
-            childs {
-                editCheckbox_title = renderlet:TEXT
-                editCheckbox_title {
-                    name = editCheckbox_title
-                    label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_checkboxes.title
-                    sanitize = false
-                    wrap = <div class="formidable-rdrstd-rdtwrap">|</div>
-                }
+        editCheckbox_uid = renderlet:HIDDEN
+        editCheckbox_uid {
+          name = editCheckbox_uid
+        }
 
-                editCheckbox_uid = renderlet:HIDDEN
-                editCheckbox_uid {
-                    name = editCheckbox_uid
-                }
-
-                editCheckbox_cancelButton = renderlet:BUTTON
-                editCheckbox_cancelButton {
-                    name = editCheckbox_cancelButton
-                    label = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:label_cancel
-                    wrap = <div class="formidable-rdrstd-rdtwrap modalbox-buttons">|
-                    onclick {
-                        runat = client
-                        userobj.php (
+        editCheckbox_cancelButton = renderlet:BUTTON
+        editCheckbox_cancelButton {
+          name = editCheckbox_cancelButton
+          label = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:label_cancel
+          wrap = <div class="formidable-rdrstd-rdtwrap modalbox-buttons">|
+          onclick {
+            runat = client
+            userobj.php (
                             return $this->aORenderlets['editCheckboxModalBox']->majixCloseBox();
-                        )
-                    }
-                }
+            )
+          }
+        }
 
-                editCheckbox_saveButton = renderlet:BUTTON
-                editCheckbox_saveButton {
-                    name = editCheckbox_saveButton
-                    label = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:label_save
-                    wrap = |</div>
-                    onclick {
-                        runat = ajax
-                        cache = false
-                        params = editCheckbox_title, editCheckbox_uid
-                        userobj.php (
+        editCheckbox_saveButton = renderlet:BUTTON
+        editCheckbox_saveButton {
+          name = editCheckbox_saveButton
+          label = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:label_save
+          wrap = |</div>
+          onclick {
+            runat = ajax
+            cache = false
+            params = editCheckbox_title, editCheckbox_uid
+            userobj.php (
                             return \OliverKlee\Seminars\FrontEnd\EventEditor::updateCheckbox($this);
-                        )
-                    }
-                }
+            )
+          }
+        }
+      }
+    }
+
+    payment_methods = renderlet:CHECKBOX
+    payment_methods {
+      name = payment_methods
+      label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_seminars.payment_methods
+      class = tx-seminars-pi1-event-editor-checkbox
+      data.userobj {
+        extension = this
+        method = populateListPaymentMethods
+      }
+
+      validators {
+        10 = validator:STANDARD
+        10.custom {
+          message = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:message_noPaymentMethodsChosen
+          userobj {
+            extension = this
+            method = validateCheckboxes
+            params.10 {
+              name = elementName
+              value = payment_methods
             }
+          }
+        }
+      }
+    }
+
+    organizers = renderlet:CHECKBOX
+    organizers {
+      name = organizers
+      label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_seminars.organizers
+      class = tx-seminars-pi1-event-editor-checkbox
+      data {
+        userobj {
+          extension = this
+          method = populateListOrganizers
         }
 
-        payment_methods = renderlet:CHECKBOX
-        payment_methods {
-            name = payment_methods
-            label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_seminars.payment_methods
-            class = tx-seminars-pi1-event-editor-checkbox
-            data.userobj {
-                extension = this
-                method = populateListPaymentMethods
-            }
-
-            validators {
-                10 = validator:STANDARD
-                10.custom {
-                    message = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:message_noPaymentMethodsChosen
-                    userobj {
-                        extension = this
-                        method = validateCheckboxes
-                        params.10 {
-                            name = elementName
-                            value = payment_methods
-                        }
-                    }
-                }
-            }
+        defaultvalue.userobj {
+          extension = this
+          method = getPreselectedOrganizer
         }
+      }
 
-        organizers = renderlet:CHECKBOX
-        organizers {
-            name = organizers
-            label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_seminars.organizers
-            class = tx-seminars-pi1-event-editor-checkbox
-            data {
-                userobj {
-                    extension = this
-                    method = populateListOrganizers
-                }
-
-                defaultvalue.userobj {
-                    extension = this
-                    method = getPreselectedOrganizer
-                }
-            }
-
-            validators {
-                10 = validator:STANDARD
-                10.custom {
-                    message = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:message_emptyOrganizer
-                    userobj {
-                        php (
+      validators {
+        10 = validator:STANDARD
+        10.custom {
+          message = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:message_emptyOrganizer
+          userobj {
+            php (
                             $value = array_pop(func_get_args());
                             return (!empty($value));
-                        )
-                    }
-                }
+            )
+          }
+        }
+      }
+    }
+
+    needs_registration = renderlet:CHECKSINGLE
+    needs_registration {
+      name = needs_registration
+      label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_seminars.needs_registration
+    }
+
+    allows_multiple_registrations = renderlet:CHECKSINGLE
+    allows_multiple_registrations {
+      name = allows_multiple_registrations
+      label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_seminars.allows_multiple_registrations
+    }
+
+    attendees_min = renderlet:TEXT
+    attendees_min {
+      name = attendees_min
+      label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_seminars.attendees_min
+      sanitize = false
+      validators {
+        10 = validator:STANDARD
+        10.custom {
+          message = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:message_attendeesMinZero
+          userobj {
+            extension = this
+            method = validateInteger
+            params.10 {
+              name = elementName
+              value = attendees_min
             }
+          }
         }
+      }
+    }
 
-        needs_registration = renderlet:CHECKSINGLE
-        needs_registration {
-            name = needs_registration
-            label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_seminars.needs_registration
-        }
-
-        allows_multiple_registrations = renderlet:CHECKSINGLE
-        allows_multiple_registrations {
-            name = allows_multiple_registrations
-            label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_seminars.allows_multiple_registrations
-        }
-
-        attendees_min = renderlet:TEXT
-        attendees_min {
-            name = attendees_min
-            label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_seminars.attendees_min
-            sanitize = false
-            validators {
-                10 = validator:STANDARD
-                10.custom {
-                    message = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:message_attendeesMinZero
-                    userobj {
-                        extension = this
-                        method = validateInteger
-                        params.10 {
-                            name = elementName
-                            value = attendees_min
-                        }
-                    }
-                }
+    attendees_max = renderlet:TEXT
+    attendees_max {
+      name = attendees_max
+      label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_seminars.attendees_max
+      sanitize = false
+      validators {
+        10 = validator:STANDARD
+        10.custom {
+          message = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:message_attendeesMaxZero
+          userobj {
+            extension = this
+            method = validateInteger
+            params.10 {
+              name = elementName
+              value = attendees_max
             }
+          }
         }
+      }
+    }
 
-        attendees_max = renderlet:TEXT
-        attendees_max {
-            name = attendees_max
-            label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_seminars.attendees_max
-            sanitize = false
-            validators {
-                10 = validator:STANDARD
-                10.custom {
-                    message = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:message_attendeesMaxZero
-                    userobj {
-                        extension = this
-                        method = validateInteger
-                        params.10 {
-                            name = elementName
-                            value = attendees_max
-                        }
-                    }
-                }
+    queue_size = renderlet:CHECKSINGLE
+    queue_size {
+      name = queue_size
+      label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_seminars.queue_size
+    }
+
+    offline_attendees = renderlet:TEXT
+    offline_attendees {
+      name = offline_attendees
+      label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_seminars.offline_attendees
+      sanitize = false
+      validators {
+        10 = validator:STANDARD
+        10.custom {
+          message = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:message_offlineAttendeesZero
+          userobj {
+            extension = this
+            method = validateInteger
+            params.10 {
+              name = elementName
+              value = offline_attendees
             }
+          }
         }
+      }
+    }
 
-        queue_size = renderlet:CHECKSINGLE
-        queue_size {
-            name = queue_size
-            label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_seminars.queue_size
+    target_groups = renderlet:CHECKBOX
+    target_groups {
+      name = target_groups
+      label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_seminars.target_groups
+      class = tx-seminars-pi1-event-editor-checkbox
+      wrapitem = <tr><td>|</td></tr>
+      wrap = <table class="checkboxTable" summary=""><tbody>|</tbody></table>
+      separator =
+      data.userobj {
+        extension = this
+        method = populateListTargetGroups
+      }
+
+      validators {
+        10 = validator:STANDARD
+        10.custom {
+          message = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:message_noTargetGroupsChosen
+          userobj {
+            extension = this
+            method = validateCheckboxes
+            params.10 {
+              name = elementName
+              value = target_groups
+            }
+          }
         }
+      }
+    }
 
-        offline_attendees = renderlet:TEXT
-        offline_attendees {
-            name = offline_attendees
-            label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_seminars.offline_attendees
-            sanitize = false
-            validators {
-                10 = validator:STANDARD
-                10.custom {
-                    message = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:message_offlineAttendeesZero
-                    userobj {
-                        extension = this
-                        method = validateInteger
-                        params.10 {
-                            name = elementName
-                            value = offline_attendees
-                        }
-                    }
-                }
-            }
+    newTargetGroupButton = renderlet:BUTTON
+    newTargetGroupButton {
+      name = newTargetGroupButton
+      label = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:newTargetGroupButton
+      process.userobj {
+        extension = this
+        method = isFrontEndEditingOfRelatedRecordsAllowed
+        params.10 {
+          name = relatedRecordType
+          value = TargetGroups
         }
+      }
 
-        target_groups = renderlet:CHECKBOX
-        target_groups {
-            name = target_groups
-            label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_seminars.target_groups
-            class = tx-seminars-pi1-event-editor-checkbox
-            wrapitem = <tr><td>|</td></tr>
-            wrap = <table class="checkboxTable" summary=""><tbody>|</tbody></table>
-            separator =
-            data.userobj {
-                extension = this
-                method = populateListTargetGroups
-            }
-
-            validators {
-                10 = validator:STANDARD
-                10.custom {
-                    message = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:message_noTargetGroupsChosen
-                    userobj {
-                        extension = this
-                        method = validateCheckboxes
-                        params.10 {
-                            name = elementName
-                            value = target_groups
-                        }
-                    }
-                }
-            }
-        }
-
-        newTargetGroupButton = renderlet:BUTTON
-        newTargetGroupButton {
-            name = newTargetGroupButton
-            label = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:newTargetGroupButton
-            process.userobj {
-                extension = this
-                method = isFrontEndEditingOfRelatedRecordsAllowed
-                params.10 {
-                    name = relatedRecordType
-                    value = TargetGroups
-                }
-            }
-
-            onclick {
-                runat = ajax
-                userobj.php (
+      onclick {
+        runat = ajax
+        userobj.php (
                     $this->getRenderer()->_setDisplayLabels(true);
                     $result = $this->aORenderlets['newTargetGroupModalBox']->majixShowFreshBox();
                     $this->getRenderer()->_setDisplayLabels(false);
                     return $result;
-                )
-            }
-        }
-
-        newTargetGroupModalBox = renderlet:MODALBOX
-        newTargetGroupModalBox {
-            name = newTargetGroupModalBox
-            childs {
-                newTargetGroup_title = renderlet:TEXT
-                newTargetGroup_title {
-                    name = newTargetGroup_title
-                    label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_target_groups.title
-                    sanitize = false
-                    wrap = <div class="formidable-rdrstd-rdtwrap">|</div>
-                }
-
-                newTargetGroup_minimum_age = renderlet:TEXT
-                newTargetGroup_minimum_age {
-                    name = newTargetGroup_minimum_age
-                    label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_target_groups.minimum_age
-                    sanitize = false
-                    wrap = <div class="formidable-rdrstd-rdtwrap">|</div>
-                }
-
-                newTargetGroup_maximum_age = renderlet:TEXT
-                newTargetGroup_maximum_age {
-                    name = newTargetGroup_maximum_age
-                    label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_target_groups.maximum_age
-                    sanitize = false
-                    wrap = <div class="formidable-rdrstd-rdtwrap">|</div>
-                }
-
-                newTargetGroup_cancelButton = renderlet:BUTTON
-                newTargetGroup_cancelButton {
-                    name = newTargetGroup_cancelButton
-                    label = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:label_cancel
-                    wrap = <div class="formidable-rdrstd-rdtwrap modalbox-buttons">|
-                    onclick {
-                        runat = client
-                        userobj.php (
-                            return $this->aORenderlets['newTargetGroupModalBox']->majixCloseBox();
-                        )
-                    }
-                }
-
-                newTargetGroup_saveButton = renderlet:BUTTON
-                newTargetGroup_saveButton {
-                    name = newTargetGroup_saveButton
-                    label = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:label_save
-                    wrap = |</div>
-                    onclick {
-                        runat = ajax
-                        params = newTargetGroup_title, newTargetGroup_minimum_age, newTargetGroup_maximum_age
-                        userobj.php (
-                            return \OliverKlee\Seminars\FrontEnd\EventEditor::createNewTargetGroup($this);
-                        )
-                    }
-                }
-            }
-        }
-
-        editTargetGroupButton = renderlet:BUTTON
-        editTargetGroupButton {
-            name = editTargetGroupButton
-            label = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:label_edit
-            class = tx-seminars-pi1-event-editor-edit-button
-            onclick {
-                runat = ajax
-                cache = false
-                userobj.php (
-                    return \OliverKlee\Seminars\FrontEnd\EventEditor::showEditTargetGroupModalBox($this);
-                )
-            }
-        }
-
-        editTargetGroupModalBox = renderlet:MODALBOX
-        editTargetGroupModalBox {
-            name = editTargetGroupModalBox
-            childs {
-                editTargetGroup_title = renderlet:TEXT
-                editTargetGroup_title {
-                    name = editTargetGroup_title
-                    label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_target_groups.title
-                    sanitize = false
-                    wrap = <div class="formidable-rdrstd-rdtwrap">|</div>
-                }
-
-                editTargetGroup_uid = renderlet:HIDDEN
-                editTargetGroup_uid {
-                    name = editTargetGroup_uid
-                }
-
-                editTargetGroup_minimum_age = renderlet:TEXT
-                editTargetGroup_minimum_age {
-                    name = editTargetGroup_minimum_age
-                    label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_target_groups.minimum_age
-                    sanitize = false
-                    wrap = <div class="formidable-rdrstd-rdtwrap">|</div>
-                }
-
-                editTargetGroup_maximum_age = renderlet:TEXT
-                editTargetGroup_maximum_age {
-                    name = editTargetGroup_maximum_age
-                    label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_target_groups.maximum_age
-                    sanitize = false
-                    wrap = <div class="formidable-rdrstd-rdtwrap">|</div>
-                }
-
-                editTargetGroup_cancelButton = renderlet:BUTTON
-                editTargetGroup_cancelButton {
-                    name = editTargetGroup_cancelButton
-                    label = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:label_cancel
-                    wrap = <div class="formidable-rdrstd-rdtwrap modalbox-buttons">|
-                    onclick {
-                        runat = client
-                        userobj.php (
-                            return $this->aORenderlets['editTargetGroupModalBox']->majixCloseBox();
-                        )
-                    }
-                }
-
-                editTargetGroup_saveButton = renderlet:BUTTON
-                editTargetGroup_saveButton {
-                    name = editTargetGroup_saveButton
-                    label = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:label_save
-                    wrap = |</div>
-                    onclick {
-                        runat = ajax
-                        cache = false
-                        params = editTargetGroup_title, editTargetGroup_uid, editTargetGroup_minimum_age, editTargetGroup_maximum_age
-                        userobj.php (
-                            return \OliverKlee\Seminars\FrontEnd\EventEditor::updateTargetGroup($this);
-                        )
-                    }
-                }
-            }
-        }
-
-        cancelled = renderlet:LISTBOX
-        cancelled {
-            name = cancelled
-            label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_seminars.cancelled
-            data.items {
-                10 {
-                    caption = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_seminars.cancelled_planned
-                    value = 0
-                }
-
-                20 {
-                    caption = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_seminars.cancelled_canceled
-                    value = 1
-                }
-
-                30 {
-                    caption = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_seminars.cancelled_confirmed
-                    value = 2
-                }
-            }
-        }
-
-        uses_terms_2 = renderlet:CHECKSINGLE
-        uses_terms_2 {
-            name = uses_terms_2
-            label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_seminars.uses_terms_2
-        }
-
-        notes = renderlet:TEXTAREA
-        notes {
-            name = notes
-            label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_seminars.notes
-            sanitize = false
-            validators {
-                10 = validator:STANDARD
-                10.custom {
-                    message = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:message_emptyNotes
-                    userobj {
-                        extension = this
-                        method = validateString
-                        params.10 {
-                            name = elementName
-                            value = notes
-                        }
-                    }
-                }
-            }
-        }
-
-        submit_and_stay = renderlet:SUBMIT
-        submit_and_stay {
-            name = submit_and_stay
-            label = ###LABEL_SAVE###
-        }
-
-        btnsubmit = renderlet:SUBMIT
-        btnsubmit {
-            name = btnsubmit
-            label = ###LABEL_SAVE_AND_BACK###
-        }
+        )
+      }
     }
+
+    newTargetGroupModalBox = renderlet:MODALBOX
+    newTargetGroupModalBox {
+      name = newTargetGroupModalBox
+      childs {
+        newTargetGroup_title = renderlet:TEXT
+        newTargetGroup_title {
+          name = newTargetGroup_title
+          label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_target_groups.title
+          sanitize = false
+          wrap = <div class="formidable-rdrstd-rdtwrap">|</div>
+        }
+
+        newTargetGroup_minimum_age = renderlet:TEXT
+        newTargetGroup_minimum_age {
+          name = newTargetGroup_minimum_age
+          label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_target_groups.minimum_age
+          sanitize = false
+          wrap = <div class="formidable-rdrstd-rdtwrap">|</div>
+        }
+
+        newTargetGroup_maximum_age = renderlet:TEXT
+        newTargetGroup_maximum_age {
+          name = newTargetGroup_maximum_age
+          label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_target_groups.maximum_age
+          sanitize = false
+          wrap = <div class="formidable-rdrstd-rdtwrap">|</div>
+        }
+
+        newTargetGroup_cancelButton = renderlet:BUTTON
+        newTargetGroup_cancelButton {
+          name = newTargetGroup_cancelButton
+          label = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:label_cancel
+          wrap = <div class="formidable-rdrstd-rdtwrap modalbox-buttons">|
+          onclick {
+            runat = client
+            userobj.php (
+                            return $this->aORenderlets['newTargetGroupModalBox']->majixCloseBox();
+            )
+          }
+        }
+
+        newTargetGroup_saveButton = renderlet:BUTTON
+        newTargetGroup_saveButton {
+          name = newTargetGroup_saveButton
+          label = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:label_save
+          wrap = |</div>
+          onclick {
+            runat = ajax
+            params = newTargetGroup_title, newTargetGroup_minimum_age, newTargetGroup_maximum_age
+            userobj.php (
+                            return \OliverKlee\Seminars\FrontEnd\EventEditor::createNewTargetGroup($this);
+            )
+          }
+        }
+      }
+    }
+
+    editTargetGroupButton = renderlet:BUTTON
+    editTargetGroupButton {
+      name = editTargetGroupButton
+      label = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:label_edit
+      class = tx-seminars-pi1-event-editor-edit-button
+      onclick {
+        runat = ajax
+        cache = false
+        userobj.php (
+                    return \OliverKlee\Seminars\FrontEnd\EventEditor::showEditTargetGroupModalBox($this);
+        )
+      }
+    }
+
+    editTargetGroupModalBox = renderlet:MODALBOX
+    editTargetGroupModalBox {
+      name = editTargetGroupModalBox
+      childs {
+        editTargetGroup_title = renderlet:TEXT
+        editTargetGroup_title {
+          name = editTargetGroup_title
+          label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_target_groups.title
+          sanitize = false
+          wrap = <div class="formidable-rdrstd-rdtwrap">|</div>
+        }
+
+        editTargetGroup_uid = renderlet:HIDDEN
+        editTargetGroup_uid {
+          name = editTargetGroup_uid
+        }
+
+        editTargetGroup_minimum_age = renderlet:TEXT
+        editTargetGroup_minimum_age {
+          name = editTargetGroup_minimum_age
+          label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_target_groups.minimum_age
+          sanitize = false
+          wrap = <div class="formidable-rdrstd-rdtwrap">|</div>
+        }
+
+        editTargetGroup_maximum_age = renderlet:TEXT
+        editTargetGroup_maximum_age {
+          name = editTargetGroup_maximum_age
+          label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_target_groups.maximum_age
+          sanitize = false
+          wrap = <div class="formidable-rdrstd-rdtwrap">|</div>
+        }
+
+        editTargetGroup_cancelButton = renderlet:BUTTON
+        editTargetGroup_cancelButton {
+          name = editTargetGroup_cancelButton
+          label = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:label_cancel
+          wrap = <div class="formidable-rdrstd-rdtwrap modalbox-buttons">|
+          onclick {
+            runat = client
+            userobj.php (
+                            return $this->aORenderlets['editTargetGroupModalBox']->majixCloseBox();
+            )
+          }
+        }
+
+        editTargetGroup_saveButton = renderlet:BUTTON
+        editTargetGroup_saveButton {
+          name = editTargetGroup_saveButton
+          label = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:label_save
+          wrap = |</div>
+          onclick {
+            runat = ajax
+            cache = false
+            params = editTargetGroup_title, editTargetGroup_uid, editTargetGroup_minimum_age, editTargetGroup_maximum_age
+            userobj.php (
+                            return \OliverKlee\Seminars\FrontEnd\EventEditor::updateTargetGroup($this);
+            )
+          }
+        }
+      }
+    }
+
+    cancelled = renderlet:LISTBOX
+    cancelled {
+      name = cancelled
+      label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_seminars.cancelled
+      data.items {
+        10 {
+          caption = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_seminars.cancelled_planned
+          value = 0
+        }
+
+        20 {
+          caption = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_seminars.cancelled_canceled
+          value = 1
+        }
+
+        30 {
+          caption = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_seminars.cancelled_confirmed
+          value = 2
+        }
+      }
+    }
+
+    uses_terms_2 = renderlet:CHECKSINGLE
+    uses_terms_2 {
+      name = uses_terms_2
+      label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_seminars.uses_terms_2
+    }
+
+    notes = renderlet:TEXTAREA
+    notes {
+      name = notes
+      label = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_seminars.notes
+      sanitize = false
+      validators {
+        10 = validator:STANDARD
+        10.custom {
+          message = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:message_emptyNotes
+          userobj {
+            extension = this
+            method = validateString
+            params.10 {
+              name = elementName
+              value = notes
+            }
+          }
+        }
+      }
+    }
+
+    submit_and_stay = renderlet:SUBMIT
+    submit_and_stay {
+      name = submit_and_stay
+      label = ###LABEL_SAVE###
+    }
+
+    btnsubmit = renderlet:SUBMIT
+    btnsubmit {
+      name = btnsubmit
+      label = ###LABEL_SAVE_AND_BACK###
+    }
+  }
 }

--- a/Configuration/TypoScript/Forms/RegistrationStep1.typoscript
+++ b/Configuration/TypoScript/Forms/RegistrationStep1.typoscript
@@ -1,802 +1,808 @@
 # @deprecated #1545 will be removed in seminars 5.0
 plugin.tx_seminars_pi1.form.registration.step1 {
-    meta {
-        name = Seminar Manager registration form
-        description = This form allows FE users to register for events.
-        form.formid = tx_seminars_pi1_registration_editor
-        debug = false
-        displaylabels = false
-        minify.enabled = 1
-    }
+  meta {
+    name = Seminar Manager registration form
+    description = This form allows FE users to register for events.
+    form.formid = tx_seminars_pi1_registration_editor
+    debug = false
+    displaylabels = false
+    minify.enabled = 1
+  }
 
-    control {
-        datahandler = datahandler:RAW
-        datahandler.parentcallback = setPage
+  control {
+    datahandler = datahandler:RAW
+    datahandler.parentcallback = setPage
 
-        renderer = renderer:TEMPLATE
-        renderer.template {
-            path.userobj.php (
+    renderer = renderer:TEMPLATE
+    renderer.template {
+      path.userobj.php (
                 return \OliverKlee\Oelib\Configuration\ConfigurationRegistry::get('plugin.tx_seminars_pi1')->getAsString('registrationEditorTemplateFile');
-            )
-            subpart = ###REGISTRATION_EDITOR_STEP_1###
-            errortag = errors
-        }
+      )
+      subpart = ###REGISTRATION_EDITOR_STEP_1###
+      errortag = errors
+    }
+  }
+
+  elements {
+    step_counter = renderlet:LABEL
+    step_counter {
+      name = step_counter
+      data.value.userobj {
+        extension = this
+        method = getStepCounter
+      }
     }
 
-    elements {
-        step_counter = renderlet:LABEL
-        step_counter {
-            name = step_counter
-            data.value.userobj {
-                extension = this
-                method = getStepCounter
-            }
+    price = renderlet:LISTBOX
+    price {
+      name = price
+      data.userobj {
+        extension = this
+        method = populatePrices
+      }
+
+      validators {
+        10 = validator:STANDARD
+        10.custom {
+          message = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:message_choosePrice
+          userobj {
+            extension = this
+            method = isValidPriceSelected
+          }
+        }
+      }
+
+      process.userobj {
+        extension = this
+        method = hasRegistrationFormField
+        params.10 {
+          name = elementname
+          value = price
+        }
+      }
+    }
+
+    method_of_payment = renderlet:RADIOBUTTON
+    method_of_payment {
+      name = method_of_payment
+      data {
+        userobj {
+          extension = this
+          method = populateListPaymentMethods
         }
 
-        price = renderlet:LISTBOX
-        price {
-            name = price
-            data.userobj {
-                extension = this
-                method = populatePrices
-            }
+        defaultvalue.userobj {
+          extension = this
+          method = getPreselectedPaymentMethod
+        }
+      }
 
-            validators {
-                10 = validator:STANDARD
-                10.custom {
-                    message = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:message_choosePrice
-                    userobj {
-                        extension = this
-                        method = isValidPriceSelected
-                    }
-                }
-            }
+      wrapitem = |<br/>
+      validators {
+        10 = validator:STANDARD
+        10.custom {
+          message = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:message_chooseMethodOfPayment
+          userobj {
+            extension = this
+            method = isMethodOfPaymentSelected
+          }
+        }
+      }
 
-            process.userobj {
-                extension = this
-                method = hasRegistrationFormField
-                params.10 {
-                    name = elementname
-                    value = price
-                }
-            }
+      process.userobj {
+        extension = this
+        method = showMethodsOfPayment
+      }
+    }
+
+    account_number = renderlet:TEXT
+    account_number {
+      name = account_number
+      sanitize = false
+      data {
+        defaultvalue.userobj {
+          extension = this
+          method = retrieveDataFromSession
+          params.10 {
+            name = key
+            value = account_number
+          }
+        }
+      }
+
+      validators {
+        10 = validator:STANDARD
+        10.custom {
+          message = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:message_provideBankData
+          userobj {
+            extension = this
+            method = hasBankData
+          }
+        }
+      }
+
+      process.userobj {
+        extension = this
+        method = hasBankDataFormField
+        params.10 {
+          name = elementname
+          value = account_number
+        }
+      }
+    }
+
+    bank_code = renderlet:TEXT
+    bank_code {
+      name = bank_code
+      sanitize = false
+      data {
+        defaultvalue.userobj {
+          extension = this
+          method = retrieveDataFromSession
+          params.10 {
+            name = key
+            value = bank_code
+          }
+        }
+      }
+
+      validators {
+        10 = validator:STANDARD
+        10.custom {
+          message = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:message_provideBankData
+          userobj {
+            extension = this
+            method = hasBankData
+          }
+        }
+      }
+
+      process.userobj {
+        extension = this
+        method = hasBankDataFormField
+        params.10 {
+          name = elementname
+          value = bank_code
+        }
+      }
+    }
+
+    bank_name = renderlet:TEXT
+    bank_name {
+      name = bank_name
+      sanitize = false
+      data {
+        defaultvalue.userobj {
+          extension = this
+          method = retrieveDataFromSession
+          params.10 {
+            name = key
+            value = bank_name
+          }
+        }
+      }
+
+      validators {
+        10 = validator:STANDARD
+        10.custom {
+          message = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:message_provideBankData
+          userobj {
+            extension = this
+            method = hasBankData
+          }
+        }
+      }
+
+      process.userobj {
+        extension = this
+        method = hasBankDataFormField
+        params.10 {
+          name = elementname
+          value = bank_name
+        }
+      }
+    }
+
+    account_owner = renderlet:TEXT
+    account_owner {
+      name = account_owner
+      sanitize = false
+      data {
+        defaultvalue.userobj {
+          extension = this
+          method = retrieveDataFromSession
+          params.10 {
+            name = key
+            value = account_owner
+          }
+        }
+      }
+
+      validators {
+        10 = validator:STANDARD
+        10.custom {
+          message = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:message_provideBankData
+          userobj {
+            extension = this
+            method = hasBankData
+          }
+        }
+      }
+
+      process.userobj {
+        extension = this
+        method = hasBankDataFormField
+        params.10 {
+          name = elementname
+          value = account_owner
+        }
+      }
+    }
+
+    company = renderlet:TEXT
+    company {
+      name = company
+      sanitize = false
+      data.defaultvalue.userobj {
+        extension = this
+        method = getFeUserData
+        params.10 {
+          name = key
+          value = company
+        }
+      }
+
+      process.userobj {
+        extension = this
+        method = hasRegistrationFormField
+        params.10 {
+          name = elementname
+          value = company
+        }
+      }
+    }
+
+    gender = renderlet:LISTBOX
+    gender {
+      name = gender
+      data {
+        items {
+          10 {
+            caption = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_attendances.gender.I.0
+            value = 0
+          }
+
+          20 {
+            caption = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_attendances.gender.I.1
+            value = 1
+          }
         }
 
-        method_of_payment = renderlet:RADIOBUTTON
-        method_of_payment {
-            name = method_of_payment
-            data {
-                userobj {
-                    extension = this
-                    method = populateListPaymentMethods
-                }
+        defaultvalue.userobj {
+          extension = this
+          method = getFeUserData
+          params.10 {
+            name = key
+            value = gender
+          }
+        }
+      }
 
-                defaultvalue.userobj {
-                    extension = this
-                    method = getPreselectedPaymentMethod
-                }
-            }
+      process.userobj {
+        extension = this
+        method = hasRegistrationFormField
+        params.10 {
+          name = elementname
+          value = gender
+        }
+      }
+    }
 
-            wrapitem = |<br/>
-            validators {
-                10 = validator:STANDARD
-                10.custom {
-                    message = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:message_chooseMethodOfPayment
-                    userobj {
-                        extension = this
-                        method = isMethodOfPaymentSelected
-                    }
-                }
-            }
+    name = renderlet:TEXT
+    name {
+      name = name
+      sanitize = false
+      data.defaultvalue.userobj {
+        extension = this
+        method = getFeUserData
+        params.10 {
+          name = key
+          value = name
+        }
+      }
 
-            process.userobj {
-                extension = this
-                method = showMethodsOfPayment
-            }
+      process.userobj {
+        extension = this
+        method = hasRegistrationFormField
+        params.10 {
+          name = elementname
+          value = name
+        }
+      }
+    }
+
+    address = renderlet:TEXTAREA
+    address {
+      name = address
+      sanitize = false
+      data.defaultvalue.userobj {
+        extension = this
+        method = getFeUserData
+        params.10 {
+          name = key
+          value = address
+        }
+      }
+
+      process.userobj {
+        extension = this
+        method = hasRegistrationFormField
+        params.10 {
+          name = elementname
+          value = address
+        }
+      }
+    }
+
+    zip = renderlet:TEXT
+    zip {
+      name = zip
+      sanitize = false
+      data.defaultvalue.userobj {
+        extension = this
+        method = getFeUserData
+        params.10 {
+          name = key
+          value = zip
+        }
+      }
+
+      process.userobj {
+        extension = this
+        method = hasRegistrationFormField
+        params.10 {
+          name = elementname
+          value = zip
+        }
+      }
+    }
+
+    city = renderlet:TEXT
+    city {
+      name = city
+      sanitize = false
+      data.defaultvalue.userobj {
+        extension = this
+        method = getFeUserData
+        params.10 {
+          name = key
+          value = city
+        }
+      }
+
+      process.userobj {
+        extension = this
+        method = hasRegistrationFormField
+        params.10 {
+          name = elementname
+          value = city
+        }
+      }
+    }
+
+    country = renderlet:LISTBOX
+    country {
+      name = country
+      data {
+        userobj {
+          extension = this
+          method = populateListCountries
         }
 
-        account_number = renderlet:TEXT
-        account_number {
-            name = account_number
-            sanitize = false
-            data {
-                defaultvalue.userobj {
-                    extension = this
-                    method = retrieveDataFromSession
-                    params.10 {
-                        name = key
-                        value = account_number
-                    }
-                }
-            }
+        defaultvalue.userobj {
+          extension = this
+          method = getFeUserData
+          params.10 {
+            name = key
+            value = country
+          }
+        }
+      }
 
-            validators {
-                10 = validator:STANDARD
-                10.custom {
-                    message = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:message_provideBankData
-                    userobj {
-                        extension = this
-                        method = hasBankData
-                    }
-                }
-            }
+      process.userobj {
+        extension = this
+        method = hasRegistrationFormField
+        params.10 {
+          name = elementname
+          value = country
+        }
+      }
+    }
 
-            process.userobj {
-                extension = this
-                method = hasBankDataFormField
-                params.10 {
-                    name = elementname
-                    value = account_number
-                }
-            }
+    telephone = renderlet:TEXT
+    telephone {
+      name = telephone
+      sanitize = false
+      data.defaultvalue.userobj {
+        extension = this
+        method = getFeUserData
+        params.10 {
+          name = key
+          value = telephone
+        }
+      }
+
+      process.userobj {
+        extension = this
+        method = hasRegistrationFormField
+        params.10 {
+          name = elementname
+          value = telephone
+        }
+      }
+    }
+
+    email = renderlet:TEXT
+    email {
+      name = email
+      sanitize = false
+      data.defaultvalue.userobj {
+        extension = this
+        method = getFeUserData
+        params.10 {
+          name = key
+          value = email
+        }
+      }
+
+      process.userobj {
+        extension = this
+        method = hasRegistrationFormField
+        params.10 {
+          name = elementname
+          value = email
+        }
+      }
+    }
+
+    seats = renderlet:LISTBOX
+    seats {
+      name = seats
+      data {
+        userobj {
+          extension = this
+          method = populateSeats
         }
 
-        bank_code = renderlet:TEXT
-        bank_code {
-            name = bank_code
-            sanitize = false
-            data {
-                defaultvalue.userobj {
-                    extension = this
-                    method = retrieveDataFromSession
-                    params.10 {
-                        name = key
-                        value = bank_code
-                    }
-                }
-            }
+        defaultvalue = 1
+      }
 
-            validators {
-                10 = validator:STANDARD
-                10.custom {
-                    message = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:message_provideBankData
-                    userobj {
-                        extension = this
-                        method = hasBankData
-                    }
-                }
-            }
-
-            process.userobj {
-                extension = this
-                method = hasBankDataFormField
-                params.10 {
-                    name = elementname
-                    value = bank_code
-                }
-            }
+      validators {
+        10 = validator:PREG
+        10.pattern {
+          value = /^[\d]*$/
+          message = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:message_noSeatsNumber
         }
 
-        bank_name = renderlet:TEXT
-        bank_name {
-            name = bank_name
-            sanitize = false
-            data {
-                defaultvalue.userobj {
-                    extension = this
-                    method = retrieveDataFromSession
-                    params.10 {
-                        name = key
-                        value = bank_name
-                    }
-                }
-            }
-
-            validators {
-                10 = validator:STANDARD
-                10.custom {
-                    message = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:message_provideBankData
-                    userobj {
-                        extension = this
-                        method = hasBankData
-                    }
-                }
-            }
-
-            process.userobj {
-                extension = this
-                method = hasBankDataFormField
-                params.10 {
-                    name = elementname
-                    value = bank_name
-                }
-            }
+        20 = validator:STANDARD
+        20.custom {
+          message = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:message_invalidNumberOfSeats
+          userobj {
+            extension = this
+            method = canRegisterSeats
+          }
         }
 
-        account_owner = renderlet:TEXT
-        account_owner {
-            name = account_owner
-            sanitize = false
-            data {
-                defaultvalue.userobj {
-                    extension = this
-                    method = retrieveDataFromSession
-                    params.10 {
-                        name = key
-                        value = account_owner
-                    }
-                }
-            }
+        30 = validator:STANDARD
+        30.custom {
+          message.userobj {
+            extension = this
+            method = getMessageForSeatsNotMatchingRegisteredPersons
+          }
 
-            validators {
-                10 = validator:STANDARD
-                10.custom {
-                    message = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:message_provideBankData
-                    userobj {
-                        extension = this
-                        method = hasBankData
-                    }
-                }
-            }
+          userobj {
+            extension = this
+            method = validateNumberOfRegisteredPersons
+          }
+        }
+      }
 
-            process.userobj {
-                extension = this
-                method = hasBankDataFormField
-                params.10 {
-                    name = elementname
-                    value = account_owner
-                }
-            }
+      process.userobj {
+        extension = this
+        method = hasRegistrationFormField
+        params.10 {
+          name = elementname
+          value = seats
+        }
+      }
+    }
+
+    registered_themselves = renderlet:CHECKSINGLE
+    registered_themselves {
+      name = registered_themselves
+      data.defaultvalue = 1
+      process.userobj {
+        extension = this
+        method = hasRegistrationFormField
+        params.10 {
+          name = elementname
+          value = registered_themselves
+        }
+      }
+    }
+
+    attendees_names = renderlet:HIDDEN
+    attendees_names {
+      name = attendees_names
+      process.userobj {
+        extension = this
+        method = hasRegistrationFormField
+        params.10 {
+          name = elementname
+          value = attendees_names
+        }
+      }
+    }
+
+    structured_attendees_names = renderlet:HIDDEN
+    structured_attendees_names {
+      name = structured_attendees_names
+      validators {
+        10 = validator:STANDARD
+        10.custom {
+          message = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:message_invalidEMailAddress
+          userobj {
+            extension = this
+            method = validateAdditionalPersonsEMailAddresses
+          }
+        }
+      }
+    }
+
+    kids = renderlet:LISTBOX
+    kids {
+      name = kids
+      data.items {
+        blank {
+          caption =
+          value = 0
         }
 
-        company = renderlet:TEXT
-        company {
-            name = company
-            sanitize = false
-            data.defaultvalue.userobj {
-                extension = this
-                method = getFeUserData
-                params.10 {
-                    name = key
-                    value = company
-                }
-            }
-
-            process.userobj {
-                extension = this
-                method = hasRegistrationFormField
-                params.10 {
-                    name = elementname
-                    value = company
-                }
-            }
+        1 {
+          caption = 1
+          value = 1
         }
 
-        gender = renderlet:LISTBOX
-        gender {
-            name = gender
-            data {
-                items {
-                    10 {
-                        caption = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_attendances.gender.I.0
-                        value = 0
-                    }
-
-                    20 {
-                        caption = LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_attendances.gender.I.1
-                        value = 1
-                    }
-                }
-
-                defaultvalue.userobj {
-                    extension = this
-                    method = getFeUserData
-                    params.10 {
-                        name = key
-                        value = gender
-                    }
-                }
-            }
-
-            process.userobj {
-                extension = this
-                method = hasRegistrationFormField
-                params.10 {
-                    name = elementname
-                    value = gender
-                }
-            }
+        2 {
+          caption = 2
+          value = 2
         }
 
-        name = renderlet:TEXT
-        name {
-            name = name
-            sanitize = false
-            data.defaultvalue.userobj {
-                extension = this
-                method = getFeUserData
-                params.10 {
-                    name = key
-                    value = name
-                }
-            }
-
-            process.userobj {
-                extension = this
-                method = hasRegistrationFormField
-                params.10 {
-                    name = elementname
-                    value = name
-                }
-            }
+        3 {
+          caption = 3
+          value = 3
         }
 
-        address = renderlet:TEXTAREA
-        address {
-            name = address
-            sanitize = false
-            data.defaultvalue.userobj {
-                extension = this
-                method = getFeUserData
-                params.10 {
-                    name = key
-                    value = address
-                }
-            }
-
-            process.userobj {
-                extension = this
-                method = hasRegistrationFormField
-                params.10 {
-                    name = elementname
-                    value = address
-                }
-            }
+        4 {
+          caption = 4
+          value = 4
         }
 
-        zip = renderlet:TEXT
-        zip {
-            name = zip
-            sanitize = false
-            data.defaultvalue.userobj {
-                extension = this
-                method = getFeUserData
-                params.10 {
-                    name = key
-                    value = zip
-                }
-            }
-
-            process.userobj {
-                extension = this
-                method = hasRegistrationFormField
-                params.10 {
-                    name = elementname
-                    value = zip
-                }
-            }
+        5 {
+          caption = 5
+          value = 5
         }
+      }
 
-        city = renderlet:TEXT
-        city {
-            name = city
-            sanitize = false
-            data.defaultvalue.userobj {
-                extension = this
-                method = getFeUserData
-                params.10 {
-                    name = key
-                    value = city
-                }
-            }
-
-            process.userobj {
-                extension = this
-                method = hasRegistrationFormField
-                params.10 {
-                    name = elementname
-                    value = city
-                }
-            }
+      validators {
+        10 = validator:PREG
+        10.pattern {
+          value = /^[\d]*$/
+          message = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:message_noKidsNumber
         }
+      }
 
-        country = renderlet:LISTBOX
-        country {
-            name = country
-            data {
-                userobj {
-                    extension = this
-                    method = populateListCountries
-                }
-
-                defaultvalue.userobj {
-                    extension = this
-                    method = getFeUserData
-                    params.10 {
-                        name = key
-                        value = country
-                    }
-                }
-            }
-
-            process.userobj {
-                extension = this
-                method = hasRegistrationFormField
-                params.10 {
-                    name = elementname
-                    value = country
-                }
-            }
+      process.userobj {
+        extension = this
+        method = hasRegistrationFormField
+        params.10 {
+          name = elementname
+          value = kids
         }
+      }
+    }
 
-        telephone = renderlet:TEXT
-        telephone {
-            name = telephone
-            sanitize = false
-            data.defaultvalue.userobj {
-                extension = this
-                method = getFeUserData
-                params.10 {
-                    name = key
-                    value = telephone
-                }
-            }
+    lodgings = renderlet:CHECKBOX
+    lodgings {
+      name = lodgings
+      data.userobj {
+        extension = this
+        method = populateLodgings
+      }
 
-            process.userobj {
-                extension = this
-                method = hasRegistrationFormField
-                params.10 {
-                    name = elementname
-                    value = telephone
-                }
-            }
+      validators {
+        10 = validator:STANDARD
+        10.custom {
+          message = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:message_selectLodging
+          userobj {
+            extension = this
+            method = isLodgingSelected
+          }
         }
+      }
 
-        email = renderlet:TEXT
-        email {
-            name = email
-            sanitize = false
-            data.defaultvalue.userobj {
-                extension = this
-                method = getFeUserData
-                params.10 {
-                    name = key
-                    value = email
-                }
-            }
+      process.userobj {
+        extension = this
+        method = hasLodgings
+      }
+    }
 
-            process.userobj {
-                extension = this
-                method = hasRegistrationFormField
-                params.10 {
-                    name = elementname
-                    value = email
-                }
-            }
+    accommodation = renderlet:TEXTAREA
+    accommodation {
+      name = accommodation
+      sanitize = false
+      process.userobj {
+        extension = this
+        method = hasRegistrationFormField
+        params.10 {
+          name = elementname
+          value = accommodation
         }
+      }
+    }
 
-        seats = renderlet:LISTBOX
-        seats {
-            name = seats
-            data {
-                userobj {
-                    extension = this
-                    method = populateSeats
-                }
+    foods = renderlet:CHECKBOX
+    foods {
+      name = foods
+      data.userobj {
+        extension = this
+        method = populateFoods
+      }
 
-                defaultvalue = 1
-            }
-
-            validators {
-                10 = validator:PREG
-                10.pattern {
-                    value = /^[\d]*$/
-                    message = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:message_noSeatsNumber
-                }
-
-                20 = validator:STANDARD
-                20.custom {
-                    message = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:message_invalidNumberOfSeats
-                    userobj {
-                        extension = this
-                        method = canRegisterSeats
-                    }
-                }
-
-                30 = validator:STANDARD
-                30.custom {
-                    message.userobj {
-                        extension = this
-                        method = getMessageForSeatsNotMatchingRegisteredPersons
-                    }
-                    userobj {
-                        extension = this
-                        method = validateNumberOfRegisteredPersons
-                    }
-                }
-            }
-
-            process.userobj {
-                extension = this
-                method = hasRegistrationFormField
-                params.10 {
-                    name = elementname
-                    value = seats
-                }
-            }
+      validators {
+        10 = validator:STANDARD
+        10.custom {
+          message = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:message_selectFood
+          userobj {
+            extension = this
+            method = isFoodSelected
+          }
         }
+      }
 
-        registered_themselves = renderlet:CHECKSINGLE
-        registered_themselves {
-            name = registered_themselves
-            data.defaultvalue = 1
-            process.userobj {
-                extension = this
-                method = hasRegistrationFormField
-                params.10 {
-                    name = elementname
-                    value = registered_themselves
-                }
-            }
+      process.userobj {
+        extension = this
+        method = hasRegistrationFormField
+        params.10 {
+          name = elementname
+          value = foods
         }
+      }
+    }
 
-        attendees_names = renderlet:HIDDEN
-        attendees_names {
-            name = attendees_names
-            process.userobj {
-                extension = this
-                method = hasRegistrationFormField
-                params.10 {
-                    name = elementname
-                    value = attendees_names
-                }
-            }
+    food = renderlet:TEXTAREA
+    food {
+      name = food
+      sanitize = false
+      process.userobj {
+        extension = this
+        method = hasRegistrationFormField
+        params.10 {
+          name = elementname
+          value = food
         }
+      }
+    }
 
-        structured_attendees_names = renderlet:HIDDEN
-        structured_attendees_names {
-            name = structured_attendees_names
-            validators {
-                10 = validator:STANDARD
-                10.custom {
-                    message = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:message_invalidEMailAddress
-                    userobj {
-                        extension = this
-                        method = validateAdditionalPersonsEMailAddresses
-                    }
-                }
-            }
+    checkboxes = renderlet:CHECKBOX
+    checkboxes {
+      name = checkboxes
+      data.userobj {
+        extension = this
+        method = populateCheckboxes
+      }
+
+      process.userobj {
+        extension = this
+        method = hasCheckboxes
+      }
+    }
+
+    interests = renderlet:TEXTAREA
+    interests {
+      name = interests
+      sanitize = false
+      process.userobj {
+        extension = this
+        method = hasRegistrationFormField
+        params.10 {
+          name = elementname
+          value = interests
         }
+      }
+    }
 
-        kids = renderlet:LISTBOX
-        kids {
-            name = kids
-            data.items {
-                blank {
-                    caption =
-                    value = 0
-                }
-                1 {
-                    caption = 1
-                    value = 1
-                }
-                2 {
-                    caption = 2
-                    value = 2
-                }
-                3 {
-                    caption = 3
-                    value = 3
-                }
-                4 {
-                    caption = 4
-                    value = 4
-                }
-                5 {
-                    caption = 5
-                    value = 5
-                }
-            }
-
-            validators {
-                10 = validator:PREG
-                10.pattern {
-                    value = /^[\d]*$/
-                    message = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:message_noKidsNumber
-                }
-            }
-
-            process.userobj {
-                extension = this
-                method = hasRegistrationFormField
-                params.10 {
-                    name = elementname
-                    value = kids
-                }
-            }
+    expectations = renderlet:TEXTAREA
+    expectations {
+      name = expectations
+      sanitize = false
+      process.userobj {
+        extension = this
+        method = hasRegistrationFormField
+        params.10 {
+          name = elementname
+          value = expectations
         }
+      }
+    }
 
-        lodgings = renderlet:CHECKBOX
-        lodgings {
-            name = lodgings
-            data.userobj {
-                extension = this
-                method = populateLodgings
-            }
-
-            validators {
-                10 = validator:STANDARD
-                10.custom {
-                    message = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:message_selectLodging
-                    userobj {
-                        extension = this
-                        method = isLodgingSelected
-                    }
-                }
-            }
-
-            process.userobj {
-                extension = this
-                method = hasLodgings
-            }
+    background_knowledge = renderlet:TEXTAREA
+    background_knowledge {
+      name = background_knowledge
+      sanitize = false
+      process.userobj {
+        extension = this
+        method = hasRegistrationFormField
+        params.10 {
+          name = elementname
+          value = background_knowledge
         }
+      }
+    }
 
-        accommodation = renderlet:TEXTAREA
-        accommodation {
-            name = accommodation
-            sanitize = false
-            process.userobj {
-                extension = this
-                method = hasRegistrationFormField
-                params.10 {
-                    name = elementname
-                    value = accommodation
-                }
-            }
+    known_from = renderlet:TEXTAREA
+    known_from {
+      name = known_from
+      sanitize = false
+      process.userobj {
+        extension = this
+        method = hasRegistrationFormField
+        params.10 {
+          name = elementname
+          value = known_from
         }
+      }
+    }
 
-        foods = renderlet:CHECKBOX
-        foods {
-            name = foods
-            data.userobj {
-                extension = this
-                method = populateFoods
-            }
-
-            validators {
-                10 = validator:STANDARD
-                10.custom {
-                    message = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:message_selectFood
-                    userobj {
-                        extension = this
-                        method = isFoodSelected
-                    }
-                }
-            }
-
-            process.userobj {
-                extension = this
-                method = hasRegistrationFormField
-                params.10 {
-                    name = elementname
-                    value = foods
-                }
-            }
+    notes = renderlet:TEXTAREA
+    notes {
+      name = notes
+      sanitize = false
+      process.userobj {
+        extension = this
+        method = hasRegistrationFormField
+        params.10 {
+          name = elementname
+          value = notes
         }
+      }
+    }
 
-        food = renderlet:TEXTAREA
-        food {
-            name = food
-            sanitize = false
-            process.userobj {
-                extension = this
-                method = hasRegistrationFormField
-                params.10 {
-                    name = elementname
-                    value = food
-                }
-            }
-        }
+    button_continue = renderlet:SUBMIT
+    button_continue {
+      name = button_continue
+      label = ###LABEL_PROCEED_REGISTRATION###
+    }
 
-        checkboxes = renderlet:CHECKBOX
-        checkboxes {
-            name = checkboxes
-            data.userobj {
-                extension = this
-                method = populateCheckboxes
-            }
-
-            process.userobj {
-                extension = this
-                method = hasCheckboxes
-            }
-        }
-
-        interests = renderlet:TEXTAREA
-        interests {
-            name = interests
-            sanitize = false
-            process.userobj {
-                extension = this
-                method = hasRegistrationFormField
-                params.10 {
-                    name = elementname
-                    value = interests
-                }
-            }
-        }
-
-        expectations = renderlet:TEXTAREA
-        expectations {
-            name = expectations
-            sanitize = false
-            process.userobj {
-                extension = this
-                method = hasRegistrationFormField
-                params.10 {
-                    name = elementname
-                    value = expectations
-                }
-            }
-        }
-
-        background_knowledge = renderlet:TEXTAREA
-        background_knowledge {
-            name = background_knowledge
-            sanitize = false
-            process.userobj {
-                extension = this
-                method = hasRegistrationFormField
-                params.10 {
-                    name = elementname
-                    value = background_knowledge
-                }
-            }
-        }
-
-        known_from = renderlet:TEXTAREA
-        known_from {
-            name = known_from
-            sanitize = false
-            process.userobj {
-                extension = this
-                method = hasRegistrationFormField
-                params.10 {
-                    name = elementname
-                    value = known_from
-                }
-            }
-        }
-
-        notes = renderlet:TEXTAREA
-        notes {
-            name = notes
-            sanitize = false
-            process.userobj {
-                extension = this
-                method = hasRegistrationFormField
-                params.10 {
-                    name = elementname
-                    value = notes
-                }
-            }
-        }
-
-        button_continue = renderlet:SUBMIT
-        button_continue {
-            name = button_continue
-            label = ###LABEL_PROCEED_REGISTRATION###
-        }
-
-        button_submit = renderlet:SUBMIT
-        button_submit {
-            name = button_submit
-            label = ###LABEL_SUBMIT_REGISTRATION###
-            onclick {
-                runat = server
-                submit = full
-                userobj.php (
+    button_submit = renderlet:SUBMIT
+    button_submit {
+      name = button_submit
+      label = ###LABEL_SUBMIT_REGISTRATION###
+      onclick {
+        runat = server
+        submit = full
+        userobj.php (
                     if ($this->_oParent->getFormCreator()->oDataHandler->_allIsValid()) {
                         $this->_oParent->currentPageNumber = 2;
                     }
-                )
-            }
-        }
-
-        next_page = renderlet:PASSTHRU
-        next_page {
-            name = next_page
-            data.value = 1
-        }
+        )
+      }
     }
+
+    next_page = renderlet:PASSTHRU
+    next_page {
+      name = next_page
+      data.value = 1
+    }
+  }
 }

--- a/Configuration/TypoScript/Forms/RegistrationStep2.typoscript
+++ b/Configuration/TypoScript/Forms/RegistrationStep2.typoscript
@@ -1,634 +1,635 @@
 # @deprecated #1545 will be removed in seminars 5.0
 plugin.tx_seminars_pi1.form.registration.step2 {
-    meta {
-        name = Seminar Manager registration form
-        description = This form allows FE users to register for events.
-        form.formid = tx_seminars_pi1_registration_editor
-        debug = false
-        displaylabels = false
-    }
+  meta {
+    name = Seminar Manager registration form
+    description = This form allows FE users to register for events.
+    form.formid = tx_seminars_pi1_registration_editor
+    debug = false
+    displaylabels = false
+  }
 
-    control {
-        datahandler = datahandler:RAW
-        datahandler.parentcallback = processRegistration
+  control {
+    datahandler = datahandler:RAW
+    datahandler.parentcallback = processRegistration
 
-        renderer = renderer:TEMPLATE
-        renderer.template {
-            path.userobj.php (
+    renderer = renderer:TEMPLATE
+    renderer.template {
+      path.userobj.php (
                 return \OliverKlee\Oelib\Configuration\ConfigurationRegistry::get('plugin.tx_seminars_pi1')->getAsString('registrationEditorTemplateFile');
-            )
-            subpart = ###REGISTRATION_EDITOR_STEP_2###
-            errortag = errors
-        }
-
-        actionlets {
-            10 = actionlet:REDIRECT
-            10.url.userobj {
-                extension = this
-                method = getThankYouAfterRegistrationUrl
-            }
-        }
+      )
+      subpart = ###REGISTRATION_EDITOR_STEP_2###
+      errortag = errors
     }
 
-    elements {
-        step_counter = renderlet:LABEL
-        step_counter {
-            name = step_counter
-            data.value.userobj {
-                extension = this
-                method = getStepCounter
-            }
-        }
-
-        terms = renderlet:CHECKSINGLE
-        terms {
-            name = terms
-            label = ###LABEL_TERMS###
-            validators {
-                10 = validator:STANDARD
-                10.custom {
-                    message = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:message_acceptTerms
-                    userobj {
-                        extension = this
-                        method = isTermsChecked
-                    }
-                }
-            }
-
-            process.userobj {
-                extension = this
-                method = hasRegistrationFormField
-                params.10 {
-                    name = elementname
-                    value = terms
-                }
-            }
-        }
-
-        terms_2 = renderlet:CHECKSINGLE
-        terms_2 {
-            name = terms_2
-            label = ###LABEL_TERMS_2###
-            validators {
-                10 = validator:STANDARD
-                10.custom {
-                    message = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:message_acceptTerms2
-                    userobj {
-                        extension = this
-                        method = isTerms2CheckedAndEnabled
-                    }
-                }
-            }
-
-            process.userobj {
-                extension = this
-                method = isTerms2Enabled
-                params.10 {
-                    name = elementname
-                    value = terms_2
-                }
-            }
-        }
-
-        button_back = renderlet:SUBMIT
-        button_back {
-            name = button_back
-            refresh =
-            label = ###LABEL_BACK_REGISTRATION###
-        }
-
-        button_submit = renderlet:SUBMIT
-        button_submit {
-            name = button_submit
-            label = ###LABEL_SUBMIT_REGISTRATION###
-        }
-
-        price = renderlet:HIDDEN
-        price {
-            name = price
-            validators {
-                10 = validator:STANDARD
-                10.custom {
-                    message = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:message_choosePrice
-                    userobj {
-                        extension = this
-                        method = isValidPriceSelected
-                    }
-                }
-            }
-
-            process.userobj {
-                extension = this
-                method = hasRegistrationFormField
-                params.10 {
-                    name = elementname
-                    value = price
-                }
-            }
-        }
-
-        method_of_payment = renderlet:HIDDEN
-        method_of_payment {
-            name = method_of_payment
-            validators {
-                10 = validator:STANDARD
-                10.custom {
-                    message = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:message_chooseMethodOfPayment
-                    userobj {
-                        extension = this
-                        method = isMethodOfPaymentSelected
-                    }
-                }
-            }
-
-            process.userobj {
-                extension = this
-                method = showMethodsOfPayment
-            }
-        }
-
-        account_number = renderlet:HIDDEN
-        account_number {
-            name = account_number
-            validators {
-                10 = validator:STANDARD
-                10.custom {
-                    message = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:message_provideBankData
-                    userobj {
-                        extension = this
-                        method = hasBankData
-                    }
-                }
-            }
-
-            process.userobj {
-                extension = this
-                method = hasBankDataFormField
-                params.10 {
-                    name = elementname
-                    value = account_number
-                }
-            }
-        }
-
-        bank_code = renderlet:HIDDEN
-        bank_code {
-            name = bank_code
-            validators {
-                10 = validator:STANDARD
-                10.custom {
-                    message = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:message_provideBankData
-                    userobj {
-                        extension = this
-                        method = hasBankData
-                    }
-                }
-            }
-
-            process.userobj {
-                extension = this
-                method = hasBankDataFormField
-                params.10 {
-                    name = elementname
-                    value = bank_code
-                }
-            }
-        }
-
-        bank_name = renderlet:HIDDEN
-        bank_name {
-            name = bank_name
-            validators {
-                10 = validator:STANDARD
-                10.custom {
-                    message = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:message_provideBankData
-                    userobj {
-                        extension = this
-                        method = hasBankData
-                    }
-                }
-            }
-
-            process.userobj {
-                extension = this
-                method = hasBankDataFormField
-                params.10 {
-                    name = elementname
-                    value = bank_name
-                }
-            }
-        }
-
-        account_owner = renderlet:HIDDEN
-        account_owner {
-            name = account_owner
-            validators {
-                10 = validator:STANDARD
-                10.custom {
-                    message = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:message_provideBankData
-                    userobj {
-                        extension = this
-                        method = hasBankData
-                    }
-                }
-            }
-
-            process.userobj {
-                extension = this
-                method = hasBankDataFormField
-                params.10 {
-                    name = elementname
-                    value = account_owner
-                }
-            }
-        }
-
-        company = renderlet:HIDDEN
-        company {
-            name = company
-            process.userobj {
-                extension = this
-                method = hasRegistrationFormField
-                params.10 {
-                    name = elementname
-                    value = company
-                }
-            }
-        }
-
-        gender = renderlet:HIDDEN
-        gender {
-            name = gender
-            process.userobj {
-                extension = this
-                method = hasRegistrationFormField
-                params.10 {
-                    name = elementname
-                    value = gender
-                }
-            }
-        }
-
-        name = renderlet:HIDDEN
-        name {
-            name = name
-            process.userobj {
-                extension = this
-                method = hasRegistrationFormField
-                params.10 {
-                    name = elementname
-                    value = name
-                }
-            }
-        }
-
-        address = renderlet:HIDDEN
-        address {
-            name = address
-            process.userobj {
-                extension = this
-                method = hasRegistrationFormField
-                params.10 {
-                    name = elementname
-                    value = address
-                }
-            }
-        }
-
-        zip = renderlet:HIDDEN
-        zip {
-            name = zip
-            process.userobj {
-                extension = this
-                method = hasRegistrationFormField
-                params.10 {
-                    name = elementname
-                    value = zip
-                }
-            }
-        }
-
-        city = renderlet:HIDDEN
-        city {
-            name = city
-            process.userobj {
-                extension = this
-                method = hasRegistrationFormField
-                params.10 {
-                    name = elementname
-                    value = city
-                }
-            }
-        }
-
-        country = renderlet:HIDDEN
-        country {
-            name = country
-            process.userobj {
-                extension = this
-                method = hasRegistrationFormField
-                params.10 {
-                    name = elementname
-                    value = country
-                }
-            }
-        }
-
-        telephone = renderlet:HIDDEN
-        telephone {
-            name = telephone
-            process.userobj {
-                extension = this
-                method = hasRegistrationFormField
-                params.10 {
-                    name = elementname
-                    value = telephone
-                }
-            }
-        }
-
-        email = renderlet:HIDDEN
-        email {
-            name = email
-            process.userobj {
-                extension = this
-                method = hasRegistrationFormField
-                params.10 {
-                    name = elementname
-                    value = email
-                }
-            }
-        }
-
-        seats = renderlet:HIDDEN
-        seats {
-            name = seats
-            validators {
-                10 = validator:STANDARD
-                10.custom {
-                    message = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:message_invalidNumberOfSeats
-                    userobj {
-                        extension = this
-                        method = canRegisterSeats
-                    }
-                }
-
-                20 = validator:PREG
-                20.pattern {
-                    value = /^[\d]*$/
-                    message = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:message_noSeatsNumber
-                }
-
-                30 = validator:STANDARD
-                30.custom {
-                    message.userobj {
-                        extension = this
-                        method = getMessageForSeatsNotMatchingRegisteredPersons
-                    }
-                    userobj {
-                        extension = this
-                        method = validateNumberOfRegisteredPersons
-                    }
-                }
-            }
-
-            process.userobj {
-                extension = this
-                method = hasRegistrationFormField
-                params.10 {
-                    name = elementname
-                    value = seats
-                }
-            }
-        }
-
-        registered_themselves = renderlet:HIDDEN
-        registered_themselves {
-            name = registered_themselves
-            process.userobj {
-                extension = this
-                method = hasRegistrationFormField
-                params.10 {
-                    name = elementname
-                    value = registered_themselves
-                }
-            }
-        }
-
-        attendees_names = renderlet:HIDDEN
-        attendees_names {
-            name = attendees_names
-            process.userobj {
-                extension = this
-                method = hasRegistrationFormField
-                params.10 {
-                    name = elementname
-                    value = attendees_names
-                }
-            }
-        }
-
-        structured_attendees_names = renderlet:HIDDEN
-        structured_attendees_names {
-            name = structured_attendees_names
-            validators {
-                10 = validator:STANDARD
-                10.custom {
-                    message = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:message_invalidEMailAddress
-                    userobj {
-                        extension = this
-                        method = validateAdditionalPersonsEMailAddresses
-                    }
-                }
-            }
-        }
-
-        kids = renderlet:HIDDEN
-        kids {
-            name = kids
-            validators {
-                10 = validator:PREG
-                10.pattern {
-                    value = /^[\d]*$/
-                    message = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:message_noKidsNumber
-                }
-            }
-
-            process.userobj {
-                extension = this
-                method = hasRegistrationFormField
-                params.10 {
-                    name = elementname
-                    value = kids
-                }
-            }
-        }
-
-        lodgings = renderlet:CHECKBOX
-        lodgings {
-            name = lodgings
-            data.userobj {
-                extension = this
-                method = populateLodgings
-            }
-
-            validators {
-                10 = validator:STANDARD
-                10.custom {
-                    message = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:message_selectLodging
-                    userobj {
-                        extension = this
-                        method = isLodgingSelected
-                    }
-                }
-            }
-
-            process.userobj {
-                extension = this
-                method = hasLodgings
-            }
-        }
-
-        accommodation = renderlet:HIDDEN
-        accommodation {
-            name = accommodation
-            process.userobj {
-                extension = this
-                method = hasRegistrationFormField
-                params.10 {
-                    name = elementname
-                    value = accommodation
-                }
-            }
-        }
-
-        foods = renderlet:CHECKBOX
-        foods {
-            name = foods
-            data.userobj {
-                extension = this
-                method = populateFoods
-            }
-
-            validators {
-                10 = validator:STANDARD
-                10.custom {
-                    message = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:message_selectFood
-                    userobj {
-                        extension = this
-                        method = isFoodSelected
-                    }
-                }
-            }
-
-            process.userobj {
-                extension = this
-                method = hasFoods
-            }
-        }
-
-        food = renderlet:HIDDEN
-        food {
-            name = food
-            process.userobj {
-                extension = this
-                method = hasRegistrationFormField
-                params.10 {
-                    name = elementname
-                    value = food
-                }
-            }
-        }
-
-        checkboxes = renderlet:CHECKBOX
-        checkboxes {
-            name = checkboxes
-            data.userobj {
-                extension = this
-                method = populateCheckboxes
-            }
-
-            process.userobj {
-                extension = this
-                method = hasCheckboxes
-            }
-        }
-
-        interests = renderlet:HIDDEN
-        interests {
-            name = interests
-            process.userobj {
-                extension = this
-                method = hasRegistrationFormField
-                params.10 {
-                    name = elementname
-                    value = interests
-                }
-            }
-        }
-
-        expectations = renderlet:HIDDEN
-        expectations {
-            name = expectations
-            process.userobj {
-                extension = this
-                method = hasRegistrationFormField
-                params.10 {
-                    name = elementname
-                    value = expectations
-                }
-            }
-        }
-
-        background_knowledge = renderlet:HIDDEN
-        background_knowledge {
-            name = background_knowledge
-            process.userobj {
-                extension = this
-                method = hasRegistrationFormField
-                params.10 {
-                    name = elementname
-                    value = background_knowledge
-                }
-            }
-        }
-
-        known_from = renderlet:HIDDEN
-        known_from {
-            name = known_from
-            process.userobj {
-                extension = this
-                method = hasRegistrationFormField
-                params.10 {
-                    name = elementname
-                    value = known_from
-                }
-            }
-        }
-
-        notes = renderlet:HIDDEN
-        notes {
-            name = notes
-            process.userobj {
-                extension = this
-                method = hasRegistrationFormField
-                params.10 {
-                    name = elementname
-                    value = notes
-                }
-            }
-        }
-
-        next_page = renderlet:HIDDEN
-        next_page {
-            name = next_page
-            validators {
-                10 = validator:STANDARD
-                10.custom.userobj {
-                    extension = this
-                    method = isLastPage
-                }
-            }
-        }
+    actionlets {
+      10 = actionlet:REDIRECT
+      10.url.userobj {
+        extension = this
+        method = getThankYouAfterRegistrationUrl
+      }
     }
+  }
+
+  elements {
+    step_counter = renderlet:LABEL
+    step_counter {
+      name = step_counter
+      data.value.userobj {
+        extension = this
+        method = getStepCounter
+      }
+    }
+
+    terms = renderlet:CHECKSINGLE
+    terms {
+      name = terms
+      label = ###LABEL_TERMS###
+      validators {
+        10 = validator:STANDARD
+        10.custom {
+          message = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:message_acceptTerms
+          userobj {
+            extension = this
+            method = isTermsChecked
+          }
+        }
+      }
+
+      process.userobj {
+        extension = this
+        method = hasRegistrationFormField
+        params.10 {
+          name = elementname
+          value = terms
+        }
+      }
+    }
+
+    terms_2 = renderlet:CHECKSINGLE
+    terms_2 {
+      name = terms_2
+      label = ###LABEL_TERMS_2###
+      validators {
+        10 = validator:STANDARD
+        10.custom {
+          message = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:message_acceptTerms2
+          userobj {
+            extension = this
+            method = isTerms2CheckedAndEnabled
+          }
+        }
+      }
+
+      process.userobj {
+        extension = this
+        method = isTerms2Enabled
+        params.10 {
+          name = elementname
+          value = terms_2
+        }
+      }
+    }
+
+    button_back = renderlet:SUBMIT
+    button_back {
+      name = button_back
+      refresh =
+      label = ###LABEL_BACK_REGISTRATION###
+    }
+
+    button_submit = renderlet:SUBMIT
+    button_submit {
+      name = button_submit
+      label = ###LABEL_SUBMIT_REGISTRATION###
+    }
+
+    price = renderlet:HIDDEN
+    price {
+      name = price
+      validators {
+        10 = validator:STANDARD
+        10.custom {
+          message = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:message_choosePrice
+          userobj {
+            extension = this
+            method = isValidPriceSelected
+          }
+        }
+      }
+
+      process.userobj {
+        extension = this
+        method = hasRegistrationFormField
+        params.10 {
+          name = elementname
+          value = price
+        }
+      }
+    }
+
+    method_of_payment = renderlet:HIDDEN
+    method_of_payment {
+      name = method_of_payment
+      validators {
+        10 = validator:STANDARD
+        10.custom {
+          message = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:message_chooseMethodOfPayment
+          userobj {
+            extension = this
+            method = isMethodOfPaymentSelected
+          }
+        }
+      }
+
+      process.userobj {
+        extension = this
+        method = showMethodsOfPayment
+      }
+    }
+
+    account_number = renderlet:HIDDEN
+    account_number {
+      name = account_number
+      validators {
+        10 = validator:STANDARD
+        10.custom {
+          message = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:message_provideBankData
+          userobj {
+            extension = this
+            method = hasBankData
+          }
+        }
+      }
+
+      process.userobj {
+        extension = this
+        method = hasBankDataFormField
+        params.10 {
+          name = elementname
+          value = account_number
+        }
+      }
+    }
+
+    bank_code = renderlet:HIDDEN
+    bank_code {
+      name = bank_code
+      validators {
+        10 = validator:STANDARD
+        10.custom {
+          message = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:message_provideBankData
+          userobj {
+            extension = this
+            method = hasBankData
+          }
+        }
+      }
+
+      process.userobj {
+        extension = this
+        method = hasBankDataFormField
+        params.10 {
+          name = elementname
+          value = bank_code
+        }
+      }
+    }
+
+    bank_name = renderlet:HIDDEN
+    bank_name {
+      name = bank_name
+      validators {
+        10 = validator:STANDARD
+        10.custom {
+          message = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:message_provideBankData
+          userobj {
+            extension = this
+            method = hasBankData
+          }
+        }
+      }
+
+      process.userobj {
+        extension = this
+        method = hasBankDataFormField
+        params.10 {
+          name = elementname
+          value = bank_name
+        }
+      }
+    }
+
+    account_owner = renderlet:HIDDEN
+    account_owner {
+      name = account_owner
+      validators {
+        10 = validator:STANDARD
+        10.custom {
+          message = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:message_provideBankData
+          userobj {
+            extension = this
+            method = hasBankData
+          }
+        }
+      }
+
+      process.userobj {
+        extension = this
+        method = hasBankDataFormField
+        params.10 {
+          name = elementname
+          value = account_owner
+        }
+      }
+    }
+
+    company = renderlet:HIDDEN
+    company {
+      name = company
+      process.userobj {
+        extension = this
+        method = hasRegistrationFormField
+        params.10 {
+          name = elementname
+          value = company
+        }
+      }
+    }
+
+    gender = renderlet:HIDDEN
+    gender {
+      name = gender
+      process.userobj {
+        extension = this
+        method = hasRegistrationFormField
+        params.10 {
+          name = elementname
+          value = gender
+        }
+      }
+    }
+
+    name = renderlet:HIDDEN
+    name {
+      name = name
+      process.userobj {
+        extension = this
+        method = hasRegistrationFormField
+        params.10 {
+          name = elementname
+          value = name
+        }
+      }
+    }
+
+    address = renderlet:HIDDEN
+    address {
+      name = address
+      process.userobj {
+        extension = this
+        method = hasRegistrationFormField
+        params.10 {
+          name = elementname
+          value = address
+        }
+      }
+    }
+
+    zip = renderlet:HIDDEN
+    zip {
+      name = zip
+      process.userobj {
+        extension = this
+        method = hasRegistrationFormField
+        params.10 {
+          name = elementname
+          value = zip
+        }
+      }
+    }
+
+    city = renderlet:HIDDEN
+    city {
+      name = city
+      process.userobj {
+        extension = this
+        method = hasRegistrationFormField
+        params.10 {
+          name = elementname
+          value = city
+        }
+      }
+    }
+
+    country = renderlet:HIDDEN
+    country {
+      name = country
+      process.userobj {
+        extension = this
+        method = hasRegistrationFormField
+        params.10 {
+          name = elementname
+          value = country
+        }
+      }
+    }
+
+    telephone = renderlet:HIDDEN
+    telephone {
+      name = telephone
+      process.userobj {
+        extension = this
+        method = hasRegistrationFormField
+        params.10 {
+          name = elementname
+          value = telephone
+        }
+      }
+    }
+
+    email = renderlet:HIDDEN
+    email {
+      name = email
+      process.userobj {
+        extension = this
+        method = hasRegistrationFormField
+        params.10 {
+          name = elementname
+          value = email
+        }
+      }
+    }
+
+    seats = renderlet:HIDDEN
+    seats {
+      name = seats
+      validators {
+        10 = validator:STANDARD
+        10.custom {
+          message = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:message_invalidNumberOfSeats
+          userobj {
+            extension = this
+            method = canRegisterSeats
+          }
+        }
+
+        20 = validator:PREG
+        20.pattern {
+          value = /^[\d]*$/
+          message = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:message_noSeatsNumber
+        }
+
+        30 = validator:STANDARD
+        30.custom {
+          message.userobj {
+            extension = this
+            method = getMessageForSeatsNotMatchingRegisteredPersons
+          }
+
+          userobj {
+            extension = this
+            method = validateNumberOfRegisteredPersons
+          }
+        }
+      }
+
+      process.userobj {
+        extension = this
+        method = hasRegistrationFormField
+        params.10 {
+          name = elementname
+          value = seats
+        }
+      }
+    }
+
+    registered_themselves = renderlet:HIDDEN
+    registered_themselves {
+      name = registered_themselves
+      process.userobj {
+        extension = this
+        method = hasRegistrationFormField
+        params.10 {
+          name = elementname
+          value = registered_themselves
+        }
+      }
+    }
+
+    attendees_names = renderlet:HIDDEN
+    attendees_names {
+      name = attendees_names
+      process.userobj {
+        extension = this
+        method = hasRegistrationFormField
+        params.10 {
+          name = elementname
+          value = attendees_names
+        }
+      }
+    }
+
+    structured_attendees_names = renderlet:HIDDEN
+    structured_attendees_names {
+      name = structured_attendees_names
+      validators {
+        10 = validator:STANDARD
+        10.custom {
+          message = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:message_invalidEMailAddress
+          userobj {
+            extension = this
+            method = validateAdditionalPersonsEMailAddresses
+          }
+        }
+      }
+    }
+
+    kids = renderlet:HIDDEN
+    kids {
+      name = kids
+      validators {
+        10 = validator:PREG
+        10.pattern {
+          value = /^[\d]*$/
+          message = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:message_noKidsNumber
+        }
+      }
+
+      process.userobj {
+        extension = this
+        method = hasRegistrationFormField
+        params.10 {
+          name = elementname
+          value = kids
+        }
+      }
+    }
+
+    lodgings = renderlet:CHECKBOX
+    lodgings {
+      name = lodgings
+      data.userobj {
+        extension = this
+        method = populateLodgings
+      }
+
+      validators {
+        10 = validator:STANDARD
+        10.custom {
+          message = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:message_selectLodging
+          userobj {
+            extension = this
+            method = isLodgingSelected
+          }
+        }
+      }
+
+      process.userobj {
+        extension = this
+        method = hasLodgings
+      }
+    }
+
+    accommodation = renderlet:HIDDEN
+    accommodation {
+      name = accommodation
+      process.userobj {
+        extension = this
+        method = hasRegistrationFormField
+        params.10 {
+          name = elementname
+          value = accommodation
+        }
+      }
+    }
+
+    foods = renderlet:CHECKBOX
+    foods {
+      name = foods
+      data.userobj {
+        extension = this
+        method = populateFoods
+      }
+
+      validators {
+        10 = validator:STANDARD
+        10.custom {
+          message = LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:message_selectFood
+          userobj {
+            extension = this
+            method = isFoodSelected
+          }
+        }
+      }
+
+      process.userobj {
+        extension = this
+        method = hasFoods
+      }
+    }
+
+    food = renderlet:HIDDEN
+    food {
+      name = food
+      process.userobj {
+        extension = this
+        method = hasRegistrationFormField
+        params.10 {
+          name = elementname
+          value = food
+        }
+      }
+    }
+
+    checkboxes = renderlet:CHECKBOX
+    checkboxes {
+      name = checkboxes
+      data.userobj {
+        extension = this
+        method = populateCheckboxes
+      }
+
+      process.userobj {
+        extension = this
+        method = hasCheckboxes
+      }
+    }
+
+    interests = renderlet:HIDDEN
+    interests {
+      name = interests
+      process.userobj {
+        extension = this
+        method = hasRegistrationFormField
+        params.10 {
+          name = elementname
+          value = interests
+        }
+      }
+    }
+
+    expectations = renderlet:HIDDEN
+    expectations {
+      name = expectations
+      process.userobj {
+        extension = this
+        method = hasRegistrationFormField
+        params.10 {
+          name = elementname
+          value = expectations
+        }
+      }
+    }
+
+    background_knowledge = renderlet:HIDDEN
+    background_knowledge {
+      name = background_knowledge
+      process.userobj {
+        extension = this
+        method = hasRegistrationFormField
+        params.10 {
+          name = elementname
+          value = background_knowledge
+        }
+      }
+    }
+
+    known_from = renderlet:HIDDEN
+    known_from {
+      name = known_from
+      process.userobj {
+        extension = this
+        method = hasRegistrationFormField
+        params.10 {
+          name = elementname
+          value = known_from
+        }
+      }
+    }
+
+    notes = renderlet:HIDDEN
+    notes {
+      name = notes
+      process.userobj {
+        extension = this
+        method = hasRegistrationFormField
+        params.10 {
+          name = elementname
+          value = notes
+        }
+      }
+    }
+
+    next_page = renderlet:HIDDEN
+    next_page {
+      name = next_page
+      validators {
+        10 = validator:STANDARD
+        10.custom.userobj {
+          extension = this
+          method = isLastPage
+        }
+      }
+    }
+  }
 }

--- a/Configuration/TypoScript/Forms/Unregistration.typoscript
+++ b/Configuration/TypoScript/Forms/Unregistration.typoscript
@@ -1,46 +1,46 @@
 # @deprecated #1841 will be removed in seminars 5.0
 plugin.tx_seminars_pi1.form.unregistration {
-    meta {
-        name = Seminar Manager unregistration form
-        description = This form allows FE users to unregister for events.
-        form.formid = tx_seminars_pi1_registration_editor
-        debug = false
-        displaylabels = false
-    }
+  meta {
+    name = Seminar Manager unregistration form
+    description = This form allows FE users to unregister for events.
+    form.formid = tx_seminars_pi1_registration_editor
+    debug = false
+    displaylabels = false
+  }
 
-    control {
-        datahandler = datahandler:RAW
-        datahandler.parentcallback = processUnregistration
+  control {
+    datahandler = datahandler:RAW
+    datahandler.parentcallback = processUnregistration
 
-        renderer = renderer:TEMPLATE
-        renderer.template {
-            path.userobj.php (
+    renderer = renderer:TEMPLATE
+    renderer.template {
+      path.userobj.php (
                     return \OliverKlee\Oelib\Configuration\ConfigurationRegistry::get('plugin.tx_seminars_pi1')->getAsString('registrationEditorTemplateFile');
-            )
-            subpart = ###REGISTRATION_EDITOR_UNREGISTRATION###
-            errortag = errors
-        }
-
-        actionlets {
-            10 = actionlet:REDIRECT
-            10.url.userobj {
-                extension = this
-                method = getPageToShowAfterUnregistrationUrl
-            }
-        }
+      )
+      subpart = ###REGISTRATION_EDITOR_UNREGISTRATION###
+      errortag = errors
     }
 
-    elements {
-        button_cancel = renderlet:SUBMIT
-        button_cancel {
-            name = button_cancel
-            label = ###LABEL_CANCEL###
-        }
-
-        button_unregister = renderlet:SUBMIT
-        button_unregister {
-            name = button_unregister
-            label = ###LABEL_UNREGISTER###
-        }
+    actionlets {
+      10 = actionlet:REDIRECT
+      10.url.userobj {
+        extension = this
+        method = getPageToShowAfterUnregistrationUrl
+      }
     }
+  }
+
+  elements {
+    button_cancel = renderlet:SUBMIT
+    button_cancel {
+      name = button_cancel
+      label = ###LABEL_CANCEL###
+    }
+
+    button_unregister = renderlet:SUBMIT
+    button_unregister {
+      name = button_unregister
+      label = ###LABEL_UNREGISTER###
+    }
+  }
 }

--- a/Configuration/TypoScript/FrontEnd.typoscript
+++ b/Configuration/TypoScript/FrontEnd.typoscript
@@ -1,280 +1,280 @@
 plugin.tx_seminars_pi1 {
-    # Do not copy this variable into your TS setup! This is needed for checking whether this static template has been included correctly.
-    isStaticTemplateLoaded = 1
+  # Do not copy this variable into your TS setup! This is needed for checking whether this static template has been included correctly.
+  isStaticTemplateLoaded = 1
 
-    # Set this to 0 if you don't use the registration feature for this site and would like to disable the configuration check for this.
-    enableRegistration = 1
+  # Set this to 0 if you don't use the registration feature for this site and would like to disable the configuration check for this.
+  enableRegistration = 1
 
-    # number of clicks to registration (valid options are 2 or 3)
-    numberOfClicksForRegistration = 3
+  # number of clicks to registration (valid options are 2 or 3)
+  numberOfClicksForRegistration = 3
 
-    # location of the HTML template file
-    templateFile = EXT:seminars/Resources/Private/Templates/FrontEnd/FrontEnd.html
+  # location of the HTML template file
+  templateFile = EXT:seminars/Resources/Private/Templates/FrontEnd/FrontEnd.html
 
-    # activate Javascript framework from global config
-    loadJsFramework =< config.loadJsFramework
+  # activate Javascript framework from global config
+  loadJsFramework =< config.loadJsFramework
 
-    # location of the front-end event editor template file
-    eventEditorTemplateFile = EXT:seminars/Resources/Private/Templates/FrontEnd/EventEditor.html
+  # location of the front-end event editor template file
+  eventEditorTemplateFile = EXT:seminars/Resources/Private/Templates/FrontEnd/EventEditor.html
 
-    # location of the template file for the registration form
-    registrationEditorTemplateFile = EXT:seminars/Resources/Private/Templates/FrontEnd/RegistrationEditor.html
+  # location of the template file for the registration form
+  registrationEditorTemplateFile = EXT:seminars/Resources/Private/Templates/FrontEnd/RegistrationEditor.html
 
-    # the strftime format code for the full date
-    dateFormatYMD < plugin.tx_seminars.dateFormatYMD
+  # the strftime format code for the full date
+  dateFormatYMD < plugin.tx_seminars.dateFormatYMD
 
-    # whether to use formal or informal language
-    salutation = formal
+  # whether to use formal or informal language
+  salutation = formal
 
-    # the PID of a fixed event that should be shown in a detailed view
-    showSingleEvent =
+  # the PID of a fixed event that should be shown in a detailed view
+  showSingleEvent =
 
-    # the time-frame from which events should be displayed in the list view
-    timeframeInList = currentAndUpcoming
+  # the time-frame from which events should be displayed in the list view
+  timeframeInList = currentAndUpcoming
 
-    # comma-separated list of column names that shouldn't be displayed in the list view, e.g. organizers,price_special
-    hideColumns = image,category,subtitle,event_type,accreditation_number,credit_points,teaser,time,expiry,place,city,country,price_special,speakers,language,target_groups,attached_files,status
+  # comma-separated list of column names that shouldn't be displayed in the list view, e.g. organizers,price_special
+  hideColumns = image,category,subtitle,event_type,accreditation_number,credit_points,teaser,time,expiry,place,city,country,price_special,speakers,language,target_groups,attached_files,status
 
-    # comma-separated list of field names that shouldn't be displayed in the detail view, e.g. organizers,price_special
-    hideFields = credit_points,eventsnextday
+  # comma-separated list of field names that shouldn't be displayed in the detail view, e.g. organizers,price_special
+  hideFields = credit_points,eventsnextday
 
-    # whether the option boxes in the selector widget contain an empty entry like "not selected"
-    showEmptyEntryInOptionLists = 0
+  # whether the option boxes in the selector widget contain an empty entry like "not selected"
+  showEmptyEntryInOptionLists = 0
 
-    # comma-separated list of search options which should be shown in the search widget.
-    displaySearchFormFields =
+  # comma-separated list of search options which should be shown in the search widget.
+  displaySearchFormFields =
 
-    # how many years are displayed in the date filter
-    numberOfYearsInDateFilter = 2
+  # how many years are displayed in the date filter
+  numberOfYearsInDateFilter = 2
 
-    # whether the page browser should be hidden in list view
-    hidePageBrowser = 0
+  # whether the page browser should be hidden in list view
+  hidePageBrowser = 0
 
-    # whether canceled events should be hidden or not
-    hideCanceledEvents = 0
+  # whether canceled events should be hidden or not
+  hideCanceledEvents = 0
 
-    # comma-separated list of event types UIDs to filter the list view for,
-    # leave empty to have no such filter
-    limitListViewToEventTypes =
+  # comma-separated list of event types UIDs to filter the list view for,
+  # leave empty to have no such filter
+  limitListViewToEventTypes =
 
-    # comma-separated list of category UIDs to filter the list view for, leave
-    # empty to have no such filter
-    limitListViewToCategories =
+  # comma-separated list of category UIDs to filter the list view for, leave
+  # empty to have no such filter
+  limitListViewToCategories =
 
-    # comma-separated list of place UIDs to filter the list view for, leave
-    # empty to have no such filter
-    limitListViewToPlaces =
+  # comma-separated list of place UIDs to filter the list view for, leave
+  # empty to have no such filter
+  limitListViewToPlaces =
 
-    # comma-separated list of organizer UIDs to filter the list view for, leave
-    # empty to have no such filter
-    limitListViewToOrganizers =
+  # comma-separated list of organizer UIDs to filter the list view for, leave
+  # empty to have no such filter
+  limitListViewToOrganizers =
 
-    # whether to show only events with vacancies on in the list view
-    showOnlyEventsWithVacancies = 0
+  # whether to show only events with vacancies on in the list view
+  showOnlyEventsWithVacancies = 0
 
-    # the maximum height of the image of a seminar in the list view
-    seminarImageListViewHeight = 43
+  # the maximum height of the image of a seminar in the list view
+  seminarImageListViewHeight = 43
 
-    # the maximum width of the image of a seminar in the list view
-    seminarImageListViewWidth = 70
+  # the maximum width of the image of a seminar in the list view
+  seminarImageListViewWidth = 70
 
-    # whether the list view should always be sorted by category (before applying
-    # the normal sorting)
-    sortListViewByCategory = 0
+  # whether the list view should always be sorted by category (before applying
+  # the normal sorting)
+  sortListViewByCategory = 0
 
-    # how to display the categories in the event list view: icon, text, both
-    categoriesInListView = both
+  # how to display the categories in the event list view: icon, text, both
+  categoriesInListView = both
 
-    # whether to use the label "Price" as column header for the standard price (instead of "Standard price")
-    generalPriceInList = 0
+  # whether to use the label "Price" as column header for the standard price (instead of "Standard price")
+  generalPriceInList = 0
 
-    # whether to use the label "Price" as heading for the standard price (instead of "Standard price") in the detailed view and on the registration page
-    generalPriceInSingle = 0
+  # whether to use the label "Price" as heading for the standard price (instead of "Standard price") in the detailed view and on the registration page
+  generalPriceInSingle = 0
 
-    # whether to omit the date in the list view if it is the same as the previous item's
-    omitDateIfSameAsPrevious = 0
+  # whether to omit the date in the list view if it is the same as the previous item's
+  omitDateIfSameAsPrevious = 0
 
-    # whether to show the owner data in the single view, @deprecated #1811 will be removed in seminars 5.0
-    showOwnerDataInSingleView = 0
+  # whether to show the owner data in the single view, @deprecated #1811 will be removed in seminars 5.0
+  showOwnerDataInSingleView = 0
 
-    # the maximum width of the owner picture in the single view, @deprecated #1811 will be removed in seminars 5.0
-    ownerPictureMaxWidth = 250
+  # the maximum width of the owner picture in the single view, @deprecated #1811 will be removed in seminars 5.0
+  ownerPictureMaxWidth = 250
 
-    # who is allowed to view the list of registrations on the front end:
-    # "attendees_and_managers", "login" or "world"
-    accessToFrontEndRegistrationLists = attendees_and_managers
+  # who is allowed to view the list of registrations on the front end:
+  # "attendees_and_managers", "login" or "world"
+  accessToFrontEndRegistrationLists = attendees_and_managers
 
-    # whether to allow the CSV export in the "my VIP events" view
-    allowCsvExportOfRegistrationsInMyVipEventsView = 0
+  # whether to allow the CSV export in the "my VIP events" view
+  allowCsvExportOfRegistrationsInMyVipEventsView = 0
 
-    # whether managers may edit their events, @deprecated #1633 will be removed in seminars 5.0
-    mayManagersEditTheirEvents = 0
+  # whether managers may edit their events, @deprecated #1633 will be removed in seminars 5.0
+  mayManagersEditTheirEvents = 0
 
-    # list of comma-separated names of event fields that should be displayed on the registration page (the order doesn't matter)
-    eventFieldsOnRegistrationPage = title,price_regular,price_special,vacancies
+  # list of comma-separated names of event fields that should be displayed on the registration page (the order doesn't matter)
+  eventFieldsOnRegistrationPage = title,price_regular,price_special,vacancies
 
-    # list of tx_seminars_attendances DB fields to show for the online registration (must not be empty)
-    showRegistrationFields = step_counter,price,method_of_payment,lodgings,foods,checkboxes,interests,expectations,background_knowledge,known_from,notes,total_price,feuser_data,billing_address,registration_data,terms_2
+  # list of tx_seminars_attendances DB fields to show for the online registration (must not be empty)
+  showRegistrationFields = step_counter,price,method_of_payment,lodgings,foods,checkboxes,interests,expectations,background_knowledge,known_from,notes,total_price,feuser_data,billing_address,registration_data,terms_2
 
-    # whether the logged-in user should be registered themselves by default in the registration form (only applicable if the checkbox is hidden)
-    registerThemselvesByDefaultForHiddenCheckbox = 1
+  # whether the logged-in user should be registered themselves by default in the registration form (only applicable if the checkbox is hidden)
+  registerThemselvesByDefaultForHiddenCheckbox = 1
 
-    # fe_users DB fields to show for in the registration form
-    showFeUserFieldsInRegistrationForm = name,company,address,zip,city,country,telephone,email
+  # fe_users DB fields to show for in the registration form
+  showFeUserFieldsInRegistrationForm = name,company,address,zip,city,country,telephone,email
 
-    # fe_users DB fields on the registration form that should be displayed with a label
-    showFeUserFieldsInRegistrationFormWithLabel = telephone,email
+  # fe_users DB fields on the registration form that should be displayed with a label
+  showFeUserFieldsInRegistrationFormWithLabel = telephone,email
 
-    # the displayed number of the first registration page (for "step x of y")
-    numberOfFirstRegistrationPage = 1
+  # the displayed number of the first registration page (for "step x of y")
+  numberOfFirstRegistrationPage = 1
 
-    # the displayed number of the last registration page (for "step x of y")
-    numberOfLastRegistrationPage = 2
+  # the displayed number of the last registration page (for "step x of y")
+  numberOfLastRegistrationPage = 2
 
-    # the maximum number of seats that can be booked in one registration
-    maximumBookableSeats = 10
+  # the maximum number of seats that can be booked in one registration
+  maximumBookableSeats = 10
 
-    # whether detailed information for the speakers is shown in the single view
-    showSpeakerDetails = 1
+  # whether detailed information for the speakers is shown in the single view
+  showSpeakerDetails = 1
 
-    # whether detailed information for the locations is shown in the single view
-    showSiteDetails = 1
+  # whether detailed information for the locations is shown in the single view
+  showSiteDetails = 1
 
-    # whether file downloads are limited to attendees only
-    limitFileDownloadToAttendees = 1
+  # whether file downloads are limited to attendees only
+  limitFileDownloadToAttendees = 1
 
-    # comma-separated list of FEuser fields to show in the list of registrations for an event
-    showFeUserFieldsInRegistrationsList = name
+  # comma-separated list of FEuser fields to show in the list of registrations for an event
+  showFeUserFieldsInRegistrationsList = name
 
-    # comma-separated list of registration fields to show in the list of registrations for an event
-    showRegistrationFieldsInRegistrationList =
+  # comma-separated list of registration fields to show in the list of registrations for an event
+  showRegistrationFieldsInRegistrationList =
 
-    # whether one-time FE users will be automatically logged out after registering for an event
-    logOutOneTimeAccountsAfterRegistration = 1
+  # whether one-time FE users will be automatically logged out after registering for an event
+  logOutOneTimeAccountsAfterRegistration = 1
 
-    # whether to add sorting links to the headers in the list view
-    enableSortingLinksInListView = 1
+  # whether to add sorting links to the headers in the list view
+  enableSortingLinksInListView = 1
 
-    # when to link to the single view: always, never, onlyForNonEmptyDescription
-    linkToSingleView = always
+  # when to link to the single view: always, never, onlyForNonEmptyDescription
+  linkToSingleView = always
 
-    # whether to send an additional notification e-mail from the FE editor to the reviewers when a new record has been created
-    # @deprecated #1543 will be removed in seminars 5.0
-    sendAdditionalNotificationEmailInFrontEndEditor = 0
+  # whether to send an additional notification e-mail from the FE editor to the reviewers when a new record has been created
+  # @deprecated #1543 will be removed in seminars 5.0
+  sendAdditionalNotificationEmailInFrontEndEditor = 0
 
-    # the width of the speaker image in the single view
-    speakerImageWidth = 150
+  # the width of the speaker image in the single view
+  speakerImageWidth = 150
 
-    # the height of the speaker image in the single view
-    speakerImageHeight = 150
+  # the height of the speaker image in the single view
+  speakerImageHeight = 150
 
-    # The following variables don't have any default values provided.
-    # You need to set them yourself for this extension to work correctly.
+  # The following variables don't have any default values provided.
+  # You need to set them yourself for this extension to work correctly.
 
-    # PID of the folder that contains all the event records (e.g., the starting point)
-    pages =
+  # PID of the folder that contains all the event records (e.g., the starting point)
+  pages =
 
-    # number of levels to recurse when accessing the starting point
-    recursive =
+  # number of levels to recurse when accessing the starting point
+  recursive =
 
-    # PID of the FE page that contains the event list
-    listPID =
+  # PID of the FE page that contains the event list
+  listPID =
 
-    # PID of the FE page that contains the single view
-    detailPID =
+  # PID of the FE page that contains the single view
+  detailPID =
 
-    # PID of the FE page that contains the "my events" list
-    myEventsPID =
+  # PID of the FE page that contains the "my events" list
+  myEventsPID =
 
-    # PID of the FE page that contains the seminar registration plug-in
-    registerPID =
+  # PID of the FE page that contains the seminar registration plug-in
+  registerPID =
 
-    # PID of the thank-you page that will be displayed after a FE user has registered for an event
-    thankYouAfterRegistrationPID =
+  # PID of the thank-you page that will be displayed after a FE user has registered for an event
+  thankYouAfterRegistrationPID =
 
-    # whether to send GET parameters to the thank-you-after-registration-page-URL
-    sendParametersToThankYouAfterRegistrationPageUrl = 1
+  # whether to send GET parameters to the thank-you-after-registration-page-URL
+  sendParametersToThankYouAfterRegistrationPageUrl = 1
 
-    # PID of the page that will be displayed after a FE user has unregistered from an event
-    pageToShowAfterUnregistrationPID =
+  # PID of the page that will be displayed after a FE user has unregistered from an event
+  pageToShowAfterUnregistrationPID =
 
-    # Whether to send GET parameters to the thank-you-after-registration-page-URL.
-    sendParametersToPageToShowAfterUnregistrationUrl = 1
+  # Whether to send GET parameters to the thank-you-after-registration-page-URL.
+  sendParametersToPageToShowAfterUnregistrationUrl = 1
 
-    # whether to create FE user records for additional attendees (in addition
-    # to storing them in a text field)
-    createAdditionalAttendeesAsFrontEndUsers = 0
+  # whether to create FE user records for additional attendees (in addition
+  # to storing them in a text field)
+  createAdditionalAttendeesAsFrontEndUsers = 0
 
-    # UID of the sys folder in which FE users created as additional attendees in
-    # the registration form get stored
-    sysFolderForAdditionalAttendeeUsersPID =
+  # UID of the sys folder in which FE users created as additional attendees in
+  # the registration form get stored
+  sysFolderForAdditionalAttendeeUsersPID =
 
-    # comma-separated list of front-end user group UIDs to which the FE users
-    # created in the registration form will be assigned
-    userGroupUidsForAdditionalAttendeesFrontEndUsers =
+  # comma-separated list of front-end user group UIDs to which the FE users
+  # created in the registration form will be assigned
+  userGroupUidsForAdditionalAttendeesFrontEndUsers =
 
-    # PID of the FE page that contains the login form or onetimeaccount
-    loginPID =
+  # PID of the FE page that contains the login form or onetimeaccount
+  loginPID =
 
-    # PID of the page that contains the registrations list for participants
-    registrationsListPID =
+  # PID of the page that contains the registrations list for participants
+  registrationsListPID =
 
-    # PID of the page that contains the registrations list for event managers
-    registrationsVipListPID =
+  # PID of the page that contains the registrations list for event managers
+  registrationsVipListPID =
 
-    # UID of the FE user group that is allowed to enter and edit event records in the FE
-    eventEditorFeGroupID =
+  # UID of the FE user group that is allowed to enter and edit event records in the FE
+  eventEditorFeGroupID =
 
-    # UID of the FE user group for event managers
-    defaultEventVipsFeGroupID =
+  # UID of the FE user group for event managers
+  defaultEventVipsFeGroupID =
 
-    # PID of the page where the plug-in for editing events is located
-    eventEditorPID =
+  # PID of the page where the plug-in for editing events is located
+  eventEditorPID =
 
-    # PID of the folder where FE-created events will be stored
-    createEventsPID =
+  # PID of the folder where FE-created events will be stored
+  createEventsPID =
 
-    # PID of the folder where FE-created auxiliary records will be stored
-    createAuxiliaryRecordsPID =
+  # PID of the folder where FE-created auxiliary records will be stored
+  createAuxiliaryRecordsPID =
 
-    # PID of the page that will be shown when an event has been successfully entered on the FE
-    eventSuccessfullySavedPID =
+  # PID of the page that will be shown when an event has been successfully entered on the FE
+  eventSuccessfullySavedPID =
 
-    # comma-separated list of the fields to show in the FE-editor
-    displayFrontEndEditorFields = subtitle,accreditation_number,credit_points,categories,event_type,cancelled,teaser,description,additional_information,begin_date,end_date,begin_date_registration,deadline_early_bird,deadline_registration,needs_registration,allows_multiple_registrations,queue_size,offline_attendees,attendees_min,attendees_max,target_groups,price_regular,price_regular_early,price_regular_board,price_special,price_special_early,price_special_board,payment_methods,place,room,lodgings,foods,speakers,leaders,partners,tutors,checkboxes,uses_terms_2,notes
+  # comma-separated list of the fields to show in the FE-editor
+  displayFrontEndEditorFields = subtitle,accreditation_number,credit_points,categories,event_type,cancelled,teaser,description,additional_information,begin_date,end_date,begin_date_registration,deadline_early_bird,deadline_registration,needs_registration,allows_multiple_registrations,queue_size,offline_attendees,attendees_min,attendees_max,target_groups,price_regular,price_regular_early,price_regular_board,price_special,price_special_early,price_special_board,payment_methods,place,room,lodgings,foods,speakers,leaders,partners,tutors,checkboxes,uses_terms_2,notes
 
-    # comma-separated list of the event fields which are required to be filled in the FE editor
-    requiredFrontEndEditorFields =
+  # comma-separated list of the event fields which are required to be filled in the FE editor
+  requiredFrontEndEditorFields =
 
-    # comma-separated list of the place fields which are required to be filled in the FE editor
-    requiredFrontEndEditorPlaceFields = city
+  # comma-separated list of the place fields which are required to be filled in the FE editor
+  requiredFrontEndEditorPlaceFields = city
 
-    # UID of the payment method that corresponds to "bank transfer", @deprecated #1571 will be removed in seminars 5.0
-    bankTransferUID =
+  # UID of the payment method that corresponds to "bank transfer", @deprecated #1571 will be removed in seminars 5.0
+  bankTransferUID =
 
-    # The target for external links in seminars.
-    externalLinkTarget =
+  # The target for external links in seminars.
+  externalLinkTarget =
 
-    # the maximum width of the image of a seminar in the single view
-    seminarImageSingleViewWidth = 260
+  # the maximum width of the image of a seminar in the single view
+  seminarImageSingleViewWidth = 260
 
-    # the maximum height of the image of a seminar in the single view
-    seminarImageSingleViewHeight = 160
+  # the maximum height of the image of a seminar in the single view
+  seminarImageSingleViewHeight = 160
 
-    # whether to allow front-end editing of speakers
-    allowFrontEndEditingOfSpeakers = 0
+  # whether to allow front-end editing of speakers
+  allowFrontEndEditingOfSpeakers = 0
 
-    # whether to allow front-end editing of places
-    allowFrontEndEditingOfPlaces = 0
+  # whether to allow front-end editing of places
+  allowFrontEndEditingOfPlaces = 0
 
-    # whether to allow front-end editing of checkboxes
-    allowFrontEndEditingOfCheckboxes = 0
+  # whether to allow front-end editing of checkboxes
+  allowFrontEndEditingOfCheckboxes = 0
 
-    # whether to allow front-end editing of target groups
-    allowFrontEndEditingOfTargetGroups = 0
+  # whether to allow front-end editing of target groups
+  allowFrontEndEditingOfTargetGroups = 0
 
-    # location of language file for substitution of LABEL markers
-    locallangFilename = EXT:seminars/Resources/Private/Language/locallang.xlf
+  # location of language file for substitution of LABEL markers
+  locallangFilename = EXT:seminars/Resources/Private/Language/locallang.xlf
 
-    form =< config.tx_mkforms
+  form =< config.tx_mkforms
 }

--- a/Configuration/TypoScript/ListView.typoscript
+++ b/Configuration/TypoScript/ListView.typoscript
@@ -1,13 +1,13 @@
 plugin.tx_seminars_pi1.listView {
-    # the default sort order in list view (a sort field name)
-    orderBy = date
+  # the default sort order in list view (a sort field name)
+  orderBy = date
 
-    # whether to order ascending (0) or descending (1)
-    descFlag = 0
+  # whether to order ascending (0) or descending (1)
+  descFlag = 0
 
-    # how many results to display per page
-    results_at_a_time = 20
+  # how many results to display per page
+  results_at_a_time = 20
 
-    # the number of neighboring pages to list in the page browser
-    maxPages = 5
+  # the number of neighboring pages to list in the page browser
+  maxPages = 5
 }

--- a/Configuration/TypoScript/Page.typoscript
+++ b/Configuration/TypoScript/Page.typoscript
@@ -1,13 +1,13 @@
 page {
-    includeCSS {
-        tx_seminars_pi1 = {$plugin.tx_seminars_pi1.cssFile}
-    }
+  includeCSS {
+    tx_seminars_pi1 = {$plugin.tx_seminars_pi1.cssFile}
+  }
 
-    includeJSFooter {
-        seminarsFrontEnd = EXT:seminars/Resources/Public/JavaScript/FrontEnd/FrontEnd.js
-        seminarsFrontEnd {
-            async = 1
-            defer = 1
-        }
+  includeJSFooter {
+    seminarsFrontEnd = EXT:seminars/Resources/Public/JavaScript/FrontEnd/FrontEnd.js
+    seminarsFrontEnd {
+      async = 1
+      defer = 1
     }
+  }
 }

--- a/Configuration/TypoScript/PluginSettings.typoscript
+++ b/Configuration/TypoScript/PluginSettings.typoscript
@@ -1,3 +1,3 @@
 plugin.tx_seminars.settings {
-    salutation = {$plugin.tx_seminars.settings.salutation}
+  salutation = {$plugin.tx_seminars.settings.salutation}
 }

--- a/Configuration/TypoScript/PluginShared.typoscript
+++ b/Configuration/TypoScript/PluginShared.typoscript
@@ -1,155 +1,155 @@
 # Non-frontend specific configuration, e.g., for emails, the CSV export or the BE.
 plugin.tx_seminars {
-    # Do not copy this variable into your TS setup! This is needed for checking whether this static template has been included correctly.
-    isStaticTemplateLoaded = 1
+  # Do not copy this variable into your TS setup! This is needed for checking whether this static template has been included correctly.
+  isStaticTemplateLoaded = 1
 
-    # Set this to 0 if you don't use the registration feature for this site and would like to disable the configuration check for this.
-    enableRegistration = 1
+  # Set this to 0 if you don't use the registration feature for this site and would like to disable the configuration check for this.
+  enableRegistration = 1
 
-    # whether the registration collision check should be skipped for all events, @deprecated #1763 will be removed in seminars 5.0
-    skipRegistrationCollisionCheck = 0
+  # whether the registration collision check should be skipped for all events, @deprecated #1763 will be removed in seminars 5.0
+  skipRegistrationCollisionCheck = 0
 
-    # location of the template file
-    templateFile = EXT:seminars/Resources/Private/Templates/Mail/e-mail.html
+  # location of the template file
+  templateFile = EXT:seminars/Resources/Private/Templates/Mail/e-mail.html
 
-    # whether to use formal or informal language
-    salutation = formal
+  # whether to use formal or informal language
+  salutation = formal
 
-    # comma-separated list of section names that shouldn't be displayed in the thank-you e-mail to the user
-    hideFieldsInThankYouMail = credit_points,billing_address,kids,planned_disclaimer
+  # comma-separated list of section names that shouldn't be displayed in the thank-you e-mail to the user
+  hideFieldsInThankYouMail = credit_points,billing_address,kids,planned_disclaimer
 
-    # the CSS file for the HTML e-mail to the attendees
-    cssFileForAttendeeMail = EXT:seminars/Resources/Private/CSS/thankYouMail.css
+  # the CSS file for the HTML e-mail to the attendees
+  cssFileForAttendeeMail = EXT:seminars/Resources/Private/CSS/thankYouMail.css
 
-    # whether to use the label "Price" for the standard price (instead of "standard price") in e-mail to the participant
-    generalPriceInMail = 0
+  # whether to use the label "Price" for the standard price (instead of "standard price") in e-mail to the participant
+  generalPriceInMail = 0
 
-    # Comma-separated list of section names from the registration that shouldn't be displayed in the notification e-mail to the organizers. These fields are the big blocks in that e-mail, and some are further divided.
-    hideFieldsInNotificationMail =
+  # Comma-separated list of section names from the registration that shouldn't be displayed in the notification e-mail to the organizers. These fields are the big blocks in that e-mail, and some are further divided.
+  hideFieldsInNotificationMail =
 
-    # comma-separated list of field names from seminars that should be mentioned in the notification e-mail to the organizers (in the "seminardata" section)
-    showSeminarFieldsInNotificationMail = title,uid,event_type,date,place,price_regular,price_regular_early,price_special,price_special_early,attendees,vacancies,enough_attendees,is_full
+  # comma-separated list of field names from seminars that should be mentioned in the notification e-mail to the organizers (in the "seminardata" section)
+  showSeminarFieldsInNotificationMail = title,uid,event_type,date,place,price_regular,price_regular_early,price_special,price_special_early,attendees,vacancies,enough_attendees,is_full
 
-    # comma-separated list of field names from fe_users that should be mentioned in the notification e-mail to the organizers  (in the "feuserdata" section)
-    showFeUserFieldsInNotificationMail = username,name,email,address,zip,city,telephone
+  # comma-separated list of field names from fe_users that should be mentioned in the notification e-mail to the organizers  (in the "feuserdata" section)
+  showFeUserFieldsInNotificationMail = username,name,email,address,zip,city,telephone
 
-    # comma-separated list of field names from attendances that should be mentioned in the notification e-mail to the organizers  (in the "attendancedata" section)
-    showAttendanceFieldsInNotificationMail = uid,price,seats,total_price,method_of_payment,gender,name,address,zip,city,country,telephone,email,interests,expectations,background_knowledge,known_from,notes
+  # comma-separated list of field names from attendances that should be mentioned in the notification e-mail to the organizers  (in the "attendancedata" section)
+  showAttendanceFieldsInNotificationMail = uid,price,seats,total_price,method_of_payment,gender,name,address,zip,city,country,telephone,email,interests,expectations,background_knowledge,known_from,notes
 
-    # Whether to send the additional notification e-mails to the organizers or not. Additional notification mails are sent if for example an event gets full.
-    sendAdditionalNotificationEmails = 1
+  # Whether to send the additional notification e-mails to the organizers or not. Additional notification mails are sent if for example an event gets full.
+  sendAdditionalNotificationEmails = 1
 
-    # Whether to send a notification to the organizers if a user has registered.
-    sendNotification = 1
+  # Whether to send a notification to the organizers if a user has registered.
+  sendNotification = 1
 
-    # Whether to send a notification to the organizers if a user has unregistered.
-    sendNotificationOnUnregistration = 1
+  # Whether to send a notification to the organizers if a user has unregistered.
+  sendNotificationOnUnregistration = 1
 
-    # Whether to send a notification to the organizers if someone registered for the queue.
-    sendNotificationOnRegistrationForQueue = 1
+  # Whether to send a notification to the organizers if someone registered for the queue.
+  sendNotificationOnRegistrationForQueue = 1
 
-    # Whether to send a notification to the organizers if the queue has been updated.
-    sendNotificationOnQueueUpdate = 1
+  # Whether to send a notification to the organizers if the queue has been updated.
+  sendNotificationOnQueueUpdate = 1
 
-    # Whether to send a confirmation to the user after the user has registered.
-    sendConfirmation = 1
+  # Whether to send a confirmation to the user after the user has registered.
+  sendConfirmation = 1
 
-    # Whether to send a confirmation to the user if the user has unregistered.
-    sendConfirmationOnUnregistration = 1
+  # Whether to send a confirmation to the user if the user has unregistered.
+  sendConfirmationOnUnregistration = 1
 
-    # Whether to send a confirmation to the user if the user has registered for the queue.
-    sendConfirmationOnRegistrationForQueue = 1
+  # Whether to send a confirmation to the user if the user has registered for the queue.
+  sendConfirmationOnRegistrationForQueue = 1
 
-    # Whether to send a confirmation to the user if the queue has been updated.
-    sendConfirmationOnQueueUpdate = 1
+  # Whether to send a confirmation to the user if the queue has been updated.
+  sendConfirmationOnQueueUpdate = 1
 
-    # Whether to add the CSV file of the registrations when sending the reminder e-mails to the organizers.
-    addRegistrationCsvToOrganizerReminderMail = 0
+  # Whether to add the CSV file of the registrations when sending the reminder e-mails to the organizers.
+  addRegistrationCsvToOrganizerReminderMail = 0
 
-    # the time format (in strftime format)
-    timeFormat = %H:%M
+  # the time format (in strftime format)
+  timeFormat = %H:%M
 
-    # the strftime format code for the full date
-    dateFormatYMD = %d.%m.%Y
+  # the strftime format code for the full date
+  dateFormatYMD = %d.%m.%Y
 
-    # ISO 4217 alpha 3 code of the currency to be used, must be valid
-    currency = EUR
+  # ISO 4217 alpha 3 code of the currency to be used, must be valid
+  currency = EUR
 
-    # whether to also show the time of the registration deadline
-    showTimeOfRegistrationDeadline = 0
+  # whether to also show the time of the registration deadline
+  showTimeOfRegistrationDeadline = 0
 
-    # whether to also show the time of the early bird deadline
-    showTimeOfEarlyBirdDeadline = 0
+  # whether to also show the time of the early bird deadline
+  showTimeOfEarlyBirdDeadline = 0
 
-    # whether to also show the time of the unregistration deadline
-    showTimeOfUnregistrationDeadline = 0
+  # whether to also show the time of the unregistration deadline
+  showTimeOfUnregistrationDeadline = 0
 
-    # Number of days before the start of an event until unregistration is possible. (If you want to disable this feature, just leave this value empty.)
-    unregistrationDeadlineDaysBeforeBeginDate =
+  # Number of days before the start of an event until unregistration is possible. (If you want to disable this feature, just leave this value empty.)
+  unregistrationDeadlineDaysBeforeBeginDate =
 
-    # whether registration should be possible even if an event has already started
-    allowRegistrationForStartedEvents = 0
+  # whether registration should be possible even if an event has already started
+  allowRegistrationForStartedEvents = 0
 
-    # whether registration for events without a date should be possible
-    allowRegistrationForEventsWithoutDate = 0
+  # whether registration for events without a date should be possible
+  allowRegistrationForEventsWithoutDate = 0
 
-    # Whether unregistration is possible even when there are no registrations
-    # on the waiting list yet.
-    allowUnregistrationWithEmptyWaitingList = 0
+  # Whether unregistration is possible even when there are no registrations
+  # on the waiting list yet.
+  allowUnregistrationWithEmptyWaitingList = 0
 
-    # If there are at least this many vancancies, "enough" is displayed instead of the exact number.
-    showVacanciesThreshold = 10
+  # If there are at least this many vancancies, "enough" is displayed instead of the exact number.
+  showVacanciesThreshold = 10
 
-    # whether events that have no standard price set should have "to be announced" as price instead of "free"
-    showToBeAnnouncedForEmptyPrice = 0
+  # whether events that have no standard price set should have "to be announced" as price instead of "free"
+  showToBeAnnouncedForEmptyPrice = 0
 
-    # The charset for the CSV export, e.g., utf-8, iso-8859-1 or iso-8859-15.
-    # The default is iso-9959-15 because Excel has problems with importing utf-8.
-    charsetForCsv = iso-8859-15
+  # The charset for the CSV export, e.g., utf-8, iso-8859-1 or iso-8859-15.
+  # The default is iso-9959-15 because Excel has problems with importing utf-8.
+  charsetForCsv = iso-8859-15
 
-    # the filename proposed for CSV export of event lists
-    filenameForEventsCsv = events.csv
+  # the filename proposed for CSV export of event lists
+  filenameForEventsCsv = events.csv
 
-    # the filename proposed for CSV export of registration lists
-    filenameForRegistrationsCsv = registrations.csv
+  # the filename proposed for CSV export of registration lists
+  filenameForRegistrationsCsv = registrations.csv
 
-    # comma-separated list of field names from tx_seminars_seminars that will be used for CSV export
-    fieldsFromEventsForCsv = uid,title,subtitle,description,event_type,date,time,place,room,speakers,price_regular,attendees,attendees_max,vacancies,is_full
+  # comma-separated list of field names from tx_seminars_seminars that will be used for CSV export
+  fieldsFromEventsForCsv = uid,title,subtitle,description,event_type,date,time,place,room,speakers,price_regular,attendees,attendees_max,vacancies,is_full
 
-    # comma-separated list of field names from fe_users that will be used for CSV export
-    fieldsFromFeUserForCsv = name,company,address,zip,city,country,telephone,email
+  # comma-separated list of field names from fe_users that will be used for CSV export
+  fieldsFromFeUserForCsv = name,company,address,zip,city,country,telephone,email
 
-    # comma-separated list of field names from tx_seminars_attendances that will be used for CSV export
-    fieldsFromAttendanceForCsv = uid,price,total_price,method_of_payment,interests,expectations,background_knowledge,known_from,notes
+  # comma-separated list of field names from tx_seminars_attendances that will be used for CSV export
+  fieldsFromAttendanceForCsv = uid,price,total_price,method_of_payment,interests,expectations,background_knowledge,known_from,notes
 
-    # whether to show attendances on the registration queue in the CSV export or not
-    showAttendancesOnRegistrationQueueInCSV = 0
+  # whether to show attendances on the registration queue in the CSV export or not
+  showAttendancesOnRegistrationQueueInCSV = 0
 
-    # comma-separated list of field names from fe_users that will be used for CLI CSV export
-    fieldsFromFeUserForEmailCsv = name,company,address,zip,city,country,telephone,email
+  # comma-separated list of field names from fe_users that will be used for CLI CSV export
+  fieldsFromFeUserForEmailCsv = name,company,address,zip,city,country,telephone,email
 
-    # comma-separated list of field names from tx_seminars_attendances that will be used for CLI CSV export
-    fieldsFromAttendanceForEmailCsv = uid,price,total_price,method_of_payment,interests,expectations,background_knowledge,known_from,notes
+  # comma-separated list of field names from tx_seminars_attendances that will be used for CLI CSV export
+  fieldsFromAttendanceForEmailCsv = uid,price,total_price,method_of_payment,interests,expectations,background_knowledge,known_from,notes
 
-    # whether to show attendances on the registration queue in the CLI CSV export or not
-    showAttendancesOnRegistrationQueueInEmailCsv = 0
+  # whether to show attendances on the registration queue in the CLI CSV export or not
+  showAttendancesOnRegistrationQueueInEmailCsv = 0
 
-    # whether to add the Excel-specific "sep=;" line to the CSV
-    addExcelSpecificSeparatorLineToCsv = 0
+  # whether to add the Excel-specific "sep=;" line to the CSV
+  addExcelSpecificSeparatorLineToCsv = 0
 
-    # whether to send a cancelation deadline reminder to the organizers
-    sendCancelationDeadlineReminder = 0
+  # whether to send a cancelation deadline reminder to the organizers
+  sendCancelationDeadlineReminder = 0
 
-    # how many days before an events' begin date the organizers should be reminded about this event via e-mail, zero disables the reminder
-    sendEventTakesPlaceReminderDaysBeforeBeginDate = 0
+  # how many days before an events' begin date the organizers should be reminded about this event via e-mail, zero disables the reminder
+  sendEventTakesPlaceReminderDaysBeforeBeginDate = 0
 
-    # Set this to 1 to hide the special price for the first registration of a user and to automatically offer the special
-    # price for the 2nd, 3rd etc. registrations of the same user.
-    automaticSpecialPriceForSubsequentRegistrationsBySameUser = 0
+  # Set this to 1 to hide the special price for the first registration of a user and to automatically offer the special
+  # price for the 2nd, 3rd etc. registrations of the same user.
+  automaticSpecialPriceForSubsequentRegistrationsBySameUser = 0
 
-    # The following variables don't have any default values provided.
-    # You need to set them yourself for this extension to work correctly.
+  # The following variables don't have any default values provided.
+  # You need to set them yourself for this extension to work correctly.
 
-    # PID of the folder where event registrations (attendances) will be stored
-    attendancesPID =
+  # PID of the folder where event registrations (attendances) will be stored
+  attendancesPID =
 }

--- a/Configuration/TypoScript/Publication.typoscript
+++ b/Configuration/TypoScript/Publication.typoscript
@@ -1,22 +1,22 @@
 tx_seminars_publication = PAGE
 tx_seminars_publication {
-    # The page type number for the publish links. Do not change this!
-    typeNum = 737
+  # The page type number for the publish links. Do not change this!
+  typeNum = 737
 
-    config {
-        enableContentLengthHeader = 1
-        no_cache = 1
-        doctype = xhtml_strict
-        removeDefaultJS = 1
-        setJS_openPic = 0
-    }
+  config {
+    enableContentLengthHeader = 1
+    no_cache = 1
+    doctype = xhtml_strict
+    removeDefaultJS = 1
+    setJS_openPic = 0
+  }
 
-    includeLibs.tx_seminars_publication = EXT:seminars/Classes/FrontEnd/EventPublication.php
-    stdWrap.wrap = <p>|</p>
+  includeLibs.tx_seminars_publication = EXT:seminars/Classes/FrontEnd/EventPublication.php
+  stdWrap.wrap = <p>|</p>
 
-    10 = USER
-    10 {
-        userFunc = \OliverKlee\Seminars\FrontEnd\EventPublication->render
-        xhtml_cleaning = all
-    }
+  10 = USER
+  10 {
+    userFunc = \OliverKlee\Seminars\FrontEnd\EventPublication->render
+    xhtml_cleaning = all
+  }
 }

--- a/Configuration/TypoScript/RegistrationDigestEmail.typoscript
+++ b/Configuration/TypoScript/RegistrationDigestEmail.typoscript
@@ -1,23 +1,23 @@
 # Configuration for the (usually daily) registration digest email.
 plugin.tx_seminars.registrationDigestEmail {
-    # whether to send out the emails when the seminars Scheduler task is executed
-    enable = 0
+  # whether to send out the emails when the seminars Scheduler task is executed
+  enable = 0
 
-    # email address of the sender
-    fromEmail =
+  # email address of the sender
+  fromEmail =
 
-    # name of the sender
-    fromName =
+  # name of the sender
+  fromName =
 
-    # email address of the recipient
-    toEmail =
+  # email address of the recipient
+  toEmail =
 
-    # name of the recipient
-    toName =
+  # name of the recipient
+  toName =
 
-    # path to the fluid template for the plaintext email
-    plaintextTemplate = EXT:seminars/Resources/Private/Templates/Mail/RegistrationDigest.txt
+  # path to the fluid template for the plaintext email
+  plaintextTemplate = EXT:seminars/Resources/Private/Templates/Mail/RegistrationDigest.txt
 
-    # path to the fluid template for the HTML email
-    htmlTemplate = EXT:seminars/Resources/Private/Templates/Mail/RegistrationDigest.html
+  # path to the fluid template for the HTML email
+  htmlTemplate = EXT:seminars/Resources/Private/Templates/Mail/RegistrationDigest.html
 }

--- a/Configuration/TypoScript/constants.typoscript
+++ b/Configuration/TypoScript/constants.typoscript
@@ -1,11 +1,11 @@
 plugin {
-    tx_seminars_pi1 {
-        # cat=plugin.tx_seminars_pi1//; type=string; label=Path to CSS file: location of the CSS file (leave empty to include no CSS file)
-        cssFile = EXT:seminars/Resources/Public/CSS/FrontEnd/FrontEnd.css
-    }
+  tx_seminars_pi1 {
+    # cat=plugin.tx_seminars_pi1//; type=string; label=Path to CSS file: location of the CSS file (leave empty to include no CSS file)
+    cssFile = EXT:seminars/Resources/Public/CSS/FrontEnd/FrontEnd.css
+  }
 
-    tx_seminars.settings {
-        # cat=plugin.tx_seminars.settings//; type=options [formal,informal]; label=Salutation mode in the frontend
-        salutation = formal
-    }
+  tx_seminars.settings {
+    # cat=plugin.tx_seminars.settings//; type=options [formal,informal]; label=Salutation mode in the frontend
+    salutation = formal
+  }
 }

--- a/ext_typoscript_setup.txt
+++ b/ext_typoscript_setup.txt
@@ -1,173 +1,173 @@
 # This file can be removed once we drop support for TYPO3 V9.
 config.tx_extbase.persistence.classes {
-    OliverKlee\Seminars\Domain\Model\AccommodationOption {
-        mapping {
-            tableName = tx_seminars_lodgings
-        }
+  OliverKlee\Seminars\Domain\Model\AccommodationOption {
+    mapping {
+      tableName = tx_seminars_lodgings
+    }
+  }
+
+  OliverKlee\Seminars\Domain\Model\Event\Event {
+    mapping {
+      tableName = tx_seminars_seminars
+      columns {
+        owner_feuser.mapOnProperty = ownerUid
+      }
     }
 
-    OliverKlee\Seminars\Domain\Model\Event\Event {
-        mapping {
-            tableName = tx_seminars_seminars
-            columns {
-                owner_feuser.mapOnProperty = ownerUid
-            }
-        }
-
-        subclasses {
-            0 = OliverKlee\Seminars\Domain\Model\Event\SingleEvent
-            1 = OliverKlee\Seminars\Domain\Model\Event\EventTopic
-            2 = OliverKlee\Seminars\Domain\Model\Event\EventDate
-        }
+    subclasses {
+      0 = OliverKlee\Seminars\Domain\Model\Event\SingleEvent
+      1 = OliverKlee\Seminars\Domain\Model\Event\EventTopic
+      2 = OliverKlee\Seminars\Domain\Model\Event\EventDate
     }
+  }
 
-    OliverKlee\Seminars\Domain\Model\Event\SingleEvent {
-        mapping {
-            tableName = tx_seminars_seminars
-            recordType = 0
-            columns {
-                title.mapOnProperty = internalTitle
-                begin_date.mapOnProperty = start
-                end_date.mapOnProperty = end
-                begin_date_registration.mapOnProperty = registrationStart
-                deadline_early_bird.mapOnProperty = earlyBirdDeadline
-                deadline_registration.mapOnProperty = registrationDeadline
-                needs_registration.mapOnProperty = registrationRequired
-                queue_size.mapOnProperty = waitingList
-                attendees_min.mapOnProperty = minimumNumberOfRegistrations
-                attendees_max.mapOnProperty = maximumNumberOfRegistrations
-                price_regular.mapOnProperty = standardPrice
-                price_regular_early.mapOnProperty = earlyBirdPrice
-                place.mapOnProperty = venues
-                owner_feuser.mapOnProperty = ownerUid
-                uses_terms_2.mapOnProperty = additionalTermsAndConditions
-                allows_multiple_registrations.mapOnProperty = multipleRegistrationPossible
-                offline_attendees.mapOnProperty = numberOfOfflineRegistrations
-                cancelled.mapOnProperty = status
-                price_special.mapOnProperty = specialPrice
-                price_special_early.mapOnProperty = specialEarlyBirdPrice
-                lodgings.mapOnProperty = accommodationOptions
-                foods.mapOnProperty = foodOptions
-                checkboxes.mapOnProperty = registrationCheckboxes
-            }
-        }
+  OliverKlee\Seminars\Domain\Model\Event\SingleEvent {
+    mapping {
+      tableName = tx_seminars_seminars
+      recordType = 0
+      columns {
+        title.mapOnProperty = internalTitle
+        begin_date.mapOnProperty = start
+        end_date.mapOnProperty = end
+        begin_date_registration.mapOnProperty = registrationStart
+        deadline_early_bird.mapOnProperty = earlyBirdDeadline
+        deadline_registration.mapOnProperty = registrationDeadline
+        needs_registration.mapOnProperty = registrationRequired
+        queue_size.mapOnProperty = waitingList
+        attendees_min.mapOnProperty = minimumNumberOfRegistrations
+        attendees_max.mapOnProperty = maximumNumberOfRegistrations
+        price_regular.mapOnProperty = standardPrice
+        price_regular_early.mapOnProperty = earlyBirdPrice
+        place.mapOnProperty = venues
+        owner_feuser.mapOnProperty = ownerUid
+        uses_terms_2.mapOnProperty = additionalTermsAndConditions
+        allows_multiple_registrations.mapOnProperty = multipleRegistrationPossible
+        offline_attendees.mapOnProperty = numberOfOfflineRegistrations
+        cancelled.mapOnProperty = status
+        price_special.mapOnProperty = specialPrice
+        price_special_early.mapOnProperty = specialEarlyBirdPrice
+        lodgings.mapOnProperty = accommodationOptions
+        foods.mapOnProperty = foodOptions
+        checkboxes.mapOnProperty = registrationCheckboxes
+      }
     }
+  }
 
-    OliverKlee\Seminars\Domain\Model\Event\EventTopic {
-        mapping {
-            tableName = tx_seminars_seminars
-            recordType = 1
-            columns {
-                title.mapOnProperty = internalTitle
-                price_regular.mapOnProperty = standardPrice
-                price_regular_early.mapOnProperty = earlyBirdPrice
-                owner_feuser.mapOnProperty = ownerUid
-                uses_terms_2.mapOnProperty = additionalTermsAndConditions
-                allows_multiple_registrations.mapOnProperty = multipleRegistrationPossible
-                price_special.mapOnProperty = specialPrice
-                price_special_early.mapOnProperty = specialEarlyBirdPrice
-            }
-        }
+  OliverKlee\Seminars\Domain\Model\Event\EventTopic {
+    mapping {
+      tableName = tx_seminars_seminars
+      recordType = 1
+      columns {
+        title.mapOnProperty = internalTitle
+        price_regular.mapOnProperty = standardPrice
+        price_regular_early.mapOnProperty = earlyBirdPrice
+        owner_feuser.mapOnProperty = ownerUid
+        uses_terms_2.mapOnProperty = additionalTermsAndConditions
+        allows_multiple_registrations.mapOnProperty = multipleRegistrationPossible
+        price_special.mapOnProperty = specialPrice
+        price_special_early.mapOnProperty = specialEarlyBirdPrice
+      }
     }
+  }
 
-    OliverKlee\Seminars\Domain\Model\Event\EventDate {
-        mapping {
-            tableName = tx_seminars_seminars
-            recordType = 2
-            columns {
-                title.mapOnProperty = internalTitle
-                topic.mapOnProperty = topic
-                begin_date.mapOnProperty = start
-                end_date.mapOnProperty = end
-                begin_date_registration.mapOnProperty = registrationStart
-                deadline_early_bird.mapOnProperty = earlyBirdDeadline
-                deadline_registration.mapOnProperty = registrationDeadline
-                needs_registration.mapOnProperty = registrationRequired
-                queue_size.mapOnProperty = waitingList
-                attendees_min.mapOnProperty = minimumNumberOfRegistrations
-                attendees_max.mapOnProperty = maximumNumberOfRegistrations
-                place.mapOnProperty = venues
-                owner_feuser.mapOnProperty = ownerUid
-                offline_attendees.mapOnProperty = numberOfOfflineRegistrations
-                cancelled.mapOnProperty = status
-                lodgings.mapOnProperty = accommodationOptions
-                foods.mapOnProperty = foodOptions
-                checkboxes.mapOnProperty = registrationCheckboxes
-            }
-        }
+  OliverKlee\Seminars\Domain\Model\Event\EventDate {
+    mapping {
+      tableName = tx_seminars_seminars
+      recordType = 2
+      columns {
+        title.mapOnProperty = internalTitle
+        topic.mapOnProperty = topic
+        begin_date.mapOnProperty = start
+        end_date.mapOnProperty = end
+        begin_date_registration.mapOnProperty = registrationStart
+        deadline_early_bird.mapOnProperty = earlyBirdDeadline
+        deadline_registration.mapOnProperty = registrationDeadline
+        needs_registration.mapOnProperty = registrationRequired
+        queue_size.mapOnProperty = waitingList
+        attendees_min.mapOnProperty = minimumNumberOfRegistrations
+        attendees_max.mapOnProperty = maximumNumberOfRegistrations
+        place.mapOnProperty = venues
+        owner_feuser.mapOnProperty = ownerUid
+        offline_attendees.mapOnProperty = numberOfOfflineRegistrations
+        cancelled.mapOnProperty = status
+        lodgings.mapOnProperty = accommodationOptions
+        foods.mapOnProperty = foodOptions
+        checkboxes.mapOnProperty = registrationCheckboxes
+      }
     }
+  }
 
-    OliverKlee\Seminars\Domain\Model\EventType {
-        mapping {
-            tableName = tx_seminars_event_types
-        }
+  OliverKlee\Seminars\Domain\Model\EventType {
+    mapping {
+      tableName = tx_seminars_event_types
     }
+  }
 
-    OliverKlee\Seminars\Domain\Model\FoodOption {
-        mapping {
-            tableName = tx_seminars_foods
-        }
+  OliverKlee\Seminars\Domain\Model\FoodOption {
+    mapping {
+      tableName = tx_seminars_foods
     }
+  }
 
-    OliverKlee\Seminars\Domain\Model\Organizer {
-        mapping {
-            tableName = tx_seminars_organizers
-            columns {
-                title.mapOnProperty = name
-                email.mapOnProperty = emailAddress
-            }
-        }
+  OliverKlee\Seminars\Domain\Model\Organizer {
+    mapping {
+      tableName = tx_seminars_organizers
+      columns {
+        title.mapOnProperty = name
+        email.mapOnProperty = emailAddress
+      }
     }
+  }
 
-    OliverKlee\Seminars\Domain\Model\PaymentMethod {
-        mapping {
-            tableName = tx_seminars_payment_methods
-        }
+  OliverKlee\Seminars\Domain\Model\PaymentMethod {
+    mapping {
+      tableName = tx_seminars_payment_methods
     }
+  }
 
-    OliverKlee\Seminars\Domain\Model\Registration\Registration {
-        mapping {
-            tableName = tx_seminars_attendances
-            columns {
-                seminar.mapOnProperty = event
-                registration_queue.mapOnProperty = onWaitingList
-                notes.mapOnProperty = comments
-                lodgings.mapOnProperty = accommodationOptions
-                foods.mapOnProperty = foodOptions
-                checkboxes.mapOnProperty = registrationCheckboxes
-                company.mapOnProperty = billingCompany
-                name.mapOnProperty = billingFullName
-                address.mapOnProperty = billingStreetAddress
-                zip.mapOnProperty = billingZipCode
-                city.mapOnProperty = billingCity
-                country.mapOnProperty = billingCountry
-                telephone.mapOnProperty = billingPhoneNumber
-                email.mapOnProperty = billingEmailAddress
-                price.mapOnProperty = priceCode
-                method_of_payment.mapOnProperty = paymentMethod
-            }
-        }
+  OliverKlee\Seminars\Domain\Model\Registration\Registration {
+    mapping {
+      tableName = tx_seminars_attendances
+      columns {
+        seminar.mapOnProperty = event
+        registration_queue.mapOnProperty = onWaitingList
+        notes.mapOnProperty = comments
+        lodgings.mapOnProperty = accommodationOptions
+        foods.mapOnProperty = foodOptions
+        checkboxes.mapOnProperty = registrationCheckboxes
+        company.mapOnProperty = billingCompany
+        name.mapOnProperty = billingFullName
+        address.mapOnProperty = billingStreetAddress
+        zip.mapOnProperty = billingZipCode
+        city.mapOnProperty = billingCity
+        country.mapOnProperty = billingCountry
+        telephone.mapOnProperty = billingPhoneNumber
+        email.mapOnProperty = billingEmailAddress
+        price.mapOnProperty = priceCode
+        method_of_payment.mapOnProperty = paymentMethod
+      }
     }
+  }
 
-    OliverKlee\Seminars\Domain\Model\RegistrationCheckbox {
-        mapping {
-            tableName = tx_seminars_checkboxes
-        }
+  OliverKlee\Seminars\Domain\Model\RegistrationCheckbox {
+    mapping {
+      tableName = tx_seminars_checkboxes
     }
+  }
 
-    OliverKlee\Seminars\Domain\Model\Speaker {
-        mapping {
-            tableName = tx_seminars_speakers
-            columns {
-                title.mapOnProperty = name
-                email.mapOnProperty = emailAddress
-            }
-        }
+  OliverKlee\Seminars\Domain\Model\Speaker {
+    mapping {
+      tableName = tx_seminars_speakers
+      columns {
+        title.mapOnProperty = name
+        email.mapOnProperty = emailAddress
+      }
     }
+  }
 
-    OliverKlee\Seminars\Domain\Model\Venue {
-        mapping {
-            tableName = tx_seminars_sites
-        }
+  OliverKlee\Seminars\Domain\Model\Venue {
+    mapping {
+      tableName = tx_seminars_sites
     }
+  }
 }


### PR DESCRIPTION
Now we are up to date with what the Core uses again, and autoformatting the TypoScript files does not create any warnings anymore.

Also autoformat all TypoScript files.

Fixes #1870