### PR TITLE
 [TASK] Make registrations hideable again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,6 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Added
 
 ### Changed
-- Make registrations non-hideable (#2191)
 - Switch the FAL-related fields in the DB to int (#2187)
 - Shrink some DB fields to save some space (#2187)
 - !!! Switch the CSV export to always use UTF-8 (#2181)

--- a/Classes/Service/RegistrationManager.php
+++ b/Classes/Service/RegistrationManager.php
@@ -594,7 +594,7 @@ class RegistrationManager
 
         $this->getConnectionForTable('tx_seminars_attendances')->update(
             'tx_seminars_attendances',
-            ['deleted' => 1, 'tstamp' => $GLOBALS['SIM_EXEC_TIME']],
+            ['hidden' => 1, 'tstamp' => $GLOBALS['SIM_EXEC_TIME']],
             ['uid' => $uid]
         );
 

--- a/Configuration/TCA/tx_seminars_attendances.php
+++ b/Configuration/TCA/tx_seminars_attendances.php
@@ -11,6 +11,9 @@ $tca = [
         'cruser_id' => 'cruser_id',
         'default_sortby' => 'ORDER BY crdate DESC',
         'delete' => 'deleted',
+        'enablecolumns' => [
+            'disabled' => 'hidden',
+        ],
         'iconfile' => 'EXT:seminars/Resources/Public/Icons/Registration.gif',
         'searchFields' => 'title',
     ],
@@ -61,6 +64,14 @@ $tca = [
             'label' => 'LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_attendances.been_there',
             'config' => [
                 'type' => 'check',
+            ],
+        ],
+        'hidden' => [
+            'exclude' => 1,
+            'label' => 'LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:LGL.hidden',
+            'config' => [
+                'type' => 'check',
+                'default' => 0,
             ],
         ],
         'registration_queue' => [
@@ -470,7 +481,7 @@ $tca = [
     'types' => [
         '0' => [
             'showitem' => '' .
-                '--div--;LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_attendances.divLabelOverview, title, uid, seminar, user, been_there, ' .
+                '--div--;LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_attendances.divLabelOverview, title, uid, seminar, user, been_there, hidden, ' .
                 '--div--;LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_attendances.divLabelBookingInformation, registration_queue, registered_themselves, seats, price, price_code, total_price, attendees_names, additional_persons, kids, foods, food, lodgings, accommodation, checkboxes, ' .
                 '--div--;LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_attendances.divLabelRegistrationComments, interests, expectations, background_knowledge, known_from, notes, ' .
                 '--div--;LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_attendances.divLabelPaymentInformation, datepaid, currency, including_tax, method_of_payment, ' .

--- a/Tests/Functional/Domain/Repository/Event/EventRepositoryTest.php
+++ b/Tests/Functional/Domain/Repository/Event/EventRepositoryTest.php
@@ -714,6 +714,52 @@ final class EventRepositoryTest extends FunctionalTestCase
     /**
      * @test
      */
+    public function updateRegistrationCounterCacheIgnoresHiddenRegistrations(): void
+    {
+        $this->importDataSet(__DIR__ . '/Fixtures/SingleEventWithHiddenRegistrationWithZeroCounterCache.xml');
+        $event = $this->subject->findByUid(1);
+
+        $this->subject->updateRegistrationCounterCache($event);
+
+        $connection = $this->getConnectionPool()->getConnectionForTable('tx_seminars_seminars');
+        $query = 'SELECT * FROM tx_seminars_seminars WHERE uid = :uid';
+        $result = $connection->executeQuery($query, ['uid' => 1]);
+        if (\method_exists($result, 'fetchAssociative')) {
+            $databaseRow = $result->fetchAssociative();
+        } else {
+            $databaseRow = $result->fetch();
+        }
+        self::assertIsArray($databaseRow);
+
+        self::assertSame(0, (int)$databaseRow['registrations']);
+    }
+
+    /**
+     * @test
+     */
+    public function updateRegistrationCounterCacheIgnoresDeletedRegistrations(): void
+    {
+        $this->importDataSet(__DIR__ . '/Fixtures/SingleEventWithHiddenRegistrationWithZeroCounterCache.xml');
+        $event = $this->subject->findByUid(1);
+
+        $this->subject->updateRegistrationCounterCache($event);
+
+        $connection = $this->getConnectionPool()->getConnectionForTable('tx_seminars_seminars');
+        $query = 'SELECT * FROM tx_seminars_seminars WHERE uid = :uid';
+        $result = $connection->executeQuery($query, ['uid' => 1]);
+        if (\method_exists($result, 'fetchAssociative')) {
+            $databaseRow = $result->fetchAssociative();
+        } else {
+            $databaseRow = $result->fetch();
+        }
+        self::assertIsArray($databaseRow);
+
+        self::assertSame(0, (int)$databaseRow['registrations']);
+    }
+
+    /**
+     * @test
+     */
     public function findByPageUidInBackEndModeForNoEventsReturnsEmptyArray(): void
     {
         $result = $this->subject->findByPageUidInBackEndMode(0);

--- a/Tests/Functional/Domain/Repository/Event/Fixtures/SingleEventWithHiddenRegistrationWithZeroCounterCache.xml
+++ b/Tests/Functional/Domain/Repository/Event/Fixtures/SingleEventWithHiddenRegistrationWithZeroCounterCache.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<dataset>
+    <tx_seminars_seminars>
+        <uid>1</uid>
+        <object_type>0</object_type>
+        <title>Single event with 2 registrations with zero counter cache</title>
+        <registrations>0</registrations>
+    </tx_seminars_seminars>
+    <tx_seminars_attendances>
+        <uid>1</uid>
+        <seminar>1</seminar>
+        <hidden>1</hidden>
+    </tx_seminars_attendances>
+</dataset>

--- a/Tests/Functional/Domain/Repository/Registration/Fixtures/HiddenRegistrationWithEvent.xml
+++ b/Tests/Functional/Domain/Repository/Registration/Fixtures/HiddenRegistrationWithEvent.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<dataset>
+    <tx_seminars_attendances>
+        <uid>1</uid>
+        <hidden>1</hidden>
+        <seminar>1</seminar>
+        <seats>1</seats>
+    </tx_seminars_attendances>
+    <tx_seminars_seminars>
+        <uid>1</uid>
+    </tx_seminars_seminars>
+</dataset>

--- a/Tests/Functional/Domain/Repository/Registration/Fixtures/HiddenRegistrationWithEventAndUser.xml
+++ b/Tests/Functional/Domain/Repository/Registration/Fixtures/HiddenRegistrationWithEventAndUser.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<dataset>
+    <tx_seminars_attendances>
+        <uid>1</uid>
+        <seminar>1</seminar>
+        <user>1</user>
+        <hidden>1</hidden>
+    </tx_seminars_attendances>
+    <tx_seminars_seminars>
+        <uid>1</uid>
+    </tx_seminars_seminars>
+    <fe_users>
+        <uid>1</uid>
+    </fe_users>
+</dataset>

--- a/Tests/Functional/Domain/Repository/Registration/Fixtures/HiddenWaitingListRegistrationWithEvent.xml
+++ b/Tests/Functional/Domain/Repository/Registration/Fixtures/HiddenWaitingListRegistrationWithEvent.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<dataset>
+    <tx_seminars_attendances>
+        <uid>1</uid>
+        <hidden>1</hidden>
+        <seminar>1</seminar>
+        <registration_queue>1</registration_queue>
+        <seats>1</seats>
+    </tx_seminars_attendances>
+    <tx_seminars_seminars>
+        <uid>1</uid>
+    </tx_seminars_seminars>
+</dataset>

--- a/Tests/Functional/Domain/Repository/Registration/Fixtures/HiddenWaitingListRegistrationWithEventAndUser.xml
+++ b/Tests/Functional/Domain/Repository/Registration/Fixtures/HiddenWaitingListRegistrationWithEventAndUser.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<dataset>
+    <tx_seminars_attendances>
+        <uid>1</uid>
+        <seminar>1</seminar>
+        <user>1</user>
+        <registration_queue>1</registration_queue>
+        <hidden>1</hidden>
+    </tx_seminars_attendances>
+    <tx_seminars_seminars>
+        <uid>1</uid>
+    </tx_seminars_seminars>
+    <fe_users>
+        <uid>1</uid>
+    </fe_users>
+</dataset>

--- a/Tests/Functional/Domain/Repository/Registration/RegistrationRepositoryTest.php
+++ b/Tests/Functional/Domain/Repository/Registration/RegistrationRepositoryTest.php
@@ -368,6 +368,17 @@ final class RegistrationRepositoryTest extends FunctionalTestCase
     /**
      * @test
      */
+    public function existsRegistrationForHiddenMatchingRegistrationReturnsFalse(): void
+    {
+        $this->importDataSet(__DIR__ . '/Fixtures/HiddenRegistrationWithEventAndUser.xml');
+        $event = $this->eventRepository->findByUid(1);
+
+        self::assertFalse($this->subject->existsRegistrationForEventAndUser($event, 1));
+    }
+
+    /**
+     * @test
+     */
     public function existsRegistrationForDeletedMatchingRegistrationReturnsFalse(): void
     {
         $this->importDataSet(__DIR__ . '/Fixtures/DeletedRegistrationWithEventAndUser.xml');
@@ -449,6 +460,16 @@ final class RegistrationRepositoryTest extends FunctionalTestCase
     /**
      * @test
      */
+    public function countRegularSeatsByEventIgnoresHiddenRegistration(): void
+    {
+        $this->importDataSet(__DIR__ . '/Fixtures/HiddenRegistrationWithEvent.xml');
+
+        self::assertSame(0, $this->subject->countRegularSeatsByEvent(1));
+    }
+
+    /**
+     * @test
+     */
     public function countRegularSeatsByEventIgnoresDeletedRegistration(): void
     {
         $this->importDataSet(__DIR__ . '/Fixtures/DeletedRegistrationWithEvent.xml');
@@ -512,6 +533,16 @@ final class RegistrationRepositoryTest extends FunctionalTestCase
         $this->importDataSet(__DIR__ . '/Fixtures/TwoMultiSeatWaitingListRegistrationsWithSameEvent.xml');
 
         self::assertSame(5, $this->subject->countWaitingListSeatsByEvent(1));
+    }
+
+    /**
+     * @test
+     */
+    public function countWaitingListSeatsByEventIgnoresHiddenRegistration(): void
+    {
+        $this->importDataSet(__DIR__ . '/Fixtures/HiddenWaitingListRegistrationWithEvent.xml');
+
+        self::assertSame(0, $this->subject->countWaitingListSeatsByEvent(1));
     }
 
     /**
@@ -592,6 +623,18 @@ final class RegistrationRepositoryTest extends FunctionalTestCase
         $this->importDataSet(__DIR__ . '/Fixtures/RegistrationWithEventAndUser.xml');
 
         $result = $this->subject->findRegularRegistrationsByEvent(2);
+
+        self::assertSame([], $result);
+    }
+
+    /**
+     * @test
+     */
+    public function findRegularRegistrationsByEventIgnoresHiddenRegistrations(): void
+    {
+        $this->importDataSet(__DIR__ . '/Fixtures/HiddenRegistrationWithEventAndUser.xml');
+
+        $result = $this->subject->findRegularRegistrationsByEvent(1);
 
         self::assertSame([], $result);
     }
@@ -680,6 +723,18 @@ final class RegistrationRepositoryTest extends FunctionalTestCase
         $this->importDataSet(__DIR__ . '/Fixtures/WaitingListRegistrationWithEvent.xml');
 
         $result = $this->subject->findWaitingListRegistrationsByEvent(2);
+
+        self::assertSame([], $result);
+    }
+
+    /**
+     * @test
+     */
+    public function findWaitingListRegistrationsByEventIgnoresHiddenRegistrations(): void
+    {
+        $this->importDataSet(__DIR__ . '/Fixtures/HiddenWaitingListRegistrationWithEventAndUser.xml');
+
+        $result = $this->subject->findWaitingListRegistrationsByEvent(1);
 
         self::assertSame([], $result);
     }

--- a/Tests/LegacyUnit/Service/RegistrationManagerTest.php
+++ b/Tests/LegacyUnit/Service/RegistrationManagerTest.php
@@ -1329,7 +1329,7 @@ final class RegistrationManagerTest extends TestCase
     /**
      * @test
      */
-    public function removeRegistrationDeletesRegistrationUser(): void
+    public function removeRegistrationHidesRegistrationOfUser(): void
     {
         $userUid = $this->testingFramework->createAndLoginFrontEndUser();
         $seminarUid = $this->seminarUid;
@@ -1340,6 +1340,7 @@ final class RegistrationManagerTest extends TestCase
             [
                 'user' => $userUid,
                 'seminar' => $seminarUid,
+                'hidden' => 0,
             ]
         );
 
@@ -1352,7 +1353,7 @@ final class RegistrationManagerTest extends TestCase
             ->where(
                 $query->expr()->eq('user', $query->createNamedParameter($userUid, \PDO::PARAM_INT)),
                 $query->expr()->eq('seminar', $query->createNamedParameter($seminarUid, \PDO::PARAM_INT)),
-                $query->expr()->eq('deleted', $query->createNamedParameter(1, \PDO::PARAM_INT))
+                $query->expr()->eq('hidden', $query->createNamedParameter(1, \PDO::PARAM_INT))
             )
             ->execute()
             ->fetchColumn(0);

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -3072,12 +3072,12 @@ parameters:
 
 		-
 			message: "#^Cannot cast mixed to int\\.$#"
-			count: 2
+			count: 4
 			path: Tests/Functional/Domain/Repository/Event/EventRepositoryTest.php
 
 		-
 			message: "#^Parameter \\#1 \\$event of method OliverKlee\\\\Seminars\\\\Domain\\\\Repository\\\\Event\\\\EventRepository\\:\\:updateRegistrationCounterCache\\(\\) expects OliverKlee\\\\Seminars\\\\Domain\\\\Model\\\\Event\\\\Event, OliverKlee\\\\Seminars\\\\Domain\\\\Model\\\\Event\\\\Event\\|null given\\.$#"
-			count: 2
+			count: 4
 			path: Tests/Functional/Domain/Repository/Event/EventRepositoryTest.php
 
 		-
@@ -3107,7 +3107,7 @@ parameters:
 
 		-
 			message: "#^Parameter \\#1 \\$event of method OliverKlee\\\\Seminars\\\\Domain\\\\Repository\\\\Registration\\\\RegistrationRepository\\:\\:existsRegistrationForEventAndUser\\(\\) expects OliverKlee\\\\Seminars\\\\Domain\\\\Model\\\\Event\\\\EventInterface, OliverKlee\\\\Seminars\\\\Domain\\\\Model\\\\Event\\\\Event\\|null given\\.$#"
-			count: 6
+			count: 7
 			path: Tests/Functional/Domain/Repository/Registration/RegistrationRepositoryTest.php
 
 		-


### PR DESCRIPTION
It's helpful to hide registrations after all, e.g., when someone cancels their registration.

This reverts commit 16d76a9c0f58f025699db6f5f51db327b31ea6cc.

Closes #2195