### PR TITLE
[BUGFIX] Convert linebreaks in the organizer signatures in HTML email

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Removed
 
 ### Fixed
+- Convert linebreaks in the organizer signatures in the HTML email (#2482)
 
 ## 5.2.0
 

--- a/Classes/Service/RegistrationManager.php
+++ b/Classes/Service/RegistrationManager.php
@@ -916,7 +916,16 @@ class RegistrationManager
         }
 
         $footers = $event->getOrganizersFooter();
-        $template->setMarker('footer', !empty($footers) ? "\n-- \n" . $footers[0] : '');
+        $footerCode = '';
+        if ($footers !== []) {
+            $firstFooter = $footers[0];
+            if ($useHtml) {
+                $footerCode = "\n<hr/>\n" . \nl2br(\htmlspecialchars($firstFooter, ENT_QUOTES | ENT_HTML5));
+            } else {
+                $footerCode = "\n-- \n" . $firstFooter;
+            }
+        }
+        $template->setMarker('footer', $footerCode);
 
         $registrationNew = MapperRegistry::get(RegistrationMapper::class)->find($registration->getUid());
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1871,11 +1871,6 @@ parameters:
 			path: Classes/Service/RegistrationManager.php
 
 		-
-			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
-			count: 1
-			path: Classes/Service/RegistrationManager.php
-
-		-
 			message: "#^Instanceof between OliverKlee\\\\Seminars\\\\Service\\\\SingleViewLinkBuilder and OliverKlee\\\\Seminars\\\\Service\\\\SingleViewLinkBuilder will always evaluate to true\\.$#"
 			count: 1
 			path: Classes/Service/RegistrationManager.php
@@ -2817,7 +2812,7 @@ parameters:
 
 		-
 			message: "#^Cannot call method getHtmlBody\\(\\) on \\(PHPUnit\\\\Framework\\\\MockObject\\\\MockObject&TYPO3\\\\CMS\\\\Core\\\\Mail\\\\MailMessage\\)\\|null\\.$#"
-			count: 9
+			count: 11
 			path: Tests/Functional/Service/RegistrationManagerTest.php
 
 		-
@@ -2827,7 +2822,7 @@ parameters:
 
 		-
 			message: "#^Cannot call method getTextBody\\(\\) on \\(PHPUnit\\\\Framework\\\\MockObject\\\\MockObject&TYPO3\\\\CMS\\\\Core\\\\Mail\\\\MailMessage\\)\\|null\\.$#"
-			count: 32
+			count: 33
 			path: Tests/Functional/Service/RegistrationManagerTest.php
 
 		-
@@ -2867,7 +2862,7 @@ parameters:
 
 		-
 			message: "#^Parameter \\#2 \\$haystack of static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertStringContainsString\\(\\) expects string, resource\\|string\\|null given\\.$#"
-			count: 24
+			count: 23
 			path: Tests/Functional/Service/RegistrationManagerTest.php
 
 		-


### PR DESCRIPTION
In the plain-text email, linebreaks in the organizer signatures need to stay linebreaks, while they need to be converted to `<br/>` in the HTML emails.

Fixes #2473