### PR TITLE
[BUGFIX] Do not use a footer separator in the HTML emails

### DIFF
--- a/Classes/Service/RegistrationManager.php
+++ b/Classes/Service/RegistrationManager.php
@@ -920,7 +920,7 @@ class RegistrationManager
         if ($footers !== []) {
             $firstFooter = $footers[0];
             if ($useHtml) {
-                $footerCode = "\n<hr/>\n" . \nl2br(\htmlspecialchars($firstFooter, ENT_QUOTES | ENT_HTML5));
+                $footerCode = \nl2br(\htmlspecialchars($firstFooter, ENT_QUOTES | ENT_HTML5));
             } else {
                 $footerCode = "\n-- \n" . $firstFooter;
             }

--- a/Tests/Functional/Service/RegistrationManagerTest.php
+++ b/Tests/Functional/Service/RegistrationManagerTest.php
@@ -920,7 +920,7 @@ final class RegistrationManagerTest extends FunctionalTestCase
         $result = $this->email->getHtmlBody();
 
         self::assertIsString($result);
-        self::assertStringContainsString("\n<hr/>\n" . $footer, $result);
+        self::assertStringContainsString($footer, $result);
     }
 
     /**
@@ -948,7 +948,7 @@ final class RegistrationManagerTest extends FunctionalTestCase
         $result = $this->email->getHtmlBody();
 
         self::assertIsString($result);
-        self::assertStringContainsString("\n<hr/>\norganizer<br />\nfooter", $result);
+        self::assertStringContainsString("organizer<br />\nfooter", $result);
     }
 
     /**


### PR DESCRIPTION
Using `<hr/>` as a separator breaks the layout.

Fixes #2486