### PR TITLE
[TASK] Deprecate the `dateFormat` and `timeFormat` settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Changed
 
 ### Deprecated
+- Deprecate the `dateFormat` and `timeFormat` settings (#2343)
 
 ### Removed
 - Drop unused code from the legacy model classes (#2339)

--- a/Configuration/TypoScript/FrontEnd.typoscript
+++ b/Configuration/TypoScript/FrontEnd.typoscript
@@ -11,7 +11,7 @@ plugin.tx_seminars_pi1 {
   # activate Javascript framework from global config
   loadJsFramework =< config.loadJsFramework
 
-  # the strftime format code for the full date
+  # the strftime format code for the full date, @deprecated #2342 will be removed in seminars 6.0
   dateFormatYMD < plugin.tx_seminars.dateFormatYMD
 
   # whether to use formal or informal language

--- a/Configuration/TypoScript/PluginShared.typoscript
+++ b/Configuration/TypoScript/PluginShared.typoscript
@@ -63,10 +63,10 @@ plugin.tx_seminars {
   # Whether to add the CSV file of the registrations when sending the reminder e-mails to the organizers.
   addRegistrationCsvToOrganizerReminderMail = 0
 
-  # the time format (in strftime format)
+  # the time format (in strftime format), @deprecated #2342 will be removed in seminars 6.0
   timeFormat = %H:%M
 
-  # the strftime format code for the full date
+  # the strftime format code for the full date, @deprecated #2342 will be removed in seminars 6.0
   dateFormatYMD = %d.%m.%Y
 
   # ISO 4217 alpha 3 code of the currency to be used, must be valid

--- a/Documentation/Reference/SetupCommonForFront-endPlug-inAndBack-endModuleInPlugintxSeminars/Index.rst
+++ b/Documentation/Reference/SetupCommonForFront-endPlug-inAndBack-endModuleInPlugintxSeminars/Index.rst
@@ -404,7 +404,8 @@ only be configured using your TypoScript setup, but not via flexforms.
          string
 
    Description
-         the time format (in  *strftime* format)
+         the time format (in  *strftime* format),
+         @deprecated #2342 will be removed in seminars 6.0
 
    Default
          %H:%M
@@ -419,8 +420,8 @@ only be configured using your TypoScript setup, but not via flexforms.
          string
 
    Description
-         the  *strftime* format code for the full date *(change this to your
-         local date format)*
+         the  *strftime* format code for the full date (change this to your
+         local date format), @deprecated #2342 will be removed in seminars 6.0
 
    Default
          %d.%m.%Y

--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -584,6 +584,10 @@ Wir konnten dieser Veranstaltung nun fest zusagen.</target>
 				<source>Y-m-d</source>
 				<target>d.m.Y</target>
 			</trans-unit>
+			<trans-unit id="timeFormat">
+				<source>H:i</source>
+				<target>H:i</target>
+			</trans-unit>
 			<trans-unit id="decimalSeparator">
 				<source>.</source>
 				<target>,</target>

--- a/Resources/Private/Language/dk.locallang.xlf
+++ b/Resources/Private/Language/dk.locallang.xlf
@@ -8,6 +8,10 @@
 				<source>Y-m-d</source>
 				<target>d/m/Y</target>
 			</trans-unit>
+			<trans-unit id="timeFormat">
+				<source>H:i</source>
+				<target>H:i</target>
+			</trans-unit>
 			<trans-unit id="decimalSeparator">
 				<source>.</source>
 				<target>,</target>

--- a/Resources/Private/Language/fr.locallang.xlf
+++ b/Resources/Private/Language/fr.locallang.xlf
@@ -8,6 +8,10 @@
 				<source>Y-m-d</source>
 				<target>d/m/Y</target>
 			</trans-unit>
+			<trans-unit id="timeFormat">
+				<source>H:i</source>
+				<target>H:i</target>
+			</trans-unit>
 			<trans-unit id="decimalSeparator">
 				<source>.</source>
 				<target>,</target>

--- a/Resources/Private/Language/it.locallang.xlf
+++ b/Resources/Private/Language/it.locallang.xlf
@@ -8,6 +8,10 @@
 				<source>Y-m-d</source>
 				<target>d/m/Y</target>
 			</trans-unit>
+			<trans-unit id="timeFormat">
+				<source>H:i</source>
+				<target>H:i</target>
+			</trans-unit>
 			<trans-unit id="decimalSeparator">
 				<source>.</source>
 				<target>,</target>

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -450,6 +450,9 @@ This event now has been confirmed.</source>
 			<trans-unit id="dateFormat">
 				<source>Y-m-d</source>
 			</trans-unit>
+			<trans-unit id="timeFormat">
+				<source>H:i</source>
+			</trans-unit>
 			<trans-unit id="decimalSeparator">
 				<source>.</source>
 			</trans-unit>

--- a/Resources/Private/Language/nl.locallang.xlf
+++ b/Resources/Private/Language/nl.locallang.xlf
@@ -8,6 +8,10 @@
 				<source>Y-m-d</source>
 				<target>d-m-Y</target>
 			</trans-unit>
+			<trans-unit id="timeFormat">
+				<source>H:i</source>
+				<target>H:i</target>
+			</trans-unit>
 			<trans-unit id="decimalSeparator">
 				<source>.</source>
 				<target>,</target>

--- a/Resources/Private/Language/ru.locallang.xlf
+++ b/Resources/Private/Language/ru.locallang.xlf
@@ -8,6 +8,10 @@
 				<source>Y-m-d</source>
 				<target>d.m.Y</target>
 			</trans-unit>
+			<trans-unit id="timeFormat">
+				<source>H:i</source>
+				<target>H:i</target>
+			</trans-unit>
 			<trans-unit id="decimalSeparator">
 				<source>.</source>
 				<target>,</target>


### PR DESCRIPTION
`strftime` is deprecated, and we cannot use its format anymore.

Also, are language- and region-specific and hence should come from the locallang files, not the configuration.

Hence also add the time format to the locallang files.

Fixes #2342