### PR TITLE
[TASK] Stop using a salutation-aware translator where not necessary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   (#1825, #1830, #1848, #1855, #1861, #1871, #1873, #1886, #1889, #1890, #1892,
   #1893, #1896, #1898, #1899, #1902, #1906, #1914, #1920, #1932, #1942, #1944,
   #1952, #1953, #1957, #1962, #1966, #1967, #1968, #1974, #1977, #1979, #1982,
-  #1988, #2001, #2005, #2006, #2008, #2009)
+  #1988, #2001, #2005, #2006, #2008, #2009, #2011)
 - Add `Registration.hasSeparateBillingAddress` (#1821)
 - Add salutation-aware localization functionality (#1813, #1818, #1822)
 - Add a `PriceFinder` class (#1799)

--- a/Resources/Private/Templates/EventRegistration/Confirm.html
+++ b/Resources/Private/Templates/EventRegistration/Confirm.html
@@ -198,7 +198,7 @@
                         <f:if condition="{registration.billingCompany}">
                             <tr>
                                 <th scope="row">
-                                    <s:salutationAwareTranslate key="{labelPrefix}.billingCompany"/>
+                                    <f:translate key="{labelPrefix}.billingCompany"/>
                                 </th>
                                 <td>
                                     {registration.billingCompany}
@@ -209,7 +209,7 @@
                         <f:if condition="{registration.billingFullName}">
                             <tr>
                                 <th scope="row">
-                                    <s:salutationAwareTranslate key="{labelPrefix}.billingFullName"/>
+                                    <f:translate key="{labelPrefix}.billingFullName"/>
                                 </th>
                                 <td>
                                     {registration.billingFullName}
@@ -220,7 +220,7 @@
                         <f:if condition="{registration.billingStreetAddress}">
                             <tr>
                                 <th scope="row">
-                                    <s:salutationAwareTranslate key="{labelPrefix}.billingStreetAddress"/>
+                                    <f:translate key="{labelPrefix}.billingStreetAddress"/>
                                 </th>
                                 <td>
                                     {registration.billingStreetAddress -> f:format.nl2br()}
@@ -231,7 +231,7 @@
                         <f:if condition="{registration.billingZipCode}">
                             <tr>
                                 <th scope="row">
-                                    <s:salutationAwareTranslate key="{labelPrefix}.billingZipCode"/>
+                                    <f:translate key="{labelPrefix}.billingZipCode"/>
                                 </th>
                                 <td>
                                     {registration.billingZipCode}
@@ -242,7 +242,7 @@
                         <f:if condition="{registration.billingCity}">
                             <tr>
                                 <th scope="row">
-                                    <s:salutationAwareTranslate key="{labelPrefix}.billingCity"/>
+                                    <f:translate key="{labelPrefix}.billingCity"/>
                                 </th>
                                 <td>
                                     {registration.billingZipCode}
@@ -253,7 +253,7 @@
                         <f:if condition="{registration.billingCountry}">
                             <tr>
                                 <th scope="row">
-                                    <s:salutationAwareTranslate key="{labelPrefix}.billingCountry"/>
+                                    <f:translate key="{labelPrefix}.billingCountry"/>
                                 </th>
                                 <td>
                                     {registration.billingCountry}
@@ -264,7 +264,7 @@
                         <f:if condition="{registration.billingPhoneNumber}">
                             <tr>
                                 <th scope="row">
-                                    <s:salutationAwareTranslate key="{labelPrefix}.billingPhoneNumber"/>
+                                    <f:translate key="{labelPrefix}.billingPhoneNumber"/>
                                 </th>
                                 <td>
                                     {registration.billingPhoneNumber}
@@ -275,7 +275,7 @@
                         <f:if condition="{registration.billingEmailAddress}">
                             <tr>
                                 <th scope="row">
-                                    <s:salutationAwareTranslate key="{labelPrefix}.billingEmailAddress"/>
+                                    <f:translate key="{labelPrefix}.billingEmailAddress"/>
                                 </th>
                                 <td>
                                     {registration.billingEmailAddress}

--- a/Resources/Private/Templates/EventRegistration/New.html
+++ b/Resources/Private/Templates/EventRegistration/New.html
@@ -56,7 +56,7 @@
                 <div class="d-none tx-seminars-display-none" data-behavior="tx-seminars-attendees-names">
                     <div class="row mb-3">
                         <label for="{idPrefix}-attendeesNames" class="col-sm-2 col-form-label">
-                            <s:salutationAwareTranslate key="{labelPrefix}.attendeesNames"/>
+                            <f:translate key="{labelPrefix}.attendeesNames"/>
                         </label>
                         <div class="col-sm-10">
                             <f:form.textarea property="attendeesNames" id="{idPrefix}-attendeesNames"
@@ -259,7 +259,7 @@
 
                     <div class="row mb-3 ms-3">
                         <label for="{idPrefix}-billingCompany" class="col-sm-2 col-form-label">
-                            <s:salutationAwareTranslate key="{labelPrefix}.billingCompany"/>
+                            <f:translate key="{labelPrefix}.billingCompany"/>
                         </label>
                         <div class="col-sm-10">
                             <f:form.textfield property="billingCompany" id="{idPrefix}-billingCompany" maxlength="256"
@@ -272,7 +272,7 @@
 
                     <div class="row mb-3 ms-3">
                         <label for="{idPrefix}-billingFullName" class="col-sm-2 col-form-label">
-                            <s:salutationAwareTranslate key="{labelPrefix}.billingFullName"/>
+                            <f:translate key="{labelPrefix}.billingFullName"/>
                         </label>
                         <div class="col-sm-10">
                             <f:form.textfield property="billingFullName" id="{idPrefix}-billingFullName" maxlength="80"
@@ -285,7 +285,7 @@
 
                     <div class="row mb-3 ms-3">
                         <label for="{idPrefix}-billingStreetAddress" class="col-sm-2 col-form-label">
-                            <s:salutationAwareTranslate key="{labelPrefix}.billingStreetAddress"/>
+                            <f:translate key="{labelPrefix}.billingStreetAddress"/>
                         </label>
                         <div class="col-sm-10">
                             <f:form.textarea property="billingStreetAddress" id="{idPrefix}-billingStreetAddress"
@@ -299,7 +299,7 @@
 
                     <div class="row mb-3 ms-3">
                         <label for="{idPrefix}-billingZipCode" class="col-sm-2 col-form-label">
-                            <s:salutationAwareTranslate key="{labelPrefix}.billingZipCode"/>
+                            <f:translate key="{labelPrefix}.billingZipCode"/>
                         </label>
                         <div class="col-sm-10">
                             <f:form.textfield property="billingZipCode" id="{idPrefix}-billingZipCode" maxlength="20"
@@ -312,7 +312,7 @@
 
                     <div class="row mb-3 ms-3">
                         <label for="{idPrefix}-billingCity" class="col-sm-2 col-form-label">
-                            <s:salutationAwareTranslate key="{labelPrefix}.billingCity"/>
+                            <f:translate key="{labelPrefix}.billingCity"/>
                         </label>
                         <div class="col-sm-10">
                             <f:form.textfield property="billingCity" id="{idPrefix}-billingCity" maxlength="50"
@@ -325,7 +325,7 @@
 
                     <div class="row mb-3 ms-3">
                         <label for="{idPrefix}-billingCountry" class="col-sm-2 col-form-label">
-                            <s:salutationAwareTranslate key="{labelPrefix}.billingCountry"/>
+                            <f:translate key="{labelPrefix}.billingCountry"/>
                         </label>
                         <div class="col-sm-10">
                             <f:form.textfield property="billingCountry" id="{idPrefix}-billingCountry" maxlength="60"
@@ -338,7 +338,7 @@
 
                     <div class="row mb-3 ms-3">
                         <label for="{idPrefix}-billingPhoneNumber" class="col-sm-2 col-form-label">
-                            <s:salutationAwareTranslate key="{labelPrefix}.billingPhoneNumber"/>
+                            <f:translate key="{labelPrefix}.billingPhoneNumber"/>
                         </label>
                         <div class="col-sm-10">
                             <f:form.textfield property="billingPhoneNumber" id="{idPrefix}-billingPhoneNumber"
@@ -351,7 +351,7 @@
 
                     <div class="row mb-3 ms-3">
                         <label for="{idPrefix}-billingEmailAddress" class="col-sm-2 col-form-label">
-                            <s:salutationAwareTranslate key="{labelPrefix}.billingEmailAddress"/>
+                            <f:translate key="{labelPrefix}.billingEmailAddress"/>
                         </label>
                         <div class="col-sm-10">
                             <f:form.textfield property="billingEmailAddress" id="{idPrefix}-billingEmailAddress"


### PR DESCRIPTION
Using this translator has a performance penalty which we want to avoid.

(Also, using the standard Fluid translater will make the HTML templates a bit more compact.)

[ci skip]