### PR TITLE
[BUGFIX] Disable moving registration records with the event record

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Removed
 
 ### Fixed
+- Disable moving registration records with the event record (#2453)
 - Fix internal links to speakers and organizers (#2442)
 - Use `seminarImageSingleViewWidth`/-`Height` as maximum (#2397)
 - Fix links to pages in RTE texts (#2374)

--- a/Configuration/TCA/tx_seminars_seminars.php
+++ b/Configuration/TCA/tx_seminars_seminars.php
@@ -765,6 +765,9 @@ $tca = [
                     'levelLinksPosition' => 'bottom',
                     'expandSingle' => 1,
                 ],
+                'behavior' => [
+                    'disableMovingChildrenWithParent' => true,
+                ],
             ],
         ],
         'cancelled' => [


### PR DESCRIPTION
Usually, registrations are stored in a separate folder.

Fixes #2437