### PR TITLE
[BUGFIX] Also create slugs for new records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,14 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Added
 
 ### Changed
+- Drop the UID from the event record slug (#2537)
 
 ### Deprecated
 
 ### Removed
 
 ### Fixed
+- Also create slugs for new records (#2537)
 
 ## 5.3.0
 

--- a/Classes/Seo/SlugGenerator.php
+++ b/Classes/Seo/SlugGenerator.php
@@ -9,7 +9,6 @@ use OliverKlee\Seminars\Domain\Model\Event\EventInterface;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\DataHandling\SlugHelper;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\CMS\Core\Utility\MathUtility;
 
 /**
  * Builds the slug for event records.
@@ -30,17 +29,11 @@ class SlugGenerator
     }
 
     /**
-     * @param array{record: array{uid?: string|int, title?: string, object_type?: int, topic?: int}} $parameters
+     * @param array{record: array{title?: string, object_type?: int, topic?: int}} $parameters
      */
     public function generateSlug(array $parameters): string
     {
         $record = $parameters['record'];
-        $rawUid = $record['uid'] ?? '';
-        $uid = (int)$rawUid;
-        // New, not already saved records get a uid like "NEW56fe740dd5a455"; those records can not have a URL yet
-        if (!MathUtility::canBeInterpretedAsInteger($rawUid) || $uid <= 0) {
-            return '';
-        }
 
         $title = $record['title'] ?? '';
         $recordType = $record['object_type'] ?? 0;
@@ -65,8 +58,6 @@ class SlugGenerator
             }
         }
 
-        $titleSlug = (new SlugHelper(self::TABLE_NAME, 'slug', []))->sanitize($title);
-
-        return $titleSlug !== '' ? ($titleSlug . '/' . $uid) : (string)$uid;
+        return (new SlugHelper(self::TABLE_NAME, 'slug', []))->sanitize($title);
     }
 }

--- a/Configuration/TCA/tx_seminars_seminars.php
+++ b/Configuration/TCA/tx_seminars_seminars.php
@@ -83,8 +83,8 @@ $tca = [
                 'type' => 'slug',
                 'size' => 50,
                 'generatorOptions' => [
-                    'fields' => ['title', 'uid'],
-                    'fieldSeparator' => '/',
+                    'fields' => ['title'],
+                    'fieldSeparator' => '-',
                     'postModifiers' => [
                         \OliverKlee\Seminars\Seo\SlugGenerator::class . '->generateSlug',
                     ],

--- a/Tests/Functional/Seo/SlugGeneratorTest.php
+++ b/Tests/Functional/Seo/SlugGeneratorTest.php
@@ -32,6 +32,16 @@ final class SlugGeneratorTest extends FunctionalTestCase
     }
 
     /**
+     * @test
+     */
+    public function generateSlugForEmptyRecordReturnsEmptyString(): void
+    {
+        $result = $this->subject->generateSlug(['record' => []]);
+
+        self::assertSame('', $result);
+    }
+
+    /**
      * @return array<string,array{0: EventInterface::TYPE_*}>
      */
     public static function nonDateEventTypeDataProvider(): array
@@ -48,14 +58,14 @@ final class SlugGeneratorTest extends FunctionalTestCase
      * @param EventInterface::TYPE_* $type
      * @dataProvider nonDateEventTypeDataProvider
      */
-    public function generateSlugForNonEventDateWithEmptyTitleReturnsUidOnly(int $type): void
+    public function generateSlugForNonEventDateWithEmptyTitleReturnsEmptyString(int $type): void
     {
         $uid = 1234;
         $record = ['uid' => $uid, 'object_type' => $type, 'title' => ''];
 
         $result = $this->subject->generateSlug(['record' => $record]);
 
-        self::assertSame((string)$uid, $result);
+        self::assertSame('', $result);
     }
 
     /**
@@ -64,14 +74,14 @@ final class SlugGeneratorTest extends FunctionalTestCase
      * @param EventInterface::TYPE_* $type
      * @dataProvider nonDateEventTypeDataProvider
      */
-    public function generateSlugForNonEventDateWithWhitespaceOnlyTitleReturnsUidOnly(int $type): void
+    public function generateSlugForNonEventDateWithWhitespaceOnlyTitleReturnsEmptyString(int $type): void
     {
         $uid = 1234;
         $record = ['uid' => $uid, 'object_type' => $type, 'title' => " \t\n\r"];
 
         $result = $this->subject->generateSlug(['record' => $record]);
 
-        self::assertSame((string)$uid, $result);
+        self::assertSame('', $result);
     }
 
     /**
@@ -80,20 +90,20 @@ final class SlugGeneratorTest extends FunctionalTestCase
      * @param EventInterface::TYPE_* $type
      * @dataProvider nonDateEventTypeDataProvider
      */
-    public function generateSlugForNonEventDateWithNonTitleReturnsSlugifiedTitleAndUid(int $type): void
+    public function generateSlugForNonEventDateWithNonTitleReturnsSlugifiedTitle(int $type): void
     {
         $uid = 1234;
         $record = ['uid' => $uid, 'object_type' => $type, 'title' => 'There will be cake!'];
 
         $result = $this->subject->generateSlug(['record' => $record]);
 
-        self::assertSame('there-will-be-cake/' . $uid, $result);
+        self::assertSame('there-will-be-cake', $result);
     }
 
     /**
      * @test
      */
-    public function generateSlugForEventDateWithTopicReturnsSlugFromTopicTitleAndDateUid(): void
+    public function generateSlugForEventDateWithTopicReturnsSlugFromTopicTitle(): void
     {
         $this->importDataSet(__DIR__ . '/Fixtures/EventDateWithTopic.xml');
 
@@ -108,13 +118,13 @@ final class SlugGeneratorTest extends FunctionalTestCase
 
         $result = $this->subject->generateSlug(['record' => $record]);
 
-        self::assertSame('event-topic/' . $eventDateUid, $result);
+        self::assertSame('event-topic', $result);
     }
 
     /**
      * @test
      */
-    public function generateSlugForEventDateWithTopicWithEmptyTitleReturnsDateUidOnly(): void
+    public function generateSlugForEventDateWithTopicWithEmptyTitleReturnsEmptyString(): void
     {
         $this->importDataSet(__DIR__ . '/Fixtures/EventDateWithTopicWithoutTitle.xml');
 
@@ -129,13 +139,13 @@ final class SlugGeneratorTest extends FunctionalTestCase
 
         $result = $this->subject->generateSlug(['record' => $record]);
 
-        self::assertSame((string)$eventDateUid, $result);
+        self::assertSame('', $result);
     }
 
     /**
      * @test
      */
-    public function generateSlugForEventDateWithoutTopicReturnsDateUidOnly(): void
+    public function generateSlugForEventDateWithoutTopicReturnsEmptyString(): void
     {
         $this->importDataSet(__DIR__ . '/Fixtures/EventDateWithoutTopic.xml');
 
@@ -150,13 +160,13 @@ final class SlugGeneratorTest extends FunctionalTestCase
 
         $result = $this->subject->generateSlug(['record' => $record]);
 
-        self::assertSame((string)$eventDateUid, $result);
+        self::assertSame('', $result);
     }
 
     /**
      * @test
      */
-    public function generateSlugForEventDateWithDeletedTopicReturnsDateUidOnly(): void
+    public function generateSlugForEventDateWithDeletedTopicReturnsEmptyString(): void
     {
         $this->importDataSet(__DIR__ . '/Fixtures/EventDateWithDeletedTopic.xml');
 
@@ -171,6 +181,6 @@ final class SlugGeneratorTest extends FunctionalTestCase
 
         $result = $this->subject->generateSlug(['record' => $record]);
 
-        self::assertSame((string)$eventDateUid, $result);
+        self::assertSame('', $result);
     }
 }

