### PR TITLE
[FEATURE] Display icons for registrations in the BE module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Add more `Event` properties and repository methods (#2089, #2124)
 - Add a rewritten BE module for TYPO3 >= 10LTS
   (#2074, #2075, #2076, #2077, #2078, #2084, #2085, #2088, #2094, #2095, #2097
-  #2100, #2105, #2109, #2113, #2114, #2116, #2120, #2122, #2123)
+  #2100, #2105, #2109, #2113, #2114, #2116, #2120, #2122, #2123, #2125, #2126)
 - Add an SVG icon for the BE module (#2071)
 
 ### Changed

--- a/Classes/Controller/BackEnd/RegistrationController.php
+++ b/Classes/Controller/BackEnd/RegistrationController.php
@@ -48,11 +48,13 @@ class RegistrationController extends AbstractController
         if ($event instanceof EventDateInterface) {
             $eventUid = $event->getUid();
             $regularRegistrations = $this->registrationRepository->findRegularRegistrationsByEvent($eventUid);
+            $this->registrationRepository->enrichWithRawData($regularRegistrations);
             $this->view->assign('regularRegistrations', $regularRegistrations);
 
             if ($event->hasWaitingList()) {
                 $waitingListRegistrations = $this->registrationRepository
                     ->findWaitingListRegistrationsByEvent($eventUid);
+                $this->registrationRepository->enrichWithRawData($waitingListRegistrations);
                 $this->view->assign('waitingListRegistrations', $waitingListRegistrations);
             }
         }

--- a/Resources/Private/Partials/BackEnd/EventList.html
+++ b/Resources/Private/Partials/BackEnd/EventList.html
@@ -9,10 +9,9 @@
     <table class="table table-hover table-striped">
         <thead>
             <tr>
-                <th scope="col" class="nowrap">
+                <th scope="col" colspan="2" class="nowrap">
                     <f:translate key="{propertyLabelPrefix}.uid"/>
                 </th>
-                <th scope="col" class="col-icon nowrap">&nbsp;</th>
                 <th scope="col" class="col-title col-responsive">
                     <f:translate key="{propertyLabelPrefix}.internalTitle"/>
                 </th>

--- a/Resources/Private/Partials/BackEnd/RegistrationList.html
+++ b/Resources/Private/Partials/BackEnd/RegistrationList.html
@@ -1,10 +1,13 @@
-<html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers" data-namespace-typo3-fluid="true">
+<html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
+      xmlns:core="http://typo3.org/ns/TYPO3/CMS/Core/ViewHelpers"
+      data-namespace-typo3-fluid="true">
+    <f:variable name="tableName" value="tx_seminars_attendances"/>
     <f:variable name="propertyLabelPrefix" value="backEndModule.events.property"/>
 
     <table class="table table-hover table-striped">
         <thead>
             <tr>
-                <th scope="col" class="nowrap">
+                <th scope="col" colspan="2" class="nowrap">
                     <f:translate key="{propertyLabelPrefix}.uid"/>
                 </th>
                 <th scope="col" class="col-title col-responsive">
@@ -20,6 +23,9 @@
                 <tr>
                     <td class="text-end text-right nowrap">
                         {registration.uid}
+                    </td>
+                    <td class="col-icon nowrap">
+                        <core:iconForRecord table="{tableName}" row="{registration.rawData}"/>
                     </td>
                     <td class="col-title col-responsive">
                         {registration.user.name}

--- a/Tests/Unit/Controller/BackEnd/RegistrationControllerTest.php
+++ b/Tests/Unit/Controller/BackEnd/RegistrationControllerTest.php
@@ -254,6 +254,24 @@ final class RegistrationControllerTest extends UnitTestCase
     /**
      * @test
      */
+    public function showForEventActionEnrichesRegularRegistrationsWithRawData(): void
+    {
+        $eventUid = 5;
+        $event = $this->createMock(SingleEvent::class);
+        $event->method('getUid')->willReturn($eventUid);
+        $regularRegistrations = [new Registration()];
+
+        $this->registrationRepositoryMock->expects(self::once())->method('findRegularRegistrationsByEvent')
+            ->with($eventUid)->willReturn($regularRegistrations);
+        $this->registrationRepositoryMock->expects(self::once())->method('enrichWithRawData')
+            ->with($regularRegistrations);
+
+        $this->subject->showForEventAction($event);
+    }
+
+    /**
+     * @test
+     */
     public function showForEventActionForEventWithWaitingListPassesWaitingRegistrationsForProvidedEventToView(): void
     {
         $eventUid = 5;
@@ -273,6 +291,25 @@ final class RegistrationControllerTest extends UnitTestCase
                 ['regularRegistrations', self::anything()],
                 ['waitingListRegistrations', $waitingListRegistrations]
             );
+
+        $this->subject->showForEventAction($event);
+    }
+
+    /**
+     * @test
+     */
+    public function showForEventActionForEventWithWaitingListEnrichesWaitingListRegistrationsWithRawData(): void
+    {
+        $eventUid = 5;
+        $event = $this->createMock(SingleEvent::class);
+        $event->method('getUid')->willReturn($eventUid);
+        $event->method('hasWaitingList')->willReturn(true);
+        $waitingListRegistrations = [new Registration()];
+
+        $this->registrationRepositoryMock->expects(self::once())->method('findWaitingListRegistrationsByEvent')
+            ->with($eventUid)->willReturn($waitingListRegistrations);
+        $this->registrationRepositoryMock->expects(self::exactly(2))->method('enrichWithRawData')
+            ->withConsecutive([self::anything()], [$waitingListRegistrations]);
 
         $this->subject->showForEventAction($event);
     }


### PR DESCRIPTION
Also use the UID column header for both the UID as well as the icon in order to save horizontal screen space.