### PR TITLE
[TASK] Deprecate the `charsetForCsv` setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Use a different hue of orange in the extension icon (#2070, #2071)
 
 ### Deprecated
+- Deprecate the `charsetForCsv` setting (#2108)
 
 ### Removed
 

--- a/Classes/Configuration/CsvExportConfigurationCheck.php
+++ b/Classes/Configuration/CsvExportConfigurationCheck.php
@@ -24,6 +24,9 @@ class CsvExportConfigurationCheck extends AbstractConfigurationCheck
         $this->checkShowAttendancesOnRegistrationQueueInEmailCsv();
     }
 
+    /**
+     * @deprecated #2107 will be removed in seminars 5.0
+     */
     private function checkCharsetForCsv(): void
     {
         $this->checkForNonEmptyString(

--- a/Classes/Csv/CsvDownloader.php
+++ b/Classes/Csv/CsvDownloader.php
@@ -73,6 +73,7 @@ class CsvDownloader
                     $result = $this->addErrorHeaderAndReturnMessage(self::NOT_FOUND);
             }
 
+            // @deprecated #2107 will be removed in seminars 5.0
             $resultCharset = strtolower($this->configuration->getAsString('charsetForCsv'));
             if ($resultCharset !== 'utf-8') {
                 $result = (new CharsetConverter())->conv($result, 'utf-8', $resultCharset);

--- a/Classes/Csv/CsvResponse.php
+++ b/Classes/Csv/CsvResponse.php
@@ -20,6 +20,7 @@ class CsvResponse extends Response
         $body->rewind();
         parent::__construct($body);
 
+        // @deprecated #2107 will be removed in seminars 5.0
         $charset = ConfigurationRegistry::get('plugin.tx_seminars')->getAsString('charsetForCsv');
 
         $this->headers['Content-Type'][] = 'text/csv; header=present; charset=' . $charset;

--- a/Configuration/TypoScript/PluginShared.typoscript
+++ b/Configuration/TypoScript/PluginShared.typoscript
@@ -105,6 +105,7 @@ plugin.tx_seminars {
 
   # The charset for the CSV export, e.g., utf-8, iso-8859-1 or iso-8859-15.
   # The default is iso-9959-15 because Excel has problems with importing utf-8.
+  # @deprecated #2107 will be removed in seminars 5.0
   charsetForCsv = iso-8859-15
 
   # the filename proposed for CSV export of event lists

--- a/Documentation/DE/Referenz/SetupCommonForFront-endPlug-inAndBack-endModuleInPlugintxSeminars/Index.rst
+++ b/Documentation/DE/Referenz/SetupCommonForFront-endPlug-inAndBack-endModuleInPlugintxSeminars/Index.rst
@@ -617,6 +617,7 @@ only be configured using your TypoScript setup, but not via flexforms.
          The charset for the CSV export, e.g., utf-8, iso-8859-1 or
          iso-8859-15. The default is iso-9959-15 because Excel has problems
          with importing utf-8.
+         @deprecated #2107 will be removed in seminars 5.0
 
    Standardwert
          Iso-8859-15

--- a/Documentation/EN/Reference/SetupCommonForFront-endPlug-inAndBack-endModuleInPlugintxSeminars/Index.rst
+++ b/Documentation/EN/Reference/SetupCommonForFront-endPlug-inAndBack-endModuleInPlugintxSeminars/Index.rst
@@ -616,6 +616,7 @@ only be configured using your TypoScript setup, but not via flexforms.
          The charset for the CSV export, e.g., utf-8, iso-8859-1 or
          iso-8859-15. The default is iso-9959-15 because Excel has problems
          with importing utf-8.
+         @deprecated #2107 will be removed in seminars 5.0
 
    Default
          Iso-8859-15


### PR DESCRIPTION
The will always be UTF-8 in seminars 5.0.

Fixes #2106

[ci skip]