### PR TITLE
[BUGFIX] Provide non-suffixed slugified title to `AfterSlugGeneratedEvent`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Removed
 
 ### Fixed
+- Provide the non-suffixed slugified title to `AfterSlugGeneratedEvent` (#2612)
 
 ## 5.4.0
 

--- a/Classes/Seo/Event/AfterSlugGeneratedEvent.php
+++ b/Classes/Seo/Event/AfterSlugGeneratedEvent.php
@@ -44,7 +44,9 @@ final class AfterSlugGeneratedEvent implements StoppableEventInterface
     }
 
     /**
-     * Sets/changes the slug and stops the propagation of the event.
+     * Changes the slug and stops the propagation of the event.
+     *
+     * Note: The caller is responsible for ensuring that the slug is unique.
      */
     public function setSlug(string $slug): void
     {

--- a/Classes/Seo/SlugContext.php
+++ b/Classes/Seo/SlugContext.php
@@ -20,7 +20,7 @@ final class SlugContext
     private $displayTitle;
 
     /**
-     * @var string
+     * @var string the slugified title, which is not guaranteed to be unique
      */
     public $slugifiedTitle;
 

--- a/Classes/Seo/SlugGenerator.php
+++ b/Classes/Seo/SlugGenerator.php
@@ -77,9 +77,8 @@ class SlugGenerator
 
         $slugCandidate = (new SlugHelper(self::TABLE_NAME_EVENTS, 'slug', []))->sanitize($title);
 
-        $uniqueSlug = $this->makeSlugUnique($slugCandidate);
-        $slugContext = new SlugContext($eventUid, $title, $uniqueSlug);
-        $event = new AfterSlugGeneratedEvent($slugContext, $uniqueSlug);
+        $slugContext = new SlugContext($eventUid, $title, $slugCandidate);
+        $event = new AfterSlugGeneratedEvent($slugContext, $this->makeSlugUnique($slugCandidate));
         $this->eventDispatcher->dispatch($event);
 
         return $event->getSlug();

--- a/Tests/Functional/Seo/SlugGeneratorTest.php
+++ b/Tests/Functional/Seo/SlugGeneratorTest.php
@@ -406,12 +406,28 @@ final class SlugGeneratorTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function generateSlugReturnsSlugModifedByEvent(): void
+    public function generateSlugPassesNonUniqueSlugifiedTitleToEvent(): void
+    {
+        $this->importDataSet(__DIR__ . '/Fixtures/SingleEventWithSlug.xml');
+
+        $uid = 1234;
+        $record = ['uid' => $uid, 'object_type' => EventInterface::TYPE_SINGLE_EVENT, 'title' => 'Some event'];
+
+        $this->subject->generateSlug(['record' => $record]);
+
+        self::assertTrue($this->eventDispatcher->isDispatched());
+        self::assertSame('some-event', $this->eventDispatcher->getEvent()->getSlugContext()->getSlugifiedTitle());
+    }
+
+    /**
+     * @test
+     */
+    public function generateSlugReturnsSlugModifiedByEvent(): void
     {
         $modifiedSlug = 'there-is-no-spoon/42';
         $this->eventDispatcher->setModifiedSlug($modifiedSlug);
         $uid = 1234;
-        $record = ['uid' => $uid, 'object_type' => EventInterface::TYPE_EVENT_DATE, 'title' => ''];
+        $record = ['uid' => $uid, 'object_type' => EventInterface::TYPE_SINGLE_EVENT, 'title' => ''];
 
         $result = $this->subject->generateSlug(['record' => $record]);
 


### PR DESCRIPTION
Event listeners need to have access to the raw slugified title to work with. (The real current slug is also provided.)

Fixes #2610