### PR TITLE
[BUGFIX] Use `--no-check-lock` for `composer normalize`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -119,7 +119,7 @@
 			"@ci:static",
 			"@ci:dynamic"
 		],
-		"ci:composer:normalize": "@composer normalize --dry-run",
+		"ci:composer:normalize": "@composer normalize --no-check-lock --dry-run",
 		"ci:coverage": [
 			"@ci:coverage:unit",
 			"@ci:coverage:functional"
@@ -177,7 +177,7 @@
 			"@fix:composer",
 			"@fix:php"
 		],
-		"fix:composer": "@composer normalize",
+		"fix:composer": "@composer normalize --no-check-lock",
 		"fix:php": [
 			"@fix:php:cs",
 			"@fix:php:sniff"


### PR DESCRIPTION
We are not versioning the lockfile and hence should not require it to be up to date.

This removes some hassle from development.

Fixes #1580