### PR TITLE
[BUGFIX] Add a maximum length for the seminar title in the TCA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Removed
 
 ### Fixed
+- Add a maximum length to the seminar title in the TCA (#2544)
 - Also create slugs for new records (#2537)
 
 ## 5.3.0

--- a/Configuration/TCA/tx_seminars_seminars.php
+++ b/Configuration/TCA/tx_seminars_seminars.php
@@ -59,6 +59,7 @@ $tca = [
             'config' => [
                 'type' => 'input',
                 'size' => 30,
+                'max' => 255,
                 'eval' => 'required,trim',
             ],
         ],


### PR DESCRIPTION
Fixes #2541