### PR TITLE
[TASK] Hide duplicate labels from assitive technology

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   (#1825, #1830, #1848, #1855, #1861, #1871, #1873, #1886, #1889, #1890, #1892,
   #1893, #1896, #1898, #1899, #1902, #1906, #1914, #1920, #1932, #1942, #1944,
   #1952, #1953, #1957, #1962, #1966, #1967, #1968, #1974, #1977, #1979, #1982,
-  #1988, #2001, #2005, #2006, 2008)
+  #1988, #2001, #2005, #2006, #2008, #2009)
 - Add `Registration.hasSeparateBillingAddress` (#1821)
 - Add salutation-aware localization functionality (#1813, #1818, #1822)
 - Add a `PriceFinder` class (#1799)

--- a/Resources/Private/Templates/EventRegistration/New.html
+++ b/Resources/Private/Templates/EventRegistration/New.html
@@ -76,7 +76,7 @@
 
                 <f:if condition="{event.accommodationOptions}">
                     <div class="row mb-3">
-                        <div class="col-sm-2">
+                        <div class="col-sm-2" aria-hidden="true">
                             <f:translate key="{labelPrefix}.accommodationOptions"/>
                         </div>
                         <fieldset class="col-sm-10">
@@ -104,7 +104,7 @@
 
                 <f:if condition="{event.foodOptions}">
                     <div class="row mb-3">
-                        <div class="col-sm-2">
+                        <div class="col-sm-2" aria-hidden="true">
                             <f:translate key="{labelPrefix}.foodOptions"/>
                         </div>
                         <fieldset class="col-sm-10">


### PR DESCRIPTION
For assistive technology, we already have visually-hidden `legend`s for checkbox groups and should hence should hide the visible `label`s from assistive technologies in order to avoid duplicate labels.

This improves accessibility.

[ci skip]