### PR TITLE
[TASK] Undo a DB schema change

### DIFF
--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -357,7 +357,7 @@ CREATE TABLE tx_seminars_attendances (
     user int(11) unsigned DEFAULT '0' NOT NULL,
     seminar int(11) unsigned DEFAULT '0' NOT NULL,
     registration_queue tinyint(4) unsigned DEFAULT '0' NOT NULL,
-    price tinytext,
+    price text,
     price_code tinytext,
     seats int(11) unsigned DEFAULT '0' NOT NULL,
     registered_themselves tinyint(1) unsigned DEFAULT '0' NOT NULL,


### PR DESCRIPTION
This undoes part of 6dc3e999740611cb662445f71d78b9ef18f3e5cd.

The DB schema change is not really required, and we should avoid DB schema changes as much as possible in minor releases. Let's have this in #2044 for seminars 5.0 instead.