### PR TITLE
[BUGFIX] Make registration available in the thank-you action template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Removed
 
 ### Fixed
+- Make the registration available in the thank-you action template (#2510)
 - Do not show "registered themselves" on the configuration page unnecessarily (#2508)
 - Remove a leftover debug statement from a Fluid template (#2507)
 - Apply the "register myself" default even if hidden (#2504)

--- a/Classes/Controller/EventRegistrationController.php
+++ b/Classes/Controller/EventRegistrationController.php
@@ -223,16 +223,18 @@ class EventRegistrationController extends ActionController
 
         $this->oneTimeAccountConnector->destroyOneTimeSession();
 
-        $this->redirect('thankYou', null, null, ['event' => $event]);
+        $this->redirect('thankYou', null, null, ['event' => $event, 'registration' => $registration]);
     }
 
     /**
      * Displays the thank-you page.
      *
      * @Extbase\IgnoreValidation("event")
+     * @Extbase\IgnoreValidation("registration")
      */
-    public function thankYouAction(Event $event): void
+    public function thankYouAction(Event $event, Registration $registration): void
     {
         $this->view->assign('event', $event);
+        $this->view->assign('registration', $registration);
     }
 }

--- a/Tests/Unit/Controller/EventRegistrationControllerTest.php
+++ b/Tests/Unit/Controller/EventRegistrationControllerTest.php
@@ -1006,18 +1006,19 @@ final class EventRegistrationControllerTest extends UnitTestCase
     /**
      * @test
      */
-    public function createActionRedirectsToThankYouActionAndPassesEvent(): void
+    public function createActionRedirectsToThankYouActionAndPassesEventAndRegistration(): void
     {
         $event = new SingleEvent();
+        $registration = new Registration();
 
         $this->subject->expects(self::never())->method('forward');
         $this->subject->expects(self::never())->method('redirectToUri');
         $this->subject->expects(self::once())->method('redirect')
-            ->with('thankYou', null, null, ['event' => $event])
+            ->with('thankYou', null, null, ['event' => $event, 'registration' => $registration])
             ->willThrowException(new StopActionException('redirectToUri', 1476045828));
         $this->expectException(StopActionException::class);
 
-        $this->subject->createAction($event, new Registration());
+        $this->subject->createAction($event, $registration);
     }
 
     /**
@@ -1027,8 +1028,26 @@ final class EventRegistrationControllerTest extends UnitTestCase
     {
         $event = new SingleEvent();
 
-        $this->viewMock->expects(self::once())->method('assign')->with('event', $event);
+        $this->viewMock->expects(self::exactly(2))->method('assign')->withConsecutive(
+            ['event', $event],
+            ['registration', self::anything()]
+        );
 
-        $this->subject->thankYouAction($event);
+        $this->subject->thankYouAction($event, new Registration());
+    }
+
+    /**
+     * @test
+     */
+    public function thankYouActionPassesProvidedRegistrationToView(): void
+    {
+        $registration = new Registration();
+
+        $this->viewMock->expects(self::exactly(2))->method('assign')->withConsecutive(
+            ['event', self::anything()],
+            ['registration', $registration]
+        );
+
+        $this->subject->thankYouAction(new SingleEvent(), $registration);
     }
 }

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -102,7 +102,7 @@ defined('TYPO3') or die('Access denied.');
         // non-cacheable actions
         [
             \OliverKlee\Seminars\Controller\EventRegistrationController::class
-            => 'checkPrerequisites, new, confirm, create',
+            => 'checkPrerequisites, new, confirm, create, thankYou',
             \OliverKlee\Seminars\Controller\EventUnregistrationController::class
             => 'checkPrerequisites, confirm, unregister',
         ]


### PR DESCRIPTION
This allows the heading to be different for waiting list registrations.

Fixes #2492