### PR TITLE
[BUGFIX] Use the first applicable price if the price field is disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   #1893, #1896, #1898, #1899, #1902, #1906, #1914, #1920, #1932, #1942, #1944,
   #1952, #1953, #1957, #1962, #1966, #1967, #1968, #1974, #1977, #1979, #1982,
   #1988, #2001, #2005, #2006, #2008, #2009, #2011, #2017, #2018, #2019, #2030,
-  #2031, #2036, #2040, #2048, #2058)
+  #2031, #2036, #2040, #2048, #2058, #2060)
 - Add `Registration.hasSeparateBillingAddress` (#1821)
 - Add salutation-aware localization functionality (#1813, #1818, #1822)
 - Add a `PriceFinder` class (#1799)

--- a/Classes/Controller/EventRegistrationController.php
+++ b/Classes/Controller/EventRegistrationController.php
@@ -8,6 +8,7 @@ use OliverKlee\Seminars\Domain\Model\Event\Event;
 use OliverKlee\Seminars\Domain\Model\Event\EventDate;
 use OliverKlee\Seminars\Domain\Model\Event\EventDateInterface;
 use OliverKlee\Seminars\Domain\Model\Event\SingleEvent;
+use OliverKlee\Seminars\Domain\Model\Price;
 use OliverKlee\Seminars\Domain\Model\Registration\Registration;
 use OliverKlee\Seminars\Service\OneTimeAccountConnector;
 use OliverKlee\Seminars\Service\PriceFinder;
@@ -153,11 +154,15 @@ class EventRegistrationController extends ActionController
 
         $this->view->assign('event', $event);
 
+        $applicablePrices = $this->priceFinder->findApplicablePrices($event);
         if ($registration instanceof Registration) {
             $newRegistration = $registration;
         } else {
             $newRegistration = GeneralUtility::makeInstance(Registration::class);
             $newRegistration->setRegisteredThemselves((bool)($this->settings['registerThemselvesDefault'] ?? true));
+            $firstPrice = \array_values($applicablePrices)[0] ?? null;
+            $firstPriceCode = $firstPrice instanceof Price ? $firstPrice->getPriceCode() : Price::PRICE_STANDARD;
+            $newRegistration->setPriceCode($firstPriceCode);
         }
         $this->view->assign('registration', $newRegistration);
 
@@ -167,7 +172,7 @@ class EventRegistrationController extends ActionController
             $maximumBookableSeats = \min($maximumBookableSeats, $vacancies);
         }
         $this->view->assign('maximumBookableSeats', $maximumBookableSeats);
-        $this->view->assign('applicablePrices', $this->priceFinder->findApplicablePrices($event));
+        $this->view->assign('applicablePrices', $applicablePrices);
     }
 
     /**

--- a/Resources/Private/Templates/EventRegistration/Confirm.html
+++ b/Resources/Private/Templates/EventRegistration/Confirm.html
@@ -177,7 +177,7 @@
                         </tr>
                     </f:if>
 
-                    <f:if condition="{registration.priceCode}">
+                    <f:if condition="{selectedPrice}">
                         <tr>
                             <th scope="row">
                                 <f:translate key="{labelPrefix}.priceCode"/>
@@ -485,7 +485,7 @@
                         </td>
                     </tr>
 
-                    <f:if condition="{registration.priceCode}">
+                    <f:if condition="{selectedPrice}">
                         <tr>
                             <th scope="row">
                                 <f:translate key="{labelPrefix}.priceCode"/>
@@ -531,8 +531,10 @@
                 <f:form.hidden property="knownFrom"/>
                 <f:form.hidden property="comments"/>
                 <f:form.hidden property="priceCode"/>
-                <f:form.hidden property="humanReadablePrice"
-                               value="{f:translate(key: selectedPrice.labelKey)} {f:render(partial: 'Price', arguments: {amount: registration.totalPrice})}"/>
+                <f:if condition="{selectedPrice}">
+                    <f:form.hidden property="humanReadablePrice"
+                                   value="{f:translate(key: selectedPrice.labelKey)} {f:render(partial: 'Price', arguments: {amount: registration.totalPrice})}"/>
+                </f:if>
                 <f:form.hidden property="paymentMethod"/>
                 <f:form.hidden property="separateBillingAddress"/>
                 <f:form.hidden property="billingCompany"/>

--- a/Resources/Private/Templates/EventRegistration/New.html
+++ b/Resources/Private/Templates/EventRegistration/New.html
@@ -294,24 +294,29 @@
                 </legend>
 
                 <oelib:isFieldEnabled fieldName="priceCode">
-                    <div class="row mb-3">
-                        <label for="{idPrefix}-priceCode" class="col-sm-2 col-form-label">
-                            <f:translate key="{labelPrefix}.priceCode"/>
-                        </label>
-                        <div class="col-sm-10">
-                            <f:form.select property="priceCode" id="{idPrefix}-priceCode"
-                                           class="form-select" errorClass="is-invalid">
-                                <f:for each="{applicablePrices}" as="price">
-                                    <f:form.select.option value="{price.priceCode}">
-                                        <f:translate key="{price.labelKey}"/>
-                                        <f:render partial="Price" arguments="{amount: price.amount}"/>
-                                    </f:form.select.option>
-                                </f:for>
-                            </f:form.select>
-                            <f:render partial="EventRegistration/ValidationResult"
-                                      arguments="{property: 'priceCode'}"/>
+                    <f:then>
+                        <div class="row mb-3">
+                            <label for="{idPrefix}-priceCode" class="col-sm-2 col-form-label">
+                                <f:translate key="{labelPrefix}.priceCode"/>
+                            </label>
+                            <div class="col-sm-10">
+                                <f:form.select property="priceCode" id="{idPrefix}-priceCode"
+                                               class="form-select" errorClass="is-invalid">
+                                    <f:for each="{applicablePrices}" as="price">
+                                        <f:form.select.option value="{price.priceCode}">
+                                            <f:translate key="{price.labelKey}"/>
+                                            <f:render partial="Price" arguments="{amount: price.amount}"/>
+                                        </f:form.select.option>
+                                    </f:for>
+                                </f:form.select>
+                                <f:render partial="EventRegistration/ValidationResult"
+                                          arguments="{property: 'priceCode'}"/>
+                            </div>
                         </div>
-                    </div>
+                    </f:then>
+                    <f:else>
+                        <f:form.hidden property="priceCode"/>
+                    </f:else>
                 </oelib:isFieldEnabled>
 
                 <f:if condition="{event.paymentMethods}">

--- a/Tests/Unit/Controller/EventRegistrationControllerTest.php
+++ b/Tests/Unit/Controller/EventRegistrationControllerTest.php
@@ -401,6 +401,26 @@ final class EventRegistrationControllerTest extends UnitTestCase
     /**
      * @test
      */
+    public function newActionWithoutRegistrationPassesUsesFirstApplicablePriceForNewRegistration(): void
+    {
+        $event = new SingleEvent();
+        $price1 = new Price(100.0, 'labelKey', Price::PRICE_EARLY_BIRD);
+        $price2 = new Price(75.0, 'labelKey', Price::PRICE_SPECIAL_EARLY_BIRD);
+        $applicablePrices = [Price::PRICE_EARLY_BIRD => $price1, Price::PRICE_SPECIAL_EARLY_BIRD => $price2];
+        $this->priceFinderMock->expects(self::once())->method('findApplicablePrices')->with($event)
+            ->willReturn($applicablePrices);
+
+        $registration = new Registration();
+        GeneralUtility::addInstance(Registration::class, $registration);
+
+        $this->subject->newAction($event);
+
+        self::assertSame($price1->getPriceCode(), $registration->getPriceCode());
+    }
+
+    /**
+     * @test
+     */
     public function newActionWithoutSettingForMaximumBookableSeatsAndUnlimitedVacanciesPassesTenToView(): void
     {
         $event = new SingleEvent();


### PR DESCRIPTION
This fixes a crash on the confirmation page.

Fixes #2059