### PR TITLE
[BUGFIX] Use Composer 2.4 for the legacy tests on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -302,7 +302,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           php-version: "${{ matrix.php-version }}"
-          tools: composer:v2
+          tools: composer:v2.4
           extensions: dom, json, libxml, mysqli, zip
           coverage: none
           ini-values: error_reporting=E_ALL


### PR DESCRIPTION
The TYPO3 Console currently breaks with Composer 2.5.