### PR TITLE
[TASK] Drop `config.uniqueLinkVars` from the TypoScript

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Drop support for TYPO3 9LTS (#2156, #2165, #2170, #2176, #2179)
 
 ### Fixed
-- Drop usages of deprecated classes (#2160, #2166, #2178, #2183, #2186)
+- Drop usages of deprecated code (#2160, #2166, #2178, #2183, #2186, #2197)
 
 ## 4.4.0
 

--- a/Configuration/TypoScript/Config.typoscript
+++ b/Configuration/TypoScript/Config.typoscript
@@ -1,6 +1,4 @@
 config {
-  uniqueLinkVars = 1
-
   tx_mkforms {
     loadJsFramework = 1
     mayLoadScriptaculous = 1


### PR DESCRIPTION
This was last used in TYPO3 6.2.

Fixes #1876

[ci skip]