### PR TITLE
[TASK] Do not deprecate the `GenerateEventSlugsUpgradeWizard`

### DIFF
--- a/Classes/UpgradeWizards/GenerateEventSlugsUpgradeWizard.php
+++ b/Classes/UpgradeWizards/GenerateEventSlugsUpgradeWizard.php
@@ -17,9 +17,7 @@ use TYPO3\CMS\Install\Updates\RepeatableInterface;
 use TYPO3\CMS\Install\Updates\UpgradeWizardInterface;
 
 /**
- * Generates slugs for events
- *
- * @deprecated will be removed in seminars 7.0
+ * Generates slugs for events.
  */
 class GenerateEventSlugsUpgradeWizard implements UpgradeWizardInterface, RepeatableInterface, LoggerAwareInterface
 {


### PR DESCRIPTION
The wizard might still come in handy, e.g., when event records get imported.

[ci skip]

Fixes #2567