### PR TITLE
[TASK] Move `plugin.eventRegistration.heading.eventTitleAndDateAndUid`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Add dedicated tests for `GeneralEventMailForm::sendEmailToAttendees` (#2249)
 
 ### Changed
+- !!! Move `plugin.eventRegistration.heading.eventTitleAndDateAndUid` into a separate namespace (#2266)
 - Switch the FAL-related fields in the DB to int (#2187)
 - Shrink some DB fields to save some space (#2187)
 - !!! Switch the CSV export to always use UTF-8 (#2181)

--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -2012,7 +2012,7 @@ Wir konnten dieser Veranstaltung nun fest zusagen.</target>
 				<source>Consent to terms &amp; conditions</source>
 				<target>AGB-Zustimmung</target>
 			</trans-unit>
-			<trans-unit id="plugin.eventRegistration.heading.eventTitleAndDateAndUid">
+			<trans-unit id="plugin.eventShared.heading.eventTitleAndDateAndUid">
 				<source>%1$s, %2$s (event #%3$u)</source>
 				<target>%1$s, %2$s (Veranstaltung Nr. %3$u)</target>
 			</trans-unit>

--- a/Resources/Private/Language/fr.locallang.xlf
+++ b/Resources/Private/Language/fr.locallang.xlf
@@ -1700,7 +1700,7 @@ This event now has been confirmed.</source>
 				<source>Login page (or with onetimeaccount)</source>
 				<target>Page de login (ou avec onetimeaccount):</target>
 			</trans-unit>
-			<trans-unit id="plugin.eventRegistration.heading.eventTitleAndDateAndUid">
+			<trans-unit id="plugin.eventShared.heading.eventTitleAndDateAndUid">
 				<source>%1$s, %2$s (event #%3$u)</source>
 				<target>%1$s, %2$s (événement #%3$u)</target>
 			</trans-unit>

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -1521,7 +1521,7 @@ This event now has been confirmed.</source>
 			<trans-unit id="plugin.eventRegistration.settings.fieldsToShow.consentedToTermsAndConditions">
 				<source>Consent to terms &amp; conditions</source>
 			</trans-unit>
-			<trans-unit id="plugin.eventRegistration.heading.eventTitleAndDateAndUid">
+			<trans-unit id="plugin.eventShared.heading.eventTitleAndDateAndUid">
 				<source>%1$s, %2$s (event #%3$u)</source>
 			</trans-unit>
 			<trans-unit id="plugin.eventRegistration.heading.sorry">

--- a/Resources/Private/Language/nl.locallang.xlf
+++ b/Resources/Private/Language/nl.locallang.xlf
@@ -1680,7 +1680,7 @@ This event now has been confirmed.</source>
 				<source>Login page (or with onetimeaccount)</source>
 				<target>Inlogpagina (or met onetimeaccount)</target>
 			</trans-unit>
-			<trans-unit id="plugin.eventRegistration.heading.eventTitleAndDateAndUid">
+			<trans-unit id="plugin.eventShared.heading.eventTitleAndDateAndUid">
 				<source>%1$s, %2$s (event #%3$u)</source>
 				<target>%1$s, %2$s (evenement #%3$u)</target>
 			</trans-unit>

--- a/Resources/Private/Partials/EventTitleAndDateAndUid.html
+++ b/Resources/Private/Partials/EventTitleAndDateAndUid.html
@@ -1,5 +1,5 @@
 <html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers" data-namespace-typo3-fluid="true">
     {f:render(partial: 'EventDate', arguments: {event: event}) -> f:variable(name: 'eventDate')}
-    <f:translate key="plugin.eventRegistration.heading.eventTitleAndDateAndUid"
+    <f:translate key="plugin.eventShared.heading.eventTitleAndDateAndUid"
                  arguments="{0: event.displayTitle, 1: eventDate, 2: event.uid}"/>
 </html>

--- a/Resources/Private/Templates/BackEnd/Email/Compose.html
+++ b/Resources/Private/Templates/BackEnd/Email/Compose.html
@@ -23,7 +23,7 @@
         </h1>
         <h2>
             {f:render(partial: 'EventDate', arguments: {event: event}) -> f:variable(name: 'eventDate')}
-            <f:translate key="plugin.eventRegistration.heading.eventTitleAndDateAndUid"
+            <f:translate key="plugin.eventShared.heading.eventTitleAndDateAndUid"
                          arguments="{0: event.internalTitle, 1: eventDate, 2: event.uid}"/>
         </h2>
 

--- a/Resources/Private/Templates/BackEnd/Registration/ShowForEvent.html
+++ b/Resources/Private/Templates/BackEnd/Registration/ShowForEvent.html
@@ -33,7 +33,7 @@
             </h1>
             <h2>
                 {f:render(partial: 'EventDate', arguments: {event: event}) -> f:variable(name: 'eventDate')}
-                <f:translate key="plugin.eventRegistration.heading.eventTitleAndDateAndUid"
+                <f:translate key="plugin.eventShared.heading.eventTitleAndDateAndUid"
                              arguments="{0: event.internalTitle, 1: eventDate, 2: event.uid}"/>
             </h2>
 


### PR DESCRIPTION
To have this localized string reusable, we should have it in a shared namespace.

Fixes #2150

[ci skip]