### PR TITLE
[BUGFIX] Use seminarImageSingleViewWidth/-Height as maximum

### DIFF
--- a/Classes/FrontEnd/DefaultController.php
+++ b/Classes/FrontEnd/DefaultController.php
@@ -678,8 +678,8 @@ class DefaultController extends TemplateHelper
             'altText' => '',
             'file' => $image->getPublicUrl(),
             'file.' => [
-                'width' => $this->getConfValueInteger('seminarImageSingleViewWidth'),
-                'height' => $this->getConfValueInteger('seminarImageSingleViewHeight'),
+                'width' => $this->getConfValueInteger('seminarImageSingleViewWidth') . 'm',
+                'height' => $this->getConfValueInteger('seminarImageSingleViewHeight') . 'm',
             ],
         ];
 


### PR DESCRIPTION
Treats settings seminarImageSingleViewWidth/seminarImageSingleViewHeight as maximum image dimensions when invoking `IMAGE` cObject rendering. The change avoids that the image ratio is violated.

Fixes: #2395