### PR TITLE
[BUGFIX] Make the `RegistrationManager` injectable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Drop the `Event.getOrganizer()` alias method (#1727)
 
 ### Fixed
+- Make the `RegistrationManager` injectable (#1915)
 - Update the `.editorconfig` and TypoScript lint settings (1875)
 - Fix renderings warnings in the documentation (#1826)
 - Stop using deprecated oelib functionality (#1819)

--- a/Classes/FrontEnd/DefaultController.php
+++ b/Classes/FrontEnd/DefaultController.php
@@ -3297,13 +3297,13 @@ class DefaultController extends TemplateHelper
         if (!$this->linkBuilder instanceof SingleViewLinkBuilder) {
             $configuration = $this->getConfigurationWithFlexForms();
             $linkBuilder = GeneralUtility::makeInstance(SingleViewLinkBuilder::class, $configuration);
-            $this->injectLinkBuilder($linkBuilder);
+            $this->setLinkBuilder($linkBuilder);
         }
 
         return $this->linkBuilder;
     }
 
-    public function injectLinkBuilder(SingleViewLinkBuilder $linkBuilder): void
+    public function setLinkBuilder(SingleViewLinkBuilder $linkBuilder): void
     {
         $this->linkBuilder = $linkBuilder;
     }

--- a/Classes/FrontEnd/RequirementsList.php
+++ b/Classes/FrontEnd/RequirementsList.php
@@ -77,7 +77,7 @@ class RequirementsList extends AbstractView
 
         if (!$this->linkBuilder instanceof SingleViewLinkBuilder) {
             $configuration = $this->getConfigurationWithFlexForms();
-            $this->injectLinkBuilder(GeneralUtility::makeInstance(SingleViewLinkBuilder::class, $configuration));
+            $this->setLinkBuilder(GeneralUtility::makeInstance(SingleViewLinkBuilder::class, $configuration));
         }
 
         $output = '';
@@ -121,7 +121,7 @@ class RequirementsList extends AbstractView
         return $result;
     }
 
-    public function injectLinkBuilder(SingleViewLinkBuilder $linkBuilder): void
+    public function setLinkBuilder(SingleViewLinkBuilder $linkBuilder): void
     {
         $this->linkBuilder = $linkBuilder;
     }

--- a/Classes/Service/RegistrationManager.php
+++ b/Classes/Service/RegistrationManager.php
@@ -115,7 +115,7 @@ class RegistrationManager
         self::$instance = null;
     }
 
-    public function injectLinkBuilder(SingleViewLinkBuilder $linkBuilder): void
+    public function setLinkBuilder(SingleViewLinkBuilder $linkBuilder): void
     {
         $this->linkBuilder = $linkBuilder;
     }
@@ -1061,7 +1061,7 @@ class RegistrationManager
     ): string {
         if (!$this->linkBuilder instanceof SingleViewLinkBuilder) {
             $configuration = $this->buildConfigurationWithFlexforms($plugin);
-            $this->injectLinkBuilder(GeneralUtility::makeInstance(SingleViewLinkBuilder::class, $configuration));
+            $this->setLinkBuilder(GeneralUtility::makeInstance(SingleViewLinkBuilder::class, $configuration));
         }
 
         $wrapperPrefix = ($useHtml ? 'html_' : '') . 'field_wrapper';

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -6,4 +6,4 @@ services:
 
   OliverKlee\Seminars\:
     resource: '../Classes/*'
-    exclude: '../Classes/Domain/Model/*,../Classes/Model/*,../Classes/OldModel/*'
+    exclude: '../Classes/Domain/Model/*,../Classes/Model/*,../Classes/OldModel/*,../Classes/Service/SingleViewLinkBuilder.php'

--- a/Tests/Functional/Service/RegistrationManagerTest.php
+++ b/Tests/Functional/Service/RegistrationManagerTest.php
@@ -69,7 +69,7 @@ final class RegistrationManagerTest extends FunctionalTestCase
 
         $this->testingFramework = new TestingFramework('tx_seminars');
 
-        $this->subject = RegistrationManager::getInstance();
+        $this->subject = new RegistrationManager();
     }
 
     protected function tearDown(): void
@@ -122,6 +122,16 @@ final class RegistrationManagerTest extends FunctionalTestCase
         $controller->conf = ['loginPID' => '2', 'registerPID' => '3'];
 
         return $controller;
+    }
+
+    /**
+     * @test
+     */
+    public function canBeCreatedWithMakeInstance(): void
+    {
+        $instance = GeneralUtility::makeInstance(RegistrationManager::class);
+
+        self::assertInstanceOf(RegistrationManager::class, $instance);
     }
 
     // Tests concerning notifyOrganizers

--- a/Tests/LegacyUnit/Service/RegistrationManagerTest.php
+++ b/Tests/LegacyUnit/Service/RegistrationManagerTest.php
@@ -210,7 +210,7 @@ final class RegistrationManagerTest extends TestCase
             ['createAbsoluteUrlForEvent']
         );
         $linkBuilder->method('createAbsoluteUrlForEvent')->willReturn('https://singleview.example.com/');
-        $this->subject->injectLinkBuilder($linkBuilder);
+        $this->subject->setLinkBuilder($linkBuilder);
 
         $frontEndUserMapper = MapperRegistry::get(FrontEndUserMapper::class);
         $this->frontEndUserMapper = $frontEndUserMapper;


### PR DESCRIPTION
We cannot use `inject*` methods for objects that do not get injected (by DI), but merely set.

Also generally preject the `SingleViewLinkBuilder` from getting injected.