### PR TITLE
[TASK] Make the object type for events a drop-down

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Added
 
 ### Changed
+- Make the object type for events a drop-down (#2551)
 - Make the event slug field nullable (#2546)
 - Make the event slug field shorter (#2539)
 - Update the email CSS to simple.css v2.2.1 (#2543)

--- a/Configuration/TCA/tx_seminars_seminars.php
+++ b/Configuration/TCA/tx_seminars_seminars.php
@@ -35,7 +35,8 @@ $tca = [
             'exclude' => 1,
             'label' => 'LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_seminars.object_type',
             'config' => [
-                'type' => 'radio',
+                'type' => 'select',
+                'renderType' => 'selectSingle',
                 'default' => \OliverKlee\Seminars\Domain\Model\Event\EventInterface::TYPE_SINGLE_EVENT,
                 'items' => [
                     [

--- a/Resources/Private/Language/de.locallang_db.xlf
+++ b/Resources/Private/Language/de.locallang_db.xlf
@@ -53,8 +53,8 @@
 				<target>Thema für mehrere Veranstaltungen</target>
 			</trans-unit>
 			<trans-unit id="tx_seminars_seminars.object_type.I.2" xml:space="preserve">
-				<source>Date</source>
-				<target>Termin</target>
+				<source>Date for a topic</source>
+				<target>Termin für ein Thema</target>
 			</trans-unit>
 			<trans-unit id="tx_seminars_seminars.title" xml:space="preserve">
 				<source>Title</source>

--- a/Resources/Private/Language/dk.locallang_db.xlf
+++ b/Resources/Private/Language/dk.locallang_db.xlf
@@ -41,7 +41,7 @@
 				<target>Arrangementsemne  (Hvis arrangementet løber over flere datoer kan du her indtaste info om selve arrangementet)</target>
 			</trans-unit>
 			<trans-unit id="tx_seminars_seminars.object_type.I.2" xml:space="preserve">
-				<source>Date</source>
+				<source>Date for a topic</source>
 				<target>Arrangementssdato (Samme som ovenfor. Her vælger du blot et Arrangementsemne og indtaster så info om tid, m.m.).</target>
 			</trans-unit>
 			<trans-unit id="tx_seminars_seminars.title" xml:space="preserve">

--- a/Resources/Private/Language/fr.locallang_db.xlf
+++ b/Resources/Private/Language/fr.locallang_db.xlf
@@ -41,8 +41,8 @@
 				<target>Sujet pour événements multiples</target>
 			</trans-unit>
 			<trans-unit id="tx_seminars_seminars.object_type.I.2" xml:space="preserve">
-				<source>Date</source>
-				<target>Date</target>
+				<source>Date for a topic</source>
+				<target>Date pour un sujet</target>
 			</trans-unit>
 			<trans-unit id="tx_seminars_seminars.title" xml:space="preserve">
 				<source>Title</source>

--- a/Resources/Private/Language/it.locallang_db.xlf
+++ b/Resources/Private/Language/it.locallang_db.xlf
@@ -41,7 +41,7 @@
 				<target>Argomento eventi multipli</target>
 			</trans-unit>
 			<trans-unit id="tx_seminars_seminars.object_type.I.2" xml:space="preserve">
-				<source>Date</source>
+				<source>Date for a topic</source>
 				<target>Date eventi multipli</target>
 			</trans-unit>
 			<trans-unit id="tx_seminars_seminars.title" xml:space="preserve">

--- a/Resources/Private/Language/locallang_db.xlf
+++ b/Resources/Private/Language/locallang_db.xlf
@@ -41,7 +41,7 @@
 				<source>Topic for multiple events</source>
 			</trans-unit>
 			<trans-unit id="tx_seminars_seminars.object_type.I.2" xml:space="preserve">
-				<source>Date</source>
+				<source>Date for a topic</source>
 			</trans-unit>
 			<trans-unit id="tx_seminars_seminars.title" xml:space="preserve">
 				<source>Title</source>

--- a/Resources/Private/Language/nl.locallang_db.xlf
+++ b/Resources/Private/Language/nl.locallang_db.xlf
@@ -41,7 +41,7 @@
 				<target>Repeterende evenement onderwerp</target>
 			</trans-unit>
 			<trans-unit id="tx_seminars_seminars.object_type.I.2" xml:space="preserve">
-				<source>Date</source>
+				<source>Date for a topic</source>
 				<target>Repeterende evenement datum</target>
 			</trans-unit>
 			<trans-unit id="tx_seminars_seminars.title" xml:space="preserve">

--- a/Resources/Private/Language/ru.locallang_db.xlf
+++ b/Resources/Private/Language/ru.locallang_db.xlf
@@ -41,7 +41,7 @@
 				<target>Тема повторябщегося мероприятия</target>
 			</trans-unit>
 			<trans-unit id="tx_seminars_seminars.object_type.I.2" xml:space="preserve">
-				<source>Date</source>
+				<source>Date for a topic</source>
 				<target>Дата повторябщегося мероприятия</target>
 			</trans-unit>
 			<trans-unit id="tx_seminars_seminars.title" xml:space="preserve">


### PR DESCRIPTION
This is required for the event type to get included in the slug calculation.

Part of #2536