### PR TITLE
[BUGFIX] Make the slug generation upgrade wizard repeatable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Removed
 
 ### Fixed
+- Make the slug generation upgrade wizard repeatable (#2557)
 - Fix the slug generation for event date records (#2552)
 - Also create slugs if the event or topic is hidden or timed (#2548)
 - Add a maximum length to the seminar title in the TCA (#2544)

--- a/Classes/UpgradeWizards/GenerateEventSlugsUpgradeWizard.php
+++ b/Classes/UpgradeWizards/GenerateEventSlugsUpgradeWizard.php
@@ -12,6 +12,7 @@ use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Install\Updates\DatabaseUpdatedPrerequisite;
+use TYPO3\CMS\Install\Updates\RepeatableInterface;
 use TYPO3\CMS\Install\Updates\UpgradeWizardInterface;
 
 /**
@@ -19,7 +20,7 @@ use TYPO3\CMS\Install\Updates\UpgradeWizardInterface;
  *
  * @deprecated will be removed in seminars 7.0
  */
-class GenerateEventSlugsUpgradeWizard implements UpgradeWizardInterface, LoggerAwareInterface
+class GenerateEventSlugsUpgradeWizard implements UpgradeWizardInterface, RepeatableInterface, LoggerAwareInterface
 {
     use LoggerAwareTrait;
 

--- a/Tests/Unit/UpgradeWizards/GenerateEventSlugsUpgradeWizardTest.php
+++ b/Tests/Unit/UpgradeWizards/GenerateEventSlugsUpgradeWizardTest.php
@@ -8,6 +8,7 @@ use Nimut\TestingFramework\TestCase\UnitTestCase;
 use OliverKlee\Seminars\UpgradeWizards\GenerateEventSlugsUpgradeWizard;
 use Psr\Log\LoggerAwareInterface;
 use TYPO3\CMS\Install\Updates\DatabaseUpdatedPrerequisite;
+use TYPO3\CMS\Install\Updates\RepeatableInterface;
 use TYPO3\CMS\Install\Updates\UpgradeWizardInterface;
 
 /**
@@ -33,6 +34,14 @@ final class GenerateEventSlugsUpgradeWizardTest extends UnitTestCase
     public function isUpgradeWizard(): void
     {
         self::assertInstanceOf(UpgradeWizardInterface::class, $this->subject);
+    }
+
+    /**
+     * @test
+     */
+    public function isRepeatable(): void
+    {
+        self::assertInstanceOf(RepeatableInterface::class, $this->subject);
     }
 
     /**


### PR DESCRIPTION
If new event records have been created without a slug after the upgrade wizard has been run, it should offer to run again so it can generate slugs for the new records, too.

Fixes #2553