### PR TITLE
[TASK] Make the event slug field shorter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Added
 
 ### Changed
+- Make the event slug field shorter (#2539)
 - Update the email CSS to simple.css v2.2.1 (#2543)
 - Drop the UID from the event record slug (#2537)
 

--- a/Configuration/TCA/tx_seminars_seminars.php
+++ b/Configuration/TCA/tx_seminars_seminars.php
@@ -83,6 +83,7 @@ $tca = [
             'config' => [
                 'type' => 'slug',
                 'size' => 50,
+                'max' => 262,
                 'generatorOptions' => [
                     'fields' => ['title'],
                     'fieldSeparator' => '-',

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -190,7 +190,7 @@ CREATE TABLE tx_seminars_seminars (
     object_type int(11) unsigned DEFAULT '0' NOT NULL,
     title tinytext,
     topic int(11) unsigned DEFAULT '0' NOT NULL,
-    slug varchar(2048) DEFAULT '' NOT NULL,
+    slug varchar(262) DEFAULT '' NOT NULL,
     subtitle tinytext,
     categories int(11) unsigned DEFAULT '0' NOT NULL,
     teaser text,


### PR DESCRIPTION
The slug field only needs to accomodate the event title and a
suffix for uniqueness. Hence we can shorten it.

Fixes #2538