### PR TITLE
[FEATURE] Add a `LegacyRegistrationConfiguration`

### DIFF
--- a/Classes/Configuration/LegacyRegistrationConfiguration.php
+++ b/Classes/Configuration/LegacyRegistrationConfiguration.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OliverKlee\Seminars\Configuration;
+
+use OliverKlee\Oelib\Templating\TemplateHelper;
+use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
+
+/**
+ * Legacy configuration for the registration form. This class exists only as long as the new registration form
+ * uses the legacy email functionality.
+ *
+ * @deprecated #1911 will be removed in seminars 5.3.0
+ */
+class LegacyRegistrationConfiguration extends TemplateHelper
+{
+    public function __construct()
+    {
+        $frontEndController = $GLOBALS['TSFE'] ?? null;
+        if (!$frontEndController instanceof TypoScriptFrontendController) {
+            throw new \RuntimeException('No front end found.', 1668938450);
+        }
+        $this->cObj = $frontEndController->cObj;
+
+        parent::__construct(null, $frontEndController);
+    }
+}

--- a/Tests/Unit/Configuration/LegacyRegistrationConfigurationTest.php
+++ b/Tests/Unit/Configuration/LegacyRegistrationConfigurationTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OliverKlee\Seminars\Tests\Unit\Configuration;
+
+use Nimut\TestingFramework\TestCase\UnitTestCase;
+use OliverKlee\Oelib\Templating\TemplateHelper;
+use OliverKlee\Seminars\Configuration\LegacyRegistrationConfiguration;
+use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
+use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
+
+/**
+ * @covers \OliverKlee\Seminars\Configuration\LegacyRegistrationConfiguration
+ */
+final class LegacyRegistrationConfigurationTest extends UnitTestCase
+{
+    /**
+     * @var ContentObjectRenderer
+     */
+    private $contentObjectMock;
+
+    /**
+     * @var LegacyRegistrationConfiguration
+     */
+    private $subject;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $frontEndControllerMock = $this->getMockBuilder(TypoScriptFrontendController::class)
+            ->disableOriginalConstructor()->getMock();
+        $this->contentObjectMock = $this->getMockBuilder(ContentObjectRenderer::class)
+            ->disableOriginalConstructor()->getMock();
+        $frontEndControllerMock->cObj = $this->contentObjectMock;
+        $GLOBALS['TSFE'] = $frontEndControllerMock;
+
+        $this->subject = new LegacyRegistrationConfiguration();
+    }
+
+    protected function tearDown(): void
+    {
+        unset($GLOBALS['TSFE']);
+        parent::tearDown();
+    }
+
+    /**
+     * @test
+     */
+    public function extendsTemplateHelper(): void
+    {
+        self::assertInstanceOf(TemplateHelper::class, $this->subject);
+    }
+
+    /**
+     * @test
+     */
+    public function constructionWithoutFrontEndThrowsException(): void
+    {
+        unset($GLOBALS['TSFE']);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('No front end found.');
+        $this->expectExceptionCode(1668938450);
+
+        $this->subject = new LegacyRegistrationConfiguration();
+    }
+
+    /**
+     * @test
+     */
+    public function hasContentObjectFromFrontEnd(): void
+    {
+        self::assertSame($this->contentObjectMock, $this->subject->cObj);
+    }
+}


### PR DESCRIPTION
This class exists only as long as the new registration form uses the legacy email functionality.

Closes #1905