### PR TITLE
[TASK] Use the `Event.registrations` counter cache less

### DIFF
--- a/Classes/Mapper/EventMapper.php
+++ b/Classes/Mapper/EventMapper.php
@@ -135,7 +135,7 @@ class EventMapper extends AbstractDataMapper
      */
     public function findForRegistrationDigestEmail(): Collection
     {
-        $whereClause = 'registrations <> 0 AND object_type <> ' . EventInterface::TYPE_EVENT_TOPIC .
+        $whereClause = 'object_type <> ' . EventInterface::TYPE_EVENT_TOPIC .
             ' AND hidden = 0 AND deleted = 0 ' .
             ' AND EXISTS (' .
             'SELECT * FROM tx_seminars_attendances ' .

--- a/Classes/OldModel/LegacyEvent.php
+++ b/Classes/OldModel/LegacyEvent.php
@@ -1467,16 +1467,6 @@ class LegacyEvent extends AbstractTimeSpan
     }
 
     /**
-     * Returns the number of associated registration records (i.e., the number in the counter cache).
-     *
-     * @deprecated #1324 will be removed in seminars 5.0
-     */
-    public function getNumberOfAssociatedRegistrationRecords(): int
-    {
-        return $this->getRecordPropertyInteger('registrations');
-    }
-
-    /**
      * Returns TRUE if this seminar has at least one target group, FALSE
      * otherwise.
      *

--- a/Tests/LegacyUnit/OldModel/LegacyEventTest.php
+++ b/Tests/LegacyUnit/OldModel/LegacyEventTest.php
@@ -7568,31 +7568,6 @@ final class LegacyEventTest extends TestCase
         );
     }
 
-    // Tests regarding the number of associated registration records
-
-    /**
-     * @test
-     */
-    public function getNumberOfAssociatedRegistrationRecordsByDefaultReturnsZero(): void
-    {
-        self::assertSame(0, $this->subject->getNumberOfAssociatedRegistrationRecords());
-    }
-
-    /**
-     * @test
-     */
-    public function getNumberOfAssociatedRegistrationRecordsReturnsValueFromDatabase(): void
-    {
-        $numberOfRegistrations = 3;
-        $uid = $this->testingFramework->createRecord(
-            'tx_seminars_seminars',
-            ['registrations' => $numberOfRegistrations]
-        );
-        $subject = new TestingLegacyEvent($uid);
-
-        self::assertSame($numberOfRegistrations, $subject->getNumberOfAssociatedRegistrationRecords());
-    }
-
     // Tests concerning the price
 
     /**


### PR DESCRIPTION
This counter cache is a bad architectural decision, and we should get rid of it sooner or later.