### PR TITLE
[TASK] Increase the length limit for the DB index on the event slug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Added
 
 ### Changed
+- Drop the length limit for the DB index on the event slug (#2547)
 - Make the event slug field nullable (#2546)
 - Make the event slug field shorter (#2539)
 - Update the email CSS to simple.css v2.2.1 (#2543)

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -256,7 +256,7 @@ CREATE TABLE tx_seminars_seminars (
     KEY topic (topic),
     KEY event_takes_place_reminder_sent (event_takes_place_reminder_sent),
     KEY cancelation_deadline_reminder_sent (cancelation_deadline_reminder_sent),
-    KEY slug (slug(127)),
+    KEY slug (slug(262)),
     FULLTEXT index_event_searchfields (accreditation_number),
     FULLTEXT index_topic_searchfields (title,subtitle,description)
 ) ENGINE = MyISAM;


### PR DESCRIPTION
Now the index for the slug uses the complete slug.

Fixes #2545