### PR TITLE
[TASK] Drop obsolete TypoScript related to `sb_accessiblecontent`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Deprecated
 
 ### Removed
+- Drop obsolete TypoScript related to `sb_accessiblecontent` (#2318)
 - Drop the custom FE user group model (#2318)
 - Drop the `Event::STATUS_*` constants (#2316)
 - Drop organizer-specific registration storage folders (#2311)

--- a/Configuration/TypoScript/Content.typoscript
+++ b/Configuration/TypoScript/Content.typoscript
@@ -1,2 +1,0 @@
-# make the FE plugin work with sb_accessiblecontent
-tt_content.list.20.seminars_pi1 =< plugin.tx_seminars_pi1

--- a/Configuration/TypoScript/setup.typoscript
+++ b/Configuration/TypoScript/setup.typoscript
@@ -1,5 +1,4 @@
 <INCLUDE_TYPOSCRIPT: source="FILE:./Page.typoscript">
-<INCLUDE_TYPOSCRIPT: source="FILE:./Content.typoscript">
 
 <INCLUDE_TYPOSCRIPT: source="FILE:./PluginSettings.typoscript">
 <INCLUDE_TYPOSCRIPT: source="FILE:./View.typoscript">


### PR DESCRIPTION
This extension is not maintained and used anymore.

Fixes #1874