--- a/Tests/Functional/UpgradeWizards/GenerateEventSlugsUpgradeWizardTest.php
+++ b/Tests/Functional/UpgradeWizards/GenerateEventSlugsUpgradeWizardTest.php
@@ -101,7 +101,7 @@ class GenerateEventSlugsUpgradeWizardTest extends FunctionalTestCase
         }
 
         self::assertIsArray($databaseRow);
-        self::assertSame('event-without-slug/2', $databaseRow['slug']);
+        self::assertSame('event-without-slug', $databaseRow['slug']);
         self::assertTrue($wizardResult);
     }
 }

--- a/Tests/Unit/Seo/SlugGeneratorTest.php
+++ b/Tests/Unit/Seo/SlugGeneratorTest.php
@@ -31,39 +31,4 @@ final class SlugGeneratorTest extends UnitTestCase
     {
         self::assertSame('', $this->subject->getPrefix());
     }
-
-    /**
-     * @test
-     */
-    public function generateSlugForEmptyRecordReturnsEmptyString(): void
-    {
-        $result = $this->subject->generateSlug(['record' => []]);
-
-        self::assertSame('', $result);
-    }
-
-    /**
-     * @return array<string,array{0: string|int}>
-     */
-    public static function emptyUidDataProvider(): array
-    {
-        return [
-            'empty string' => [''],
-            'new record placeholder' => ['NEW56fe7404a3a455'],
-            'zero' => [0],
-        ];
-    }
-
-    /**
-     * @test
-     *
-     * @param string|int $uid
-     * @dataProvider emptyUidDataProvider
-     */
-    public function generateSlugForEmptyUidReturnsEmptyString($uid): void
-    {
-        $result = $this->subject->generateSlug(['record' => ['uid' => $uid]]);
-
-        self::assertSame('', $result);
-    }
 }


### PR DESCRIPTION
The UID does not need to be part of the slug to make the slug unique as TYPO3 already ensures that the slug is unique by appending a number.

Fixes #2531
Fixes #2533