### PR TITLE
[BUGFIX] Use `DateTime` instead of `DateTimeImmutable` in models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Drop the `Event.getOrganizer()` alias method (#1727)
 
 ### Fixed
+- Use `DateTime` instead of `DateTimeImmutable` in the models (#1961)
 - Streamline the HTML and CSS for the FE editor (#1959)
 - Make the `RegistrationManager` injectable (#1915)
 - Update the `.editorconfig` and TypoScript lint settings (1875)

--- a/Classes/Domain/Model/Event/EventDateInterface.php
+++ b/Classes/Domain/Model/Event/EventDateInterface.php
@@ -18,15 +18,15 @@ use TYPO3\CMS\Extbase\Persistence\ObjectStorage;
  */
 interface EventDateInterface
 {
-    public function getStart(): ?\DateTimeImmutable;
+    public function getStart(): ?\DateTime;
 
-    public function getEnd(): ?\DateTimeImmutable;
+    public function getEnd(): ?\DateTime;
 
-    public function getRegistrationStart(): ?\DateTimeImmutable;
+    public function getRegistrationStart(): ?\DateTime;
 
-    public function getEarlyBirdDeadline(): ?\DateTimeImmutable;
+    public function getEarlyBirdDeadline(): ?\DateTime;
 
-    public function getRegistrationDeadline(): ?\DateTimeImmutable;
+    public function getRegistrationDeadline(): ?\DateTime;
 
     public function isRegistrationRequired(): bool;
 

--- a/Classes/Domain/Model/Event/EventDateTrait.php
+++ b/Classes/Domain/Model/Event/EventDateTrait.php
@@ -21,27 +21,27 @@ use TYPO3\CMS\Extbase\Persistence\ObjectStorage;
 trait EventDateTrait
 {
     /**
-     * @var \DateTimeImmutable|null
+     * @var \DateTime|null
      */
     protected $start;
 
     /**
-     * @var \DateTimeImmutable|null
+     * @var \DateTime|null
      */
     protected $end;
 
     /**
-     * @var \DateTimeImmutable|null
+     * @var \DateTime|null
      */
     protected $registrationStart;
 
     /**
-     * @var \DateTimeImmutable|null
+     * @var \DateTime|null
      */
     protected $earlyBirdDeadline;
 
     /**
-     * @var \DateTimeImmutable|null
+     * @var \DateTime|null
      */
     protected $registrationDeadline;
 
@@ -124,52 +124,52 @@ trait EventDateTrait
         $this->registrationCheckboxes = new ObjectStorage();
     }
 
-    public function getStart(): ?\DateTimeImmutable
+    public function getStart(): ?\DateTime
     {
         return $this->start;
     }
 
-    public function setStart(?\DateTimeImmutable $start): void
+    public function setStart(?\DateTime $start): void
     {
         $this->start = $start;
     }
 
-    public function getEnd(): ?\DateTimeImmutable
+    public function getEnd(): ?\DateTime
     {
         return $this->end;
     }
 
-    public function setEnd(?\DateTimeImmutable $end): void
+    public function setEnd(?\DateTime $end): void
     {
         $this->end = $end;
     }
 
-    public function getRegistrationStart(): ?\DateTimeImmutable
+    public function getRegistrationStart(): ?\DateTime
     {
         return $this->registrationStart;
     }
 
-    public function setRegistrationStart(?\DateTimeImmutable $registrationStart): void
+    public function setRegistrationStart(?\DateTime $registrationStart): void
     {
         $this->registrationStart = $registrationStart;
     }
 
-    public function getEarlyBirdDeadline(): ?\DateTimeImmutable
+    public function getEarlyBirdDeadline(): ?\DateTime
     {
         return $this->earlyBirdDeadline;
     }
 
-    public function setEarlyBirdDeadline(?\DateTimeImmutable $earlyBirdDeadline): void
+    public function setEarlyBirdDeadline(?\DateTime $earlyBirdDeadline): void
     {
         $this->earlyBirdDeadline = $earlyBirdDeadline;
     }
 
-    public function getRegistrationDeadline(): ?\DateTimeImmutable
+    public function getRegistrationDeadline(): ?\DateTime
     {
         return $this->registrationDeadline;
     }
 
-    public function setRegistrationDeadline(?\DateTimeImmutable $registrationDeadline): void
+    public function setRegistrationDeadline(?\DateTime $registrationDeadline): void
     {
         $this->registrationDeadline = $registrationDeadline;
     }

--- a/Classes/Service/PriceFinder.php
+++ b/Classes/Service/PriceFinder.php
@@ -57,7 +57,7 @@ class PriceFinder implements SingletonInterface
     private function earlyBirdPricesApply(EventDateInterface $event): bool
     {
         $deadline = $event->getEarlyBirdDeadline();
-        if (!$deadline instanceof \DateTimeImmutable) {
+        if (!$deadline instanceof \DateTimeInterface) {
             return false;
         }
 

--- a/Classes/Service/RegistrationGuard.php
+++ b/Classes/Service/RegistrationGuard.php
@@ -57,29 +57,30 @@ class RegistrationGuard implements SingletonInterface
     public function isRegistrationPossibleByDate(EventDateInterface $event): bool
     {
         $registrationDeadline = $this->getRegistrationDeadlineForEvent($event);
-        if (!$registrationDeadline instanceof \DateTimeImmutable) {
+        if (!$registrationDeadline instanceof \DateTimeInterface) {
             return false;
         }
 
-        $registrationIsEarlyEnough = $this->now() < $registrationDeadline;
+        $now = $this->now();
+        $registrationIsEarlyEnough = $now < $registrationDeadline;
         $registrationIsLateEnough = true;
 
         $registrationStart = $event->getRegistrationStart();
-        if ($registrationStart instanceof \DateTimeImmutable) {
-            $registrationIsLateEnough = $this->now() >= $registrationStart;
+        if ($registrationStart instanceof \DateTimeInterface) {
+            $registrationIsLateEnough = $now >= $registrationStart;
         }
 
         return $registrationIsEarlyEnough && $registrationIsLateEnough;
     }
 
-    private function getRegistrationDeadlineForEvent(EventDateInterface $event): ?\DateTimeImmutable
+    private function getRegistrationDeadlineForEvent(EventDateInterface $event): ?\DateTime
     {
         if ($event->getStart() === null && $event->getRegistrationDeadline() === null) {
             return null;
         }
 
         $deadline = $event->getStart();
-        if ($event->getRegistrationDeadline() instanceof \DateTimeImmutable) {
+        if ($event->getRegistrationDeadline() instanceof \DateTimeInterface) {
             $deadline = $event->getRegistrationDeadline();
         }
 

--- a/Tests/Functional/Domain/Repository/Event/EventRepositoryTest.php
+++ b/Tests/Functional/Domain/Repository/Event/EventRepositoryTest.php
@@ -70,11 +70,11 @@ final class EventRepositoryTest extends FunctionalTestCase
         self::assertSame('Jousting', $result->getInternalTitle());
         self::assertSame('Jousting', $result->getDisplayTitle());
         self::assertSame('There is no glory in prevention.', $result->getDescription());
-        self::assertEquals(new \DateTimeImmutable('2022-04-02 10:00'), $result->getStart());
-        self::assertEquals(new \DateTimeImmutable('2022-04-03 18:00'), $result->getEnd());
-        self::assertEquals(new \DateTimeImmutable('2022-01-01 00:00'), $result->getRegistrationStart());
-        self::assertEquals(new \DateTimeImmutable('2022-03-02 10:00'), $result->getEarlyBirdDeadline());
-        self::assertEquals(new \DateTimeImmutable('2022-04-01 10:00'), $result->getRegistrationDeadline());
+        self::assertEquals(new \DateTime('2022-04-02 10:00'), $result->getStart());
+        self::assertEquals(new \DateTime('2022-04-03 18:00'), $result->getEnd());
+        self::assertEquals(new \DateTime('2022-01-01 00:00'), $result->getRegistrationStart());
+        self::assertEquals(new \DateTime('2022-03-02 10:00'), $result->getEarlyBirdDeadline());
+        self::assertEquals(new \DateTime('2022-04-01 10:00'), $result->getRegistrationDeadline());
         self::assertTrue($result->isRegistrationRequired());
         self::assertTrue($result->hasWaitingList());
         self::assertSame(5, $result->getMinimumNumberOfRegistrations());
@@ -94,7 +94,7 @@ final class EventRepositoryTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function mapsNotSetDateTimeImmutablesForSingleEventAsNull(): void
+    public function mapsNotSetDateTimesForSingleEventAsNull(): void
     {
         $this->importDataSet(__DIR__ . '/Fixtures/SingleEventWithoutData.xml');
 
@@ -143,11 +143,11 @@ final class EventRepositoryTest extends FunctionalTestCase
         self::assertSame('Jousting date', $result->getInternalTitle());
         self::assertSame('Jousting topic', $result->getDisplayTitle());
         self::assertSame('There is no glory in prevention.', $result->getDescription());
-        self::assertEquals(new \DateTimeImmutable('2022-04-02 10:00'), $result->getStart());
-        self::assertEquals(new \DateTimeImmutable('2022-04-03 18:00'), $result->getEnd());
-        self::assertEquals(new \DateTimeImmutable('2022-01-01 00:00'), $result->getRegistrationStart());
-        self::assertEquals(new \DateTimeImmutable('2022-03-02 10:00'), $result->getEarlyBirdDeadline());
-        self::assertEquals(new \DateTimeImmutable('2022-04-01 10:00'), $result->getRegistrationDeadline());
+        self::assertEquals(new \DateTime('2022-04-02 10:00'), $result->getStart());
+        self::assertEquals(new \DateTime('2022-04-03 18:00'), $result->getEnd());
+        self::assertEquals(new \DateTime('2022-01-01 00:00'), $result->getRegistrationStart());
+        self::assertEquals(new \DateTime('2022-03-02 10:00'), $result->getEarlyBirdDeadline());
+        self::assertEquals(new \DateTime('2022-04-01 10:00'), $result->getRegistrationDeadline());
         self::assertTrue($result->isRegistrationRequired());
         self::assertTrue($result->hasWaitingList());
         self::assertSame(5, $result->getMinimumNumberOfRegistrations());
@@ -160,7 +160,7 @@ final class EventRepositoryTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function mapsNotSetDateTimeImmutablesForEventDateAsNull(): void
+    public function mapsNotSetDateTimesForEventDateAsNull(): void
     {
         $this->importDataSet(__DIR__ . '/Fixtures/SingleEventWithoutData.xml');
 

--- a/Tests/Functional/Service/RegistrationProcessorTest.php
+++ b/Tests/Functional/Service/RegistrationProcessorTest.php
@@ -114,7 +114,7 @@ final class RegistrationProcessorTest extends FunctionalTestCase
         $registration->setUser(new FrontendUser());
 
         $event = new SingleEvent();
-        $eventStart = new \DateTimeImmutable('2020-01-01 10:00:00');
+        $eventStart = new \DateTime('2020-01-01 10:00:00');
         $event->setStart($eventStart);
         $registration->setEvent($event);
 

--- a/Tests/Unit/Domain/Model/Event/EventDateTest.php
+++ b/Tests/Unit/Domain/Model/Event/EventDateTest.php
@@ -168,7 +168,7 @@ final class EventDateTest extends UnitTestCase
      */
     public function setStartSetsStart(): void
     {
-        $date = new \DateTimeImmutable();
+        $date = new \DateTime();
         $this->subject->setStart($date);
 
         self::assertSame($date, $this->subject->getStart());
@@ -197,7 +197,7 @@ final class EventDateTest extends UnitTestCase
      */
     public function setEndSetsEnd(): void
     {
-        $date = new \DateTimeImmutable();
+        $date = new \DateTime();
         $this->subject->setEnd($date);
 
         self::assertSame($date, $this->subject->getEnd());
@@ -226,7 +226,7 @@ final class EventDateTest extends UnitTestCase
      */
     public function setEarlyBirdDeadlineSetsEarlyBirdDeadline(): void
     {
-        $date = new \DateTimeImmutable();
+        $date = new \DateTime();
         $this->subject->setEarlyBirdDeadline($date);
 
         self::assertSame($date, $this->subject->getEarlyBirdDeadline());
@@ -255,7 +255,7 @@ final class EventDateTest extends UnitTestCase
      */
     public function setRegistrationDeadlineSetsRegistrationDeadline(): void
     {
-        $date = new \DateTimeImmutable();
+        $date = new \DateTime();
         $this->subject->setRegistrationDeadline($date);
 
         self::assertSame($date, $this->subject->getRegistrationDeadline());
@@ -551,7 +551,7 @@ final class EventDateTest extends UnitTestCase
      */
     public function setRegistrationStartSetsRegistrationStart(): void
     {
-        $date = new \DateTimeImmutable();
+        $date = new \DateTime();
         $this->subject->setRegistrationStart($date);
 
         self::assertSame($date, $this->subject->getRegistrationStart());

--- a/Tests/Unit/Domain/Model/Event/SingleEventTest.php
+++ b/Tests/Unit/Domain/Model/Event/SingleEventTest.php
@@ -145,7 +145,7 @@ final class SingleEventTest extends UnitTestCase
      */
     public function setStartSetsStart(): void
     {
-        $date = new \DateTimeImmutable();
+        $date = new \DateTime();
         $this->subject->setStart($date);
 
         self::assertSame($date, $this->subject->getStart());
@@ -174,7 +174,7 @@ final class SingleEventTest extends UnitTestCase
      */
     public function setEndSetsEnd(): void
     {
-        $date = new \DateTimeImmutable();
+        $date = new \DateTime();
         $this->subject->setEnd($date);
 
         self::assertSame($date, $this->subject->getEnd());
@@ -203,7 +203,7 @@ final class SingleEventTest extends UnitTestCase
      */
     public function setEarlyBirdDeadlineSetsEarlyBirdDeadline(): void
     {
-        $date = new \DateTimeImmutable();
+        $date = new \DateTime();
         $this->subject->setEarlyBirdDeadline($date);
 
         self::assertSame($date, $this->subject->getEarlyBirdDeadline());
@@ -232,7 +232,7 @@ final class SingleEventTest extends UnitTestCase
      */
     public function setRegistrationDeadlineSetsRegistrationDeadline(): void
     {
-        $date = new \DateTimeImmutable();
+        $date = new \DateTime();
         $this->subject->setRegistrationDeadline($date);
 
         self::assertSame($date, $this->subject->getRegistrationDeadline());
@@ -567,7 +567,7 @@ final class SingleEventTest extends UnitTestCase
      */
     public function setRegistrationStartSetsRegistrationStart(): void
     {
-        $date = new \DateTimeImmutable();
+        $date = new \DateTime();
         $this->subject->setRegistrationStart($date);
 
         self::assertSame($date, $this->subject->getRegistrationStart());

--- a/Tests/Unit/Service/PriceFinderTest.php
+++ b/Tests/Unit/Service/PriceFinderTest.php
@@ -53,6 +53,14 @@ final class PriceFinderTest extends UnitTestCase
     }
 
     /**
+     * @deprecated #1960 will be removed in seminars 6.0, use `DateTIme::createFromImmutable()` instead (PHP >= 7.3)
+     */
+    private function createFromImmutable(\DateTimeInterface $dateTime): \DateTime
+    {
+        return \DateTime::createFromFormat(\DateTimeInterface::ATOM, $dateTime->format(\DateTime::ATOM));
+    }
+
+    /**
      * @test
      */
     public function isSingleton(): void
@@ -82,7 +90,7 @@ final class PriceFinderTest extends UnitTestCase
         $event = new SingleEvent();
         $event->setStandardPrice(0.0);
         $earlyBirdDeadline = $this->now->modify('-1 day');
-        $event->setEarlyBirdDeadline($earlyBirdDeadline);
+        $event->setEarlyBirdDeadline($this->createFromImmutable($earlyBirdDeadline));
 
         $result = $this->subject->findApplicablePrices($event);
 
@@ -98,7 +106,7 @@ final class PriceFinderTest extends UnitTestCase
         $event = new SingleEvent();
         $event->setStandardPrice(0.0);
         $earlyBirdDeadline = $this->now->modify('+1 day');
-        $event->setEarlyBirdDeadline($earlyBirdDeadline);
+        $event->setEarlyBirdDeadline($this->createFromImmutable($earlyBirdDeadline));
 
         $result = $this->subject->findApplicablePrices($event);
 
@@ -114,7 +122,7 @@ final class PriceFinderTest extends UnitTestCase
         $event = new SingleEvent();
         $event->setStandardPrice(0.0);
         $earlyBirdDeadline = $this->now->modify('+1 day');
-        $event->setEarlyBirdDeadline($earlyBirdDeadline);
+        $event->setEarlyBirdDeadline($this->createFromImmutable($earlyBirdDeadline));
         $event->setEarlyBirdPrice(14.5);
 
         $result = $this->subject->findApplicablePrices($event);
@@ -156,7 +164,7 @@ final class PriceFinderTest extends UnitTestCase
     {
         $event = new SingleEvent();
         $earlyBirdDeadline = $this->now->modify('-1 day');
-        $event->setEarlyBirdDeadline($earlyBirdDeadline);
+        $event->setEarlyBirdDeadline($this->createFromImmutable($earlyBirdDeadline));
 
         $standardPriceAmount = 1.0;
         $earlyBirdPriceAmount = 2.0;
@@ -183,7 +191,7 @@ final class PriceFinderTest extends UnitTestCase
     public function findApplicablePricesForAllPricesAndEarlyBirdDeadlineNowReturnsNonEarlyBirdPrices(): void
     {
         $event = new SingleEvent();
-        $event->setEarlyBirdDeadline($this->now);
+        $event->setEarlyBirdDeadline($this->createFromImmutable($this->now));
 
         $standardPriceAmount = 1.0;
         $earlyBirdPriceAmount = 2.0;
@@ -211,7 +219,7 @@ final class PriceFinderTest extends UnitTestCase
     {
         $event = new SingleEvent();
         $earlyBirdDeadline = $this->now->modify('+1 day');
-        $event->setEarlyBirdDeadline($earlyBirdDeadline);
+        $event->setEarlyBirdDeadline($this->createFromImmutable($earlyBirdDeadline));
 
         $standardPriceAmount = 1.0;
         $earlyBirdPriceAmount = 2.0;
@@ -243,7 +251,7 @@ final class PriceFinderTest extends UnitTestCase
     {
         $event = new SingleEvent();
         $earlyBirdDeadline = $this->now->modify('+1 day');
-        $event->setEarlyBirdDeadline($earlyBirdDeadline);
+        $event->setEarlyBirdDeadline($this->createFromImmutable($earlyBirdDeadline));
 
         $standardPriceAmount = 1.0;
         $earlyBirdPriceAmount = 2.0;
@@ -265,7 +273,7 @@ final class PriceFinderTest extends UnitTestCase
     {
         $event = new SingleEvent();
         $earlyBirdDeadline = $this->now->modify('+1 day');
-        $event->setEarlyBirdDeadline($earlyBirdDeadline);
+        $event->setEarlyBirdDeadline($this->createFromImmutable($earlyBirdDeadline));
 
         $standardPriceAmount = 1.0;
         $specialPriceAmount = 3.0;
@@ -295,7 +303,7 @@ final class PriceFinderTest extends UnitTestCase
     {
         $event = new SingleEvent();
         $earlyBirdDeadline = $this->now->modify('+1 day');
-        $event->setEarlyBirdDeadline($earlyBirdDeadline);
+        $event->setEarlyBirdDeadline($this->createFromImmutable($earlyBirdDeadline));
 
         $standardPriceAmount = 1.0;
         $earlyBirdPriceAmount = 2.0;


### PR DESCRIPTION
Extbase cannot map `DateTimeImmutable` properties (at least not in TYPO3 10 LTS), and this breaks the FE editor.