### PR TITLE
[BUGFIX] Also create slugs if the related topic is hidden or timed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Removed
 
 ### Fixed
+- Also create slugs if the event or topic is hidden or timed (#2548)
 - Add a maximum length to the seminar title in the TCA (#2544)
 - Also create slugs for new records (#2537)
 

--- a/Classes/Seo/SlugGenerator.php
+++ b/Classes/Seo/SlugGenerator.php
@@ -41,8 +41,11 @@ class SlugGenerator
             $title = '';
             $topicUid = $record['topic'] ?? 0;
 
-            $result = GeneralUtility::makeInstance(ConnectionPool::class)->getQueryBuilderForTable(self::TABLE_NAME)
-                ->select('title')->from(self::TABLE_NAME)->where('uid = :uid')->setParameter('uid', $topicUid)
+            $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)
+                ->getQueryBuilderForTable(self::TABLE_NAME);
+            $queryBuilder->getRestrictions()->removeAll();
+            $result = $queryBuilder->select('title')->from(self::TABLE_NAME)
+                ->where('uid = :uid')->setParameter('uid', $topicUid)
                 ->execute();
             if ($result instanceof ResultStatement) {
                 if (\method_exists($result, 'fetchAssociative')) {

--- a/Tests/Functional/Seo/Fixtures/EventDateWithHiddenTopic.xml
+++ b/Tests/Functional/Seo/Fixtures/EventDateWithHiddenTopic.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<dataset>
+    <tx_seminars_seminars>
+        <uid>1</uid>
+        <title>Event date</title>
+        <object_type>2</object_type>
+        <topic>2</topic>
+        <slug>existing-date-slug</slug>
+    </tx_seminars_seminars>
+    <tx_seminars_seminars>
+        <uid>2</uid>
+        <title>Hidden event topic</title>
+        <object_type>1</object_type>
+        <hidden>1</hidden>
+        <slug>existing-topic-slug</slug>
+    </tx_seminars_seminars>
+</dataset>

--- a/Tests/Functional/Seo/Fixtures/EventDateWithTimedTopic.xml
+++ b/Tests/Functional/Seo/Fixtures/EventDateWithTimedTopic.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<dataset>
+    <tx_seminars_seminars>
+        <uid>1</uid>
+        <title>Event date</title>
+        <object_type>2</object_type>
+        <topic>2</topic>
+        <slug>existing-date-slug</slug>
+    </tx_seminars_seminars>
+    <tx_seminars_seminars>
+        <uid>2</uid>
+        <title>Timed event topic</title>
+        <object_type>1</object_type>
+        <endtime>1</endtime>
+        <slug>existing-topic-slug</slug>
+    </tx_seminars_seminars>
+</dataset>

--- a/Tests/Functional/Seo/SlugGeneratorTest.php
+++ b/Tests/Functional/Seo/SlugGeneratorTest.php
@@ -166,7 +166,7 @@ final class SlugGeneratorTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function generateSlugForEventDateWithDeletedTopicReturnsEmptyString(): void
+    public function generateSlugForEventDateWithDeletedTopicReturnsSlugFromTopicTitle(): void
     {
         $this->importDataSet(__DIR__ . '/Fixtures/EventDateWithDeletedTopic.xml');
 
@@ -181,6 +181,48 @@ final class SlugGeneratorTest extends FunctionalTestCase
 
         $result = $this->subject->generateSlug(['record' => $record]);
 
-        self::assertSame('', $result);
+        self::assertSame('deleted-event-topic', $result);
+    }
+
+    /**
+     * @test
+     */
+    public function generateSlugForEventDateWithHiddenTopicReturnsSlugFromTopicTitle(): void
+    {
+        $this->importDataSet(__DIR__ . '/Fixtures/EventDateWithHiddenTopic.xml');
+
+        $eventDateUid = 1234;
+        $record = [
+            'uid' => $eventDateUid,
+            'object_type' => EventInterface::TYPE_EVENT_DATE,
+            'title' => 'Event date',
+            'topic' => 2,
+            'slug' => 'existing-date-slug',
+        ];
+
+        $result = $this->subject->generateSlug(['record' => $record]);
+
+        self::assertSame('hidden-event-topic', $result);
+    }
+
+    /**
+     * @test
+     */
+    public function generateSlugForEventDateWithTimedTopicReturnsSlugFromTopicTitle(): void
+    {
+        $this->importDataSet(__DIR__ . '/Fixtures/EventDateWithTimedTopic.xml');
+
+        $eventDateUid = 1234;
+        $record = [
+            'uid' => $eventDateUid,
+            'object_type' => EventInterface::TYPE_EVENT_DATE,
+            'title' => 'Event date',
+            'topic' => 2,
+            'slug' => 'existing-date-slug',
+        ];
+
+        $result = $this->subject->generateSlug(['record' => $record]);
+
+        self::assertSame('timed-event-topic', $result);
     }
 }


### PR DESCRIPTION
We want to be able to create a slug in more cases in order to avoid errors in the FE due to a missing slug.

Part of #2540