### PR TITLE
[TASK] Drop the unused `DefaultController::registrationFormHookProvider`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Deprecated
 
 ### Removed
+- Drop the unused `DefaultController::registrationFormHookProvider` (#2458)
 - Remove the links to the feature survey (#2454)
 
 ### Fixed

--- a/Classes/FrontEnd/DefaultController.php
+++ b/Classes/FrontEnd/DefaultController.php
@@ -203,11 +203,6 @@ class DefaultController extends TemplateHelper
     protected $singleViewHookProvider;
 
     /**
-     * @var HookProvider|null
-     */
-    protected $registrationFormHookProvider;
-
-    /**
      * @var SingleViewLinkBuilder|null
      */
     private $linkBuilder;


### PR DESCRIPTION
Fixes #2457