### PR TITLE
[BUG] Correct use of the configuration "accessToFrontEndRegistrationLists"

### DIFF
--- a/Classes/FrontEnd/DefaultController.php
+++ b/Classes/FrontEnd/DefaultController.php
@@ -433,7 +433,9 @@ class DefaultController extends TemplateHelper
                 $this->whatToDisplay,
                 0,
                 $this->getConfValueInteger('registrationsVipListPID'),
-                $this->getConfValueInteger('defaultEventVipsFeGroupID', 's_template_special')
+                $this->getConfValueInteger('defaultEventVipsFeGroupID', 's_template_special'),
+                $this->getConfValueString('accessToFrontEndRegistrationLists')
+
             )
         ) {
             // So a link to the VIP list is possible.
@@ -441,7 +443,10 @@ class DefaultController extends TemplateHelper
         } elseif (
             $this->seminar->canViewRegistrationsList(
                 $this->whatToDisplay,
-                $this->getConfValueInteger('registrationsListPID')
+                $this->getConfValueInteger('registrationsListPID'),
+                0,
+                0,
+                $this->getConfValueString('accessToFrontEndRegistrationLists')
             )
         ) {
             // No link to the VIP list ... so maybe to the list for the participants.
@@ -1230,7 +1235,9 @@ class DefaultController extends TemplateHelper
         $canViewListOfRegistrations = $this->seminar->canViewRegistrationsList(
             $this->whatToDisplay,
             $this->getConfValueInteger('registrationsListPID'),
-            $this->getConfValueInteger('registrationsVipListPID')
+            $this->getConfValueInteger('registrationsVipListPID'),
+            0,
+            $this->getConfValueString('accessToFrontEndRegistrationLists')
         );
 
         if (!$canViewListOfRegistrations) {

--- a/Classes/FrontEnd/RegistrationsList.php
+++ b/Classes/FrontEnd/RegistrationsList.php
@@ -86,7 +86,8 @@ class RegistrationsList extends AbstractView
                     $this->getConfValueInteger(
                         'defaultEventVipsFeGroupID',
                         's_template_special'
-                    )
+                    ),
+                    $this->getConfValueString('accessToFrontEndRegistrationLists')
                 )
             ) {
                 $isOkay = true;


### PR DESCRIPTION
The TypoScript setting "accessToFrontEndRegistrationLists" is now in use to check if a User has access to the registrationlist.