### PR TITLE
[BUGFIX] Stop using the deprecated `TYPO3_MODE` as security gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Drop support for TYPO3 9LTS (#2156, #2165, #2170, #2176, #2179)
 
 ### Fixed
-- Drop usages of deprecated classes (#2160, #2166)
+- Drop usages of deprecated classes (#2160, #2166, #2178, #2183)
 
 ## 4.4.0
 

--- a/Configuration/TCA/Overrides/fe_users.php
+++ b/Configuration/TCA/Overrides/fe_users.php
@@ -1,6 +1,6 @@
 <?php
 
-defined('TYPO3_MODE') or die('Access denied.');
+defined('TYPO3') or die('Access denied.');
 
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addTCAcolumns(
     'fe_users',

--- a/Configuration/TCA/Overrides/sys_template.php
+++ b/Configuration/TCA/Overrides/sys_template.php
@@ -1,5 +1,5 @@
 <?php
 
-defined('TYPO3_MODE') or die('Access denied.');
+defined('TYPO3') or die('Access denied.');
 
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile('seminars', 'Configuration/TypoScript', 'Seminars');

--- a/Configuration/TCA/Overrides/tt_content.php
+++ b/Configuration/TCA/Overrides/tt_content.php
@@ -1,6 +1,6 @@
 <?php
 
-defined('TYPO3_MODE') or die('Access denied.');
+defined('TYPO3') or die('Access denied.');
 
 (static function (): void {
     // This is the `AbstractPlugin`-based legacy plugin.

--- a/Configuration/TCA/tx_seminars_attendances.php
+++ b/Configuration/TCA/tx_seminars_attendances.php
@@ -1,6 +1,6 @@
 <?php
 
-defined('TYPO3_MODE') or die();
+defined('TYPO3') or die();
 
 $tca = [
     'ctrl' => [

--- a/Configuration/TCA/tx_seminars_categories.php
+++ b/Configuration/TCA/tx_seminars_categories.php
@@ -1,6 +1,6 @@
 <?php
 
-defined('TYPO3_MODE') or die();
+defined('TYPO3') or die();
 
 return [
     'ctrl' => [

--- a/Configuration/TCA/tx_seminars_checkboxes.php
+++ b/Configuration/TCA/tx_seminars_checkboxes.php
@@ -1,6 +1,6 @@
 <?php
 
-defined('TYPO3_MODE') or die();
+defined('TYPO3') or die();
 
 return [
     'ctrl' => [

--- a/Configuration/TCA/tx_seminars_event_types.php
+++ b/Configuration/TCA/tx_seminars_event_types.php
@@ -1,6 +1,6 @@
 <?php
 
-defined('TYPO3_MODE') or die();
+defined('TYPO3') or die();
 
 return [
     'ctrl' => [

--- a/Configuration/TCA/tx_seminars_foods.php
+++ b/Configuration/TCA/tx_seminars_foods.php
@@ -1,6 +1,6 @@
 <?php
 
-defined('TYPO3_MODE') or die();
+defined('TYPO3') or die();
 
 return [
     'ctrl' => [

--- a/Configuration/TCA/tx_seminars_lodgings.php
+++ b/Configuration/TCA/tx_seminars_lodgings.php
@@ -1,6 +1,6 @@
 <?php
 
-defined('TYPO3_MODE') or die();
+defined('TYPO3') or die();
 
 return [
     'ctrl' => [

--- a/Configuration/TCA/tx_seminars_organizers.php
+++ b/Configuration/TCA/tx_seminars_organizers.php
@@ -1,6 +1,6 @@
 <?php
 
-defined('TYPO3_MODE') or die();
+defined('TYPO3') or die();
 
 $tca = [
     'ctrl' => [

--- a/Configuration/TCA/tx_seminars_payment_methods.php
+++ b/Configuration/TCA/tx_seminars_payment_methods.php
@@ -1,6 +1,6 @@
 <?php
 
-defined('TYPO3_MODE') or die();
+defined('TYPO3') or die();
 
 return [
     'ctrl' => [

--- a/Configuration/TCA/tx_seminars_seminars.php
+++ b/Configuration/TCA/tx_seminars_seminars.php
@@ -1,6 +1,6 @@
 <?php
 
-defined('TYPO3_MODE') or die();
+defined('TYPO3') or die();
 
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addToInsertRecords('tx_seminars_seminars');
 

--- a/Configuration/TCA/tx_seminars_sites.php
+++ b/Configuration/TCA/tx_seminars_sites.php
@@ -1,6 +1,6 @@
 <?php
 
-defined('TYPO3_MODE') or die();
+defined('TYPO3') or die();
 
 $tca = [
     'ctrl' => [

--- a/Configuration/TCA/tx_seminars_skills.php
+++ b/Configuration/TCA/tx_seminars_skills.php
@@ -1,6 +1,6 @@
 <?php
 
-defined('TYPO3_MODE') or die();
+defined('TYPO3') or die();
 
 return [
     'ctrl' => [

--- a/Configuration/TCA/tx_seminars_speakers.php
+++ b/Configuration/TCA/tx_seminars_speakers.php
@@ -1,6 +1,6 @@
 <?php
 
-defined('TYPO3_MODE') or die();
+defined('TYPO3') or die();
 
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addToInsertRecords('tx_seminars_speakers');
 

--- a/Configuration/TCA/tx_seminars_target_groups.php
+++ b/Configuration/TCA/tx_seminars_target_groups.php
@@ -1,6 +1,6 @@
 <?php
 
-defined('TYPO3_MODE') or die();
+defined('TYPO3') or die();
 
 return [
     'ctrl' => [

--- a/Configuration/TCA/tx_seminars_test.php
+++ b/Configuration/TCA/tx_seminars_test.php
@@ -1,6 +1,6 @@
 <?php
 
-defined('TYPO3_MODE') or die();
+defined('TYPO3') or die();
 
 return [
     'ctrl' => [

--- a/Configuration/TCA/tx_seminars_timeslots.php
+++ b/Configuration/TCA/tx_seminars_timeslots.php
@@ -1,6 +1,6 @@
 <?php
 
-defined('TYPO3_MODE') or die();
+defined('TYPO3') or die();
 
 $tca = [
     'ctrl' => [

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -1,5 +1,5 @@
 <?php
-defined('TYPO3_MODE') or die('Access denied.');
+defined('TYPO3') or die('Access denied.');
 
 (static function (): void {
     $tables = [

--- a/ext_tables.php
+++ b/ext_tables.php
@@ -1,5 +1,5 @@
 <?php
-defined('TYPO3_MODE') or die('Access denied.');
+defined('TYPO3') or die('Access denied.');
 
 $boot = static function (): void {
     /**


### PR DESCRIPTION
Part of #1453