### PR TITLE
[TASK] Make the `EventRegistrationControllerTest` more strict

### DIFF
--- a/Tests/Unit/Controller/EventRegistrationControllerTest.php
+++ b/Tests/Unit/Controller/EventRegistrationControllerTest.php
@@ -111,6 +111,8 @@ final class EventRegistrationControllerTest extends UnitTestCase
         $pageUid = 42;
         $this->subject->_set('settings', ['pageForMissingEvent' => (string)$pageUid]);
 
+        $this->subject->expects(self::never())->method('forward');
+        $this->subject->expects(self::never())->method('redirectToUri');
         $this->subject->expects(self::once())->method('redirect')->with(null, null, null, [], $pageUid)
             ->willThrowException(new StopActionException('redirectToUri', 1476045828));
         $this->expectException(StopActionException::class);
@@ -126,6 +128,8 @@ final class EventRegistrationControllerTest extends UnitTestCase
         $pageUid = 42;
         $this->subject->_set('settings', ['pageForMissingEvent' => (string)$pageUid]);
 
+        $this->subject->expects(self::never())->method('forward');
+        $this->subject->expects(self::never())->method('redirectToUri');
         $this->subject->expects(self::once())->method('redirect')->with(null, null, null, [], $pageUid)
             ->willThrowException(new StopActionException('redirectToUri', 1476045828));
         $this->expectException(StopActionException::class);
@@ -142,6 +146,8 @@ final class EventRegistrationControllerTest extends UnitTestCase
         $this->registrationGuardMock->expects(self::once())->method('isRegistrationPossibleAtAnyTimeAtAll')
             ->with($event)->willReturn(false);
 
+        $this->subject->expects(self::never())->method('redirect');
+        $this->subject->expects(self::never())->method('redirectToUri');
         $this->subject->expects(self::once())->method('forward')
             ->with('deny', null, null, ['warningMessageKey' => 'noRegistrationPossibleAtAll'])
             ->willThrowException(new StopActionException('forward', 1476045801));
@@ -161,6 +167,8 @@ final class EventRegistrationControllerTest extends UnitTestCase
         $this->registrationGuardMock->expects(self::once())->method('isRegistrationPossibleByDate')
             ->with($event)->willReturn(false);
 
+        $this->subject->expects(self::never())->method('redirect');
+        $this->subject->expects(self::never())->method('redirectToUri');
         $this->subject->expects(self::once())->method('forward')
             ->with('deny', null, null, ['warningMessageKey' => 'noRegistrationPossibleAtTheMoment'])
             ->willThrowException(new StopActionException('forward', 1476045801));
@@ -184,6 +192,8 @@ final class EventRegistrationControllerTest extends UnitTestCase
         $this->registrationGuardMock->expects(self::once())
             ->method('isFreeFromRegistrationConflicts')->with($event, $userUid)->willReturn(false);
 
+        $this->subject->expects(self::never())->method('redirect');
+        $this->subject->expects(self::never())->method('redirectToUri');
         $this->subject->expects(self::once())->method('forward')
             ->with('deny', null, null, ['warningMessageKey' => 'alreadyRegistered'])
             ->willThrowException(new StopActionException('forward', 1476045801));
@@ -195,7 +205,7 @@ final class EventRegistrationControllerTest extends UnitTestCase
     /**
      * @test
      */
-    public function checkPrerequisitesActionForFullyBookedEventForwardsToDenyAction(): void
+    public function checkPrerequisitesActionForFullyBookedEventWithoutWaitingListForwardsToDenyAction(): void
     {
         $userUid = 17;
         $this->registrationGuardMock->method('getFrontEndUserUidFromSession')->willReturn($userUid);
@@ -209,6 +219,8 @@ final class EventRegistrationControllerTest extends UnitTestCase
         $this->registrationGuardMock->expects(self::once())
             ->method('getVacancies')->with($event)->willReturn(0);
 
+        $this->subject->expects(self::never())->method('redirect');
+        $this->subject->expects(self::never())->method('redirectToUri');
         $this->subject->expects(self::once())->method('forward')
             ->with('deny', null, null, ['warningMessageKey' => 'fullyBooked'])
             ->willThrowException(new StopActionException('forward', 1476045801));
@@ -236,6 +248,8 @@ final class EventRegistrationControllerTest extends UnitTestCase
         $this->registrationGuardMock->expects(self::once())
             ->method('getVacancies')->with($event)->willReturn(null);
 
+        $this->subject->expects(self::never())->method('forward');
+        $this->subject->expects(self::never())->method('redirectToUri');
         $this->subject->expects(self::once())->method('redirect')
             ->with('new', null, null, ['event' => $event])
             ->willThrowException(new StopActionException('redirectToUri', 1476045828));
@@ -263,6 +277,8 @@ final class EventRegistrationControllerTest extends UnitTestCase
         $this->registrationGuardMock->expects(self::once())
             ->method('getVacancies')->with($event)->willReturn(1);
 
+        $this->subject->expects(self::never())->method('forward');
+        $this->subject->expects(self::never())->method('redirectToUri');
         $this->subject->expects(self::once())->method('redirect')
             ->with('new', null, null, ['event' => $event])
             ->willThrowException(new StopActionException('redirectToUri', 1476045828));
@@ -298,6 +314,8 @@ final class EventRegistrationControllerTest extends UnitTestCase
         $this->uriBuilderMock->expects(self::exactly(2))->method('buildFrontendUri')
             ->willReturnOnConsecutiveCalls($redirectUrl, $loginPageUrl);
 
+        $this->subject->expects(self::never())->method('forward');
+        $this->subject->expects(self::never())->method('redirect');
         $this->subject->expects(self::once())->method('redirectToUri')
             ->with($loginPageUrl)
             ->willThrowException(new StopActionException('redirectToUri', 1476045828));
@@ -844,6 +862,8 @@ final class EventRegistrationControllerTest extends UnitTestCase
     {
         $event = new SingleEvent();
 
+        $this->subject->expects(self::never())->method('forward');
+        $this->subject->expects(self::never())->method('redirectToUri');
         $this->subject->expects(self::once())->method('redirect')
             ->with('thankYou', null, null, ['event' => $event])
             ->willThrowException(new StopActionException('redirectToUri', 1476045828));


### PR DESCRIPTION
When testing forwards/redirects, also test that no other forward/redirect happens.

Part of #1972