### PR TITLE
[TASK] Make the upgrade wizard for the billing address repeatable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Added
 
 ### Changed
+- Make the upgrade wizard for the separate billing address repeatable (#2558)
 - Document that the slug field should to be enabled for editors (#2556)
 - Make the object type for events a drop-down (#2551)
 - Make the event slug field nullable (#2546)

--- a/Classes/UpgradeWizards/SeparateBillingAddressUpgradeWizard.php
+++ b/Classes/UpgradeWizards/SeparateBillingAddressUpgradeWizard.php
@@ -10,6 +10,7 @@ use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Install\Updates\DatabaseUpdatedPrerequisite;
+use TYPO3\CMS\Install\Updates\RepeatableInterface;
 use TYPO3\CMS\Install\Updates\UpgradeWizardInterface;
 
 /**
@@ -17,7 +18,7 @@ use TYPO3\CMS\Install\Updates\UpgradeWizardInterface;
  *
  * @deprecated will be removed in seminars 6.0
  */
-class SeparateBillingAddressUpgradeWizard implements UpgradeWizardInterface, LoggerAwareInterface
+class SeparateBillingAddressUpgradeWizard implements UpgradeWizardInterface, RepeatableInterface, LoggerAwareInterface
 {
     use LoggerAwareTrait;
 

--- a/Tests/Unit/UpgradeWizards/SeparateBillingAddressUpgradeWizardTest.php
+++ b/Tests/Unit/UpgradeWizards/SeparateBillingAddressUpgradeWizardTest.php
@@ -8,6 +8,7 @@ use Nimut\TestingFramework\TestCase\UnitTestCase;
 use OliverKlee\Seminars\UpgradeWizards\SeparateBillingAddressUpgradeWizard;
 use Psr\Log\LoggerAwareInterface;
 use TYPO3\CMS\Install\Updates\DatabaseUpdatedPrerequisite;
+use TYPO3\CMS\Install\Updates\RepeatableInterface;
 use TYPO3\CMS\Install\Updates\UpgradeWizardInterface;
 
 /**
@@ -33,6 +34,14 @@ final class SeparateBillingAddressUpgradeWizardTest extends UnitTestCase
     public function isUpgradeWizard(): void
     {
         self::assertInstanceOf(UpgradeWizardInterface::class, $this->subject);
+    }
+
+    /**
+     * @test
+     */
+    public function isRepeatable(): void
+    {
+        self::assertInstanceOf(RepeatableInterface::class, $this->subject);
     }
 
     /**


### PR DESCRIPTION
If new registrations have been created/imported, they should get fixed as well.

As the legacy registration form does not exist anymore, this is an rare edge case and hence does not count as a real bugfix for real-world bugs.