### PR TITLE
[TASK] Always use UTF-8 for the CSV export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Added
 
 ### Changed
+- !!! Switch the CSV export to always use UTF-8 (#2181)
 - !!! Stop allowing single events as topics for date records (#2180)
 - Require oelib >= 5.0.1 (#2178)
 - Require feuserextrafields >= 5.2.1 (#2178)
@@ -16,6 +17,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Deprecated
 
 ### Removed
+- Drop the the `charsetForCsv` setting (#2181)
 - Drop obsolete package conflicts (#2171)
 - Drop `.htaccess` files (#2164)
 - Drop support for Emogrifier 4 and 5 (#2163)

--- a/Classes/Configuration/CsvExportConfigurationCheck.php
+++ b/Classes/Configuration/CsvExportConfigurationCheck.php
@@ -13,7 +13,6 @@ class CsvExportConfigurationCheck extends AbstractConfigurationCheck
 {
     protected function checkAllConfigurationValues(): void
     {
-        $this->checkCharsetForCsv();
         $this->checkFilenameForEventsCsv();
         $this->checkFilenameForRegistrationsCsv();
         $this->checkFieldsFromEventsForCsv();
@@ -22,18 +21,6 @@ class CsvExportConfigurationCheck extends AbstractConfigurationCheck
         $this->checkFieldsFromFeUserForEmailCsv();
         $this->checkFieldsFromAttendanceForEmailCsv();
         $this->checkShowAttendancesOnRegistrationQueueInEmailCsv();
-    }
-
-    /**
-     * @deprecated #2107 will be removed in seminars 5.0
-     */
-    private function checkCharsetForCsv(): void
-    {
-        $this->checkForNonEmptyString(
-            'charsetForCsv',
-            'This value specifies the charset to use for the CSV export.
-            If this value is not set, no charset information will be provided for CSV downloads.'
-        );
     }
 
     private function checkFilenameForEventsCsv(): void

--- a/Classes/Csv/CsvDownloader.php
+++ b/Classes/Csv/CsvDownloader.php
@@ -9,7 +9,6 @@ use OliverKlee\Oelib\Http\HeaderProxyFactory;
 use OliverKlee\Oelib\Interfaces\Configuration;
 use OliverKlee\Seminars\Localization\TranslateTrait;
 use OliverKlee\Seminars\OldModel\LegacyEvent;
-use TYPO3\CMS\Core\Charset\CharsetConverter;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
@@ -71,12 +70,6 @@ class CsvDownloader
                     break;
                 default:
                     $result = $this->addErrorHeaderAndReturnMessage(self::NOT_FOUND);
-            }
-
-            // @deprecated #2107 will be removed in seminars 5.0
-            $resultCharset = strtolower($this->configuration->getAsString('charsetForCsv'));
-            if ($resultCharset !== 'utf-8') {
-                $result = (new CharsetConverter())->conv($result, 'utf-8', $resultCharset);
             }
         } catch (\Exception $exception) {
             HeaderProxyFactory::getInstance()->getHeaderProxy()->addHeader('Status: 500 Internal Server Error');
@@ -255,9 +248,7 @@ class CsvDownloader
     private function setPageTypeAndDisposition(string $csvFileName): void
     {
         $headerProxy = HeaderProxyFactory::getInstance()->getHeaderProxy();
-        $headerProxy->addHeader(
-            'Content-type: text/csv; header=present; charset=' . $this->configuration->getAsString('charsetForCsv')
-        );
+        $headerProxy->addHeader('Content-type: text/csv; header=present; charset=utf-8');
         $headerProxy->addHeader('Content-disposition: attachment; filename=' . $csvFileName);
     }
 

--- a/Classes/Csv/CsvResponse.php
+++ b/Classes/Csv/CsvResponse.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace OliverKlee\Seminars\Csv;
 
-use OliverKlee\Oelib\Configuration\ConfigurationRegistry;
 use TYPO3\CMS\Core\Http\Response;
 use TYPO3\CMS\Core\Http\Stream;
 
@@ -20,10 +19,7 @@ class CsvResponse extends Response
         $body->rewind();
         parent::__construct($body);
 
-        // @deprecated #2107 will be removed in seminars 5.0
-        $charset = ConfigurationRegistry::get('plugin.tx_seminars')->getAsString('charsetForCsv');
-
-        $this->headers['Content-Type'][] = 'text/csv; header=present; charset=' . $charset;
+        $this->headers['Content-Type'][] = 'text/csv; header=present; charset=utf-8';
         $this->lowercasedHeaderNames['content-type'] = 'Content-Type';
 
         $contentDisposition = 'attachment';

--- a/Configuration/TypoScript/PluginShared.typoscript
+++ b/Configuration/TypoScript/PluginShared.typoscript
@@ -103,11 +103,6 @@ plugin.tx_seminars {
   # whether events that have no standard price set should have "to be announced" as price instead of "free"
   showToBeAnnouncedForEmptyPrice = 0
 
-  # The charset for the CSV export, e.g., utf-8, iso-8859-1 or iso-8859-15.
-  # The default is iso-9959-15 because Excel has problems with importing utf-8.
-  # @deprecated #2107 will be removed in seminars 5.0
-  charsetForCsv = iso-8859-15
-
   # the filename proposed for CSV export of event lists
   filenameForEventsCsv = events.csv
 

--- a/Documentation/Reference/SetupCommonForFront-endPlug-inAndBack-endModuleInPlugintxSeminars/Index.rst
+++ b/Documentation/Reference/SetupCommonForFront-endPlug-inAndBack-endModuleInPlugintxSeminars/Index.rst
@@ -607,24 +607,6 @@ only be configured using your TypoScript setup, but not via flexforms.
 .. container:: table-row
 
    Property
-         charsetForCsv
-
-   Data type
-         string
-
-   Description
-         The charset for the CSV export, e.g., utf-8, iso-8859-1 or
-         iso-8859-15. The default is iso-9959-15 because Excel has problems
-         with importing utf-8.
-         @deprecated #2107 will be removed in seminars 5.0
-
-   Default
-         Iso-8859-15
-
-
-.. container:: table-row
-
-   Property
          filenameForEventsCsv
 
    Data type

--- a/Tests/LegacyUnit/Csv/AbstractRegistrationListViewTest.php
+++ b/Tests/LegacyUnit/Csv/AbstractRegistrationListViewTest.php
@@ -88,7 +88,6 @@ final class AbstractRegistrationListViewTest extends TestCase
         $configurationRegistry = ConfigurationRegistry::getInstance();
         $configurationRegistry->set('plugin', new DummyConfiguration());
         $this->configuration = new DummyConfiguration();
-        $this->configuration->setAsString('charsetForCsv', 'utf-8');
         $configurationRegistry->set('plugin.tx_seminars', $this->configuration);
 
         $this->pageUid = $this->testingFramework->createSystemFolder();

--- a/Tests/LegacyUnit/Csv/CsvDownloaderTest.php
+++ b/Tests/LegacyUnit/Csv/CsvDownloaderTest.php
@@ -45,7 +45,6 @@ final class CsvDownloaderTest extends TestCase
     protected function setUp(): void
     {
         $this->unifyTestingEnvironment();
-        $this->configuration->setAsString('charsetForCsv', 'utf-8');
 
         $this->testingFramework = new TestingFramework('tx_seminars');
 
@@ -666,7 +665,7 @@ final class CsvDownloaderTest extends TestCase
     /**
      * @test
      */
-    public function mainCanKeepEventDataInUtf8(): void
+    public function mainKeepsEventDataInUtf8(): void
     {
         $this->configuration->setAsString('fieldsFromEventsForCsv', 'title');
 
@@ -690,33 +689,7 @@ final class CsvDownloaderTest extends TestCase
     /**
      * @test
      */
-    public function mainCanChangeEventDataToIso885915(): void
-    {
-        $this->configuration->setAsString('fieldsFromEventsForCsv', 'title');
-
-        $this->testingFramework->createRecord(
-            'tx_seminars_seminars',
-            [
-                'pid' => $this->pid,
-                'title' => 'Schöne Bären führen',
-            ]
-        );
-
-        $GLOBALS['_GET']['table'] = 'tx_seminars_seminars';
-        $GLOBALS['_GET']['pid'] = $this->pid;
-
-        $this->configuration->setAsString('charsetForCsv', 'iso-8859-15');
-
-        self::assertStringContainsString(
-            'Sch' . chr(246) . 'ne B' . chr(228) . 'ren f' . chr(252) . 'hren',
-            $this->subject->main()
-        );
-    }
-
-    /**
-     * @test
-     */
-    public function mainCanKeepRegistrationDataInUtf8(): void
+    public function mainKeepsRegistrationDataInUtf8(): void
     {
         $this->configuration->setAsString('fieldsFromFeUserForCsv', '');
         $this->configuration->setAsString('fieldsFromAttendanceForCsv', 'title');
@@ -736,35 +709,6 @@ final class CsvDownloaderTest extends TestCase
 
         self::assertStringContainsString(
             'Schöne Bären führen',
-            $this->subject->main()
-        );
-    }
-
-    /**
-     * @test
-     */
-    public function mainCanChangeRegistrationDataToIso885915(): void
-    {
-        $this->configuration->setAsString('fieldsFromFeUserForCsv', '');
-        $this->configuration->setAsString('fieldsFromAttendanceForCsv', 'title');
-
-        $this->testingFramework->createRecord(
-            'tx_seminars_attendances',
-            [
-                'pid' => $this->pid,
-                'title' => 'Schöne Bären führen',
-                'seminar' => $this->eventUid,
-                'user' => $this->testingFramework->createFrontEndUser(),
-            ]
-        );
-
-        $GLOBALS['_GET']['table'] = 'tx_seminars_attendances';
-        $GLOBALS['_GET']['pid'] = $this->pid;
-
-        $this->configuration->setAsString('charsetForCsv', 'iso-8859-15');
-
-        self::assertStringContainsString(
-            'Sch' . chr(246) . 'ne B' . chr(228) . 'ren f' . chr(252) . 'hren',
             $this->subject->main()
         );
     }

--- a/Tests/LegacyUnit/Csv/DownloadRegistrationListViewTest.php
+++ b/Tests/LegacyUnit/Csv/DownloadRegistrationListViewTest.php
@@ -47,7 +47,6 @@ final class DownloadRegistrationListViewTest extends TestCase
         $configurationRegistry = ConfigurationRegistry::getInstance();
         $configurationRegistry->set('plugin', new DummyConfiguration());
         $this->configuration = new DummyConfiguration();
-        $this->configuration->setAsString('charsetForCsv', 'utf-8');
         $configurationRegistry->set('plugin.tx_seminars', $this->configuration);
 
         $pageUid = $this->testingFramework->createSystemFolder();

--- a/Tests/LegacyUnit/Csv/EmailRegistrationListViewTest.php
+++ b/Tests/LegacyUnit/Csv/EmailRegistrationListViewTest.php
@@ -47,7 +47,6 @@ final class EmailRegistrationListViewTest extends TestCase
         $configurationRegistry = ConfigurationRegistry::getInstance();
         $configurationRegistry->set('plugin', new DummyConfiguration());
         $this->configuration = new DummyConfiguration();
-        $this->configuration->setAsString('charsetForCsv', 'utf-8');
         $configurationRegistry->set('plugin.tx_seminars', $this->configuration);
 
         $pageUid = $this->testingFramework->createSystemFolder();

--- a/Tests/LegacyUnit/Csv/EventListViewTest.php
+++ b/Tests/LegacyUnit/Csv/EventListViewTest.php
@@ -49,7 +49,6 @@ final class EventListViewTest extends TestCase
         $configurationRegistry = ConfigurationRegistry::getInstance();
         $configurationRegistry->set('plugin', new DummyConfiguration());
         $this->configuration = new DummyConfiguration();
-        $this->configuration->setAsString('charsetForCsv', 'utf-8');
         $configurationRegistry->set('plugin.tx_seminars', $this->configuration);
 
         $this->subject = new EventListView();

--- a/Tests/Unit/Controller/BackEnd/EventControllerTest.php
+++ b/Tests/Unit/Controller/BackEnd/EventControllerTest.php
@@ -6,8 +6,6 @@ namespace OliverKlee\Seminars\Tests\Unit\Controller\BackEnd;
 
 use Nimut\TestingFramework\MockObject\AccessibleMockObjectInterface;
 use Nimut\TestingFramework\TestCase\UnitTestCase;
-use OliverKlee\Oelib\Configuration\ConfigurationRegistry;
-use OliverKlee\Oelib\Configuration\DummyConfiguration;
 use OliverKlee\Seminars\BackEnd\Permissions;
 use OliverKlee\Seminars\Controller\BackEnd\EventController;
 use OliverKlee\Seminars\Csv\CsvDownloader;
@@ -89,14 +87,11 @@ final class EventControllerTest extends UnitTestCase
 
         $this->csvDownloaderMock = $this->createMock(CsvDownloader::class);
         GeneralUtility::addInstance(CsvDownloader::class, $this->csvDownloaderMock);
-        ConfigurationRegistry::getInstance()
-            ->set('plugin.tx_seminars', new DummyConfiguration(['charsetForCsv' => 'utf-8']));
     }
 
     protected function tearDown(): void
     {
         unset($GLOBALS['_GET']['id'], $GLOBALS['_GET']['pid'], $GLOBALS['_GET']['table'], $GLOBALS['_POST']['id']);
-        ConfigurationRegistry::purgeInstance();
         GeneralUtility::purgeInstances();
 
         parent::tearDown();

--- a/Tests/Unit/Controller/BackEnd/RegistrationControllerTest.php
+++ b/Tests/Unit/Controller/BackEnd/RegistrationControllerTest.php
@@ -6,8 +6,6 @@ namespace OliverKlee\Seminars\Tests\Unit\Controller\BackEnd;
 
 use Nimut\TestingFramework\MockObject\AccessibleMockObjectInterface;
 use Nimut\TestingFramework\TestCase\UnitTestCase;
-use OliverKlee\Oelib\Configuration\ConfigurationRegistry;
-use OliverKlee\Oelib\Configuration\DummyConfiguration;
 use OliverKlee\Seminars\BackEnd\Permissions;
 use OliverKlee\Seminars\Controller\BackEnd\RegistrationController;
 use OliverKlee\Seminars\Csv\CsvDownloader;
@@ -91,14 +89,11 @@ final class RegistrationControllerTest extends UnitTestCase
 
         $this->csvDownloaderMock = $this->createMock(CsvDownloader::class);
         GeneralUtility::addInstance(CsvDownloader::class, $this->csvDownloaderMock);
-        ConfigurationRegistry::getInstance()
-            ->set('plugin.tx_seminars', new DummyConfiguration(['charsetForCsv' => 'utf-8']));
     }
 
     protected function tearDown(): void
     {
         unset($GLOBALS['_GET']['id'], $GLOBALS['_GET']['pid'], $GLOBALS['_GET']['table'], $GLOBALS['_GET']['eventUid'], $GLOBALS['_POST']['id']);
-        ConfigurationRegistry::purgeInstance();
         GeneralUtility::purgeInstances();
 
         parent::tearDown();

--- a/Tests/Unit/Csv/CsvResponseTest.php
+++ b/Tests/Unit/Csv/CsvResponseTest.php
@@ -64,28 +64,14 @@ final class CsvResponseTest extends UnitTestCase
     }
 
     /**
-     * @return array<string, array<int, non-empty-string>>
-     */
-    public function charsetDataProvider(): array
-    {
-        return [
-            'iso-8859-15' => ['iso-8859-15'],
-            'utf-8' => ['utf-8'],
-        ];
-    }
-
-    /**
      * @test
-     *
-     * @dataProvider charsetDataProvider
      */
-    public function usesCharsetFromConfigurationForTheContentType(string $charset): void
+    public function usesUtf8ForTheContentType(): void
     {
-        $this->configuration->setAsString('charsetForCsv', $charset);
         $subject = new CsvResponse('');
 
         $contentTypeHeader = $subject->getHeader('Content-Type')[0];
-        self::assertStringContainsString('charset=' . $charset, $contentTypeHeader);
+        self::assertStringContainsString('charset=utf-8', $contentTypeHeader);
     }
 
     /**

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -5172,7 +5172,7 @@ parameters:
 
 		-
 			message: "#^Cannot access offset 'pid' on mixed\\.$#"
-			count: 9
+			count: 7
 			path: Tests/LegacyUnit/Csv/CsvDownloaderTest.php
 
 		-
@@ -5182,7 +5182,7 @@ parameters:
 
 		-
 			message: "#^Cannot access offset 'table' on mixed\\.$#"
-			count: 6
+			count: 4
 			path: Tests/LegacyUnit/Csv/CsvDownloaderTest.php
 
 		-


### PR DESCRIPTION
Also drop the the `charsetForCsv` setting

Fixes #2107