### PR TITLE
[TASK] Make some registration form labels reusable

### DIFF
--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -2890,35 +2890,35 @@ Wir konnten dieser Veranstaltung nun fest zusagen.</target>
 				<source>Separate billing address</source>
 				<target>Separate Rechnungsadresse</target>
 			</trans-unit>
-			<trans-unit id="plugin.eventRegistration.property.billingCompany">
+			<trans-unit id="plugin.eventRegistration.property.company">
 				<source>Company</source>
 				<target>Firma</target>
 			</trans-unit>
-			<trans-unit id="plugin.eventRegistration.property.billingFullName">
+			<trans-unit id="plugin.eventRegistration.property.fullName">
 				<source>Full name</source>
 				<target>Vollständiger Name</target>
 			</trans-unit>
-			<trans-unit id="plugin.eventRegistration.property.billingStreetAddress">
+			<trans-unit id="plugin.eventRegistration.property.streetAddress">
 				<source>Street address</source>
 				<target>Straße und Hausnummer</target>
 			</trans-unit>
-			<trans-unit id="plugin.eventRegistration.property.billingZipCode">
+			<trans-unit id="plugin.eventRegistration.property.zipCode">
 				<source>ZIP code</source>
 				<target>PLZ</target>
 			</trans-unit>
-			<trans-unit id="plugin.eventRegistration.property.billingCity">
+			<trans-unit id="plugin.eventRegistration.property.city">
 				<source>City</source>
 				<target>Stadt</target>
 			</trans-unit>
-			<trans-unit id="plugin.eventRegistration.property.billingCountry">
+			<trans-unit id="plugin.eventRegistration.property.country">
 				<source>Country</source>
 				<target>Land</target>
 			</trans-unit>
-			<trans-unit id="plugin.eventRegistration.property.billingPhoneNumber">
+			<trans-unit id="plugin.eventRegistration.property.phoneNumber">
 				<source>Phone number</source>
 				<target>Telefonnummer</target>
 			</trans-unit>
-			<trans-unit id="plugin.eventRegistration.property.billingEmailAddress">
+			<trans-unit id="plugin.eventRegistration.property.emailAddress">
 				<source>Email address</source>
 				<target>E-Mail-Adresse</target>
 			</trans-unit>

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -2177,28 +2177,28 @@ This event now has been confirmed.</source>
 			<trans-unit id="plugin.eventRegistration.property.separateBillingAddress">
 				<source>Separate billing address</source>
 			</trans-unit>
-			<trans-unit id="plugin.eventRegistration.property.billingCompany">
+			<trans-unit id="plugin.eventRegistration.property.company">
 				<source>Company</source>
 			</trans-unit>
-			<trans-unit id="plugin.eventRegistration.property.billingFullName">
+			<trans-unit id="plugin.eventRegistration.property.fullName">
 				<source>Full name</source>
 			</trans-unit>
-			<trans-unit id="plugin.eventRegistration.property.billingStreetAddress">
+			<trans-unit id="plugin.eventRegistration.property.streetAddress">
 				<source>Street address</source>
 			</trans-unit>
-			<trans-unit id="plugin.eventRegistration.property.billingZipCode">
+			<trans-unit id="plugin.eventRegistration.property.zipCode">
 				<source>ZIP code</source>
 			</trans-unit>
-			<trans-unit id="plugin.eventRegistration.property.billingCity">
+			<trans-unit id="plugin.eventRegistration.property.city">
 				<source>City</source>
 			</trans-unit>
-			<trans-unit id="plugin.eventRegistration.property.billingCountry">
+			<trans-unit id="plugin.eventRegistration.property.country">
 				<source>Country</source>
 			</trans-unit>
-			<trans-unit id="plugin.eventRegistration.property.billingPhoneNumber">
+			<trans-unit id="plugin.eventRegistration.property.phoneNumber">
 				<source>Phone number</source>
 			</trans-unit>
-			<trans-unit id="plugin.eventRegistration.property.billingEmailAddress">
+			<trans-unit id="plugin.eventRegistration.property.emailAddress">
 				<source>Email address</source>
 			</trans-unit>
 			<trans-unit id="plugin.eventRegistration.property.registrationCheckboxes">

--- a/Resources/Private/Templates/EventRegistration/Confirm.html
+++ b/Resources/Private/Templates/EventRegistration/Confirm.html
@@ -211,7 +211,7 @@
                         <f:if condition="{registration.billingCompany}">
                             <tr>
                                 <th scope="row">
-                                    <f:translate key="{labelPrefix}.billingCompany"/>
+                                    <f:translate key="{labelPrefix}.company"/>
                                 </th>
                                 <td>
                                     {registration.billingCompany}
@@ -222,7 +222,7 @@
                         <f:if condition="{registration.billingFullName}">
                             <tr>
                                 <th scope="row">
-                                    <f:translate key="{labelPrefix}.billingFullName"/>
+                                    <f:translate key="{labelPrefix}.fullName"/>
                                 </th>
                                 <td>
                                     {registration.billingFullName}
@@ -233,7 +233,7 @@
                         <f:if condition="{registration.billingStreetAddress}">
                             <tr>
                                 <th scope="row">
-                                    <f:translate key="{labelPrefix}.billingStreetAddress"/>
+                                    <f:translate key="{labelPrefix}.streetAddress"/>
                                 </th>
                                 <td>
                                     {registration.billingStreetAddress -> f:format.nl2br()}
@@ -244,7 +244,7 @@
                         <f:if condition="{registration.billingZipCode}">
                             <tr>
                                 <th scope="row">
-                                    <f:translate key="{labelPrefix}.billingZipCode"/>
+                                    <f:translate key="{labelPrefix}.zipCode"/>
                                 </th>
                                 <td>
                                     {registration.billingZipCode}
@@ -255,7 +255,7 @@
                         <f:if condition="{registration.billingCity}">
                             <tr>
                                 <th scope="row">
-                                    <f:translate key="{labelPrefix}.billingCity"/>
+                                    <f:translate key="{labelPrefix}.city"/>
                                 </th>
                                 <td>
                                     {registration.billingZipCode}
@@ -266,7 +266,7 @@
                         <f:if condition="{registration.billingCountry}">
                             <tr>
                                 <th scope="row">
-                                    <f:translate key="{labelPrefix}.billingCountry"/>
+                                    <f:translate key="{labelPrefix}.country"/>
                                 </th>
                                 <td>
                                     {registration.billingCountry}
@@ -277,7 +277,7 @@
                         <f:if condition="{registration.billingPhoneNumber}">
                             <tr>
                                 <th scope="row">
-                                    <f:translate key="{labelPrefix}.billingPhoneNumber"/>
+                                    <f:translate key="{labelPrefix}.phoneNumber"/>
                                 </th>
                                 <td>
                                     {registration.billingPhoneNumber}
@@ -288,7 +288,7 @@
                         <f:if condition="{registration.billingEmailAddress}">
                             <tr>
                                 <th scope="row">
-                                    <f:translate key="{labelPrefix}.billingEmailAddress"/>
+                                    <f:translate key="{labelPrefix}.emailAddress"/>
                                 </th>
                                 <td>
                                     {registration.billingEmailAddress}

--- a/Resources/Private/Templates/EventRegistration/New.html
+++ b/Resources/Private/Templates/EventRegistration/New.html
@@ -287,7 +287,7 @@
 
                     <div class="row mb-3 ms-3">
                         <label for="{idPrefix}-billingCompany" class="col-sm-2 col-form-label">
-                            <f:translate key="{labelPrefix}.billingCompany"/>
+                            <f:translate key="{labelPrefix}.company"/>
                         </label>
                         <div class="col-sm-10">
                             <f:form.textfield property="billingCompany" id="{idPrefix}-billingCompany" maxlength="256"
@@ -300,7 +300,7 @@
 
                     <div class="row mb-3 ms-3">
                         <label for="{idPrefix}-billingFullName" class="col-sm-2 col-form-label">
-                            <f:translate key="{labelPrefix}.billingFullName"/>
+                            <f:translate key="{labelPrefix}.fullName"/>
                         </label>
                         <div class="col-sm-10">
                             <f:form.textfield property="billingFullName" id="{idPrefix}-billingFullName" maxlength="80"
@@ -313,7 +313,7 @@
 
                     <div class="row mb-3 ms-3">
                         <label for="{idPrefix}-billingStreetAddress" class="col-sm-2 col-form-label">
-                            <f:translate key="{labelPrefix}.billingStreetAddress"/>
+                            <f:translate key="{labelPrefix}.streetAddress"/>
                         </label>
                         <div class="col-sm-10">
                             <f:form.textarea property="billingStreetAddress" id="{idPrefix}-billingStreetAddress"
@@ -327,7 +327,7 @@
 
                     <div class="row mb-3 ms-3">
                         <label for="{idPrefix}-billingZipCode" class="col-sm-2 col-form-label">
-                            <f:translate key="{labelPrefix}.billingZipCode"/>
+                            <f:translate key="{labelPrefix}.zipCode"/>
                         </label>
                         <div class="col-sm-10">
                             <f:form.textfield property="billingZipCode" id="{idPrefix}-billingZipCode" maxlength="20"
@@ -340,7 +340,7 @@
 
                     <div class="row mb-3 ms-3">
                         <label for="{idPrefix}-billingCity" class="col-sm-2 col-form-label">
-                            <f:translate key="{labelPrefix}.billingCity"/>
+                            <f:translate key="{labelPrefix}.city"/>
                         </label>
                         <div class="col-sm-10">
                             <f:form.textfield property="billingCity" id="{idPrefix}-billingCity" maxlength="50"
@@ -353,7 +353,7 @@
 
                     <div class="row mb-3 ms-3">
                         <label for="{idPrefix}-billingCountry" class="col-sm-2 col-form-label">
-                            <f:translate key="{labelPrefix}.billingCountry"/>
+                            <f:translate key="{labelPrefix}.country"/>
                         </label>
                         <div class="col-sm-10">
                             <f:form.textfield property="billingCountry" id="{idPrefix}-billingCountry" maxlength="60"
@@ -366,7 +366,7 @@
 
                     <div class="row mb-3 ms-3">
                         <label for="{idPrefix}-billingPhoneNumber" class="col-sm-2 col-form-label">
-                            <f:translate key="{labelPrefix}.billingPhoneNumber"/>
+                            <f:translate key="{labelPrefix}.phoneNumber"/>
                         </label>
                         <div class="col-sm-10">
                             <f:form.textfield property="billingPhoneNumber" id="{idPrefix}-billingPhoneNumber"
@@ -379,7 +379,7 @@
 
                     <div class="row mb-3 ms-3">
                         <label for="{idPrefix}-billingEmailAddress" class="col-sm-2 col-form-label">
-                            <f:translate key="{labelPrefix}.billingEmailAddress"/>
+                            <f:translate key="{labelPrefix}.emailAddress"/>
                         </label>
                         <div class="col-sm-10">
                             <f:form.textfield property="billingEmailAddress" id="{idPrefix}-billingEmailAddress"


### PR DESCRIPTION
Now can use the label e.g., for the full name of the billing address also for the full name of the FE user data.

[ci skip]