### PR TITLE
[BUGFIX] Remove unnecessary information from the confirmation page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Removed
 
 ### Fixed
+- Do not show "registered themselves" on the configuration page unnecessarily (#2508)
 - Remove a leftover debug statement from a Fluid template (#2507)
 - Apply the "register myself" default even if hidden (#2504)
 - Convert most classes that get injected into singletons (#2503)

--- a/Resources/Private/Templates/EventRegistration/Confirm.html
+++ b/Resources/Private/Templates/EventRegistration/Confirm.html
@@ -35,26 +35,30 @@
                         </td>
                     </tr>
 
-                    <tr>
-                        <th scope="row">
-                            <f:translate key="{labelPrefix}.attendeesNames"/>
-                        </th>
-                        <td>
-                            <f:if condition="{registration.registeredThemselves}">
-                                <f:then>
-                                    <f:translate key="{labelPrefix}.registeredThemselves"/>
-                                </f:then>
-                                <f:else>
-                                    <f:translate key="{labelPrefix}.registeredThemselves.not"/>
-                                </f:else>
-                            </f:if>
+                    <oelib:isFieldEnabled fieldName="attendeesNames|registeredThemselves">
+                        <tr>
+                            <th scope="row">
+                                <f:translate key="{labelPrefix}.attendeesNames"/>
+                            </th>
+                            <td>
+                                <oelib:isFieldEnabled fieldName="registeredThemselves">
+                                    <f:if condition="{registration.registeredThemselves}">
+                                        <f:then>
+                                            <f:translate key="{labelPrefix}.registeredThemselves"/>
+                                        </f:then>
+                                        <f:else>
+                                            <f:translate key="{labelPrefix}.registeredThemselves.not"/>
+                                        </f:else>
+                                    </f:if>
+                                    <br/>
+                                </oelib:isFieldEnabled>
 
-                            <f:if condition="{registration.attendeesNames}">
-                                <br/>
-                                {registration.attendeesNames -> f:format.nl2br()}
-                            </f:if>
-                        </td>
-                    </tr>
+                                <f:if condition="{registration.attendeesNames}">
+                                    {registration.attendeesNames -> f:format.nl2br()}
+                                </f:if>
+                            </td>
+                        </tr>
+                    </oelib:isFieldEnabled>
 
                     <f:comment>
                         We cannot directly iterate over `registration.accommodationOptions` here, as Extbase then


### PR DESCRIPTION
If the checkbox "I register myself" is not shown, there is no point showing the default value on the confirmation page.

Fixes #2506