### PR TITLE
[BUGFIX] Drop legacy registration form parameters from the login link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Removed
 
 ### Fixed
+- Drop the legacy registration form parameters from `DefaultController::getLoginLink` (#2500)
 - Use `Connection` instead of `PDO` for the named param types (#2496)
 
 ## 5.2.2

--- a/Classes/FrontEnd/DefaultController.php
+++ b/Classes/FrontEnd/DefaultController.php
@@ -476,23 +476,13 @@ class DefaultController extends TemplateHelper
         $linkConfiguration = ['parameter' => $pageId];
 
         if ($eventId > 0) {
-            $linkConfiguration['additionalParams']
-                // @deprecated These parameters can be removed in seminars 5.0
-                // when the legacy registration form is removed.
-                = GeneralUtility::implodeArrayForUrl(
-                    'tx_seminars_pi1',
-                    ['seminar' => $eventId, 'action' => 'register'],
-                    '',
-                    false,
-                    true
-                ) . '&' .
-                GeneralUtility::implodeArrayForUrl(
-                    'tx_seminars_eventregistration',
-                    ['event' => $eventId],
-                    '',
-                    false,
-                    true
-                );
+            $linkConfiguration['additionalParams'] = GeneralUtility::implodeArrayForUrl(
+                'tx_seminars_eventregistration',
+                ['event' => $eventId],
+                '',
+                false,
+                true
+            );
         }
 
         $redirectUrl = GeneralUtility::locationHeaderUrl(


### PR DESCRIPTION
Fixes #2499