### PR TITLE
[TASK] Enrich the registration in `newAction`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ## x.y.z
 
 ### Added
+- Add a waiting list functionality to the new registration form (#2465)
 - Add a diverse gender (#2378)
 
 ### Changed

--- a/Classes/Controller/EventRegistrationController.php
+++ b/Classes/Controller/EventRegistrationController.php
@@ -169,6 +169,7 @@ class EventRegistrationController extends ActionController
             $firstPriceCode = $firstPrice instanceof Price ? $firstPrice->getPriceCode() : Price::PRICE_STANDARD;
             $newRegistration->setPriceCode($firstPriceCode);
         }
+        $this->registrationProcessor->enrichWithMetadata($newRegistration, $event, $this->settings);
         $this->view->assign('registration', $newRegistration);
 
         $maximumBookableSeats = (int)($this->settings['maximumBookableSeats'] ?? self::MAXIMUM_BOOKABLE_SEATS);

--- a/Tests/Unit/Controller/EventRegistrationControllerTest.php
+++ b/Tests/Unit/Controller/EventRegistrationControllerTest.php
@@ -633,6 +633,58 @@ final class EventRegistrationControllerTest extends UnitTestCase
     /**
      * @test
      */
+    public function newActionWithRegistrationEnrichesRegistrationWithMetadata(): void
+    {
+        $event = new SingleEvent();
+        $settings = ['registration' => ['registrationRecordsStorageFolder' => '5']];
+        $this->subject->_set('settings', $settings);
+
+        $registration = new Registration();
+        $this->registrationProcesserMock->expects(self::once())->method('enrichWithMetadata')
+            ->with($registration, $event, $settings);
+
+        $this->subject->newAction($event, $registration);
+    }
+
+    /**
+     * @test
+     */
+    public function newActionWithNullRegistrationEnrichesNewRegistrationWithMetadata(): void
+    {
+        $event = new SingleEvent();
+        $settings = ['registration' => ['registrationRecordsStorageFolder' => '5']];
+        $this->subject->_set('settings', $settings);
+
+        $registration = new Registration();
+        GeneralUtility::addInstance(Registration::class, $registration);
+
+        $this->registrationProcesserMock->expects(self::once())->method('enrichWithMetadata')
+            ->with($registration, $event, $settings);
+
+        $this->subject->newAction($event, null);
+    }
+
+    /**
+     * @test
+     */
+    public function newActionWithoutRegistrationEnrichesNewRegistrationWithMetadata(): void
+    {
+        $event = new SingleEvent();
+        $settings = ['registration' => ['registrationRecordsStorageFolder' => '5']];
+        $this->subject->_set('settings', $settings);
+
+        $registration = new Registration();
+        GeneralUtility::addInstance(Registration::class, $registration);
+
+        $this->registrationProcesserMock->expects(self::once())->method('enrichWithMetadata')
+            ->with($registration, $event, $settings);
+
+        $this->subject->newAction($event);
+    }
+
+    /**
+     * @test
+     */
     public function newActionWithoutRegistrationAndWithoutRegisteredThemselvesSettingSetsItToTrue(): void
     {
         $registration = new Registration();


### PR DESCRIPTION
This allows the registration to be marked as being on the waiting list in a later commit.

Part of #1972