### PR TITLE
[BUGFIX] Fix crash when editing an event in the BE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Removed
 
 ### Fixed
+- Fix crash when editing an event in the BE (#2614)
 - Provide the non-suffixed slugified title to `AfterSlugGeneratedEvent` (#2612)
 
 ## 5.4.0

--- a/Classes/Hooks/DataHandlerHook.php
+++ b/Classes/Hooks/DataHandlerHook.php
@@ -6,7 +6,6 @@ namespace OliverKlee\Seminars\Hooks;
 
 use OliverKlee\Seminars\Hooks\Interfaces\DataSanitization;
 use OliverKlee\Seminars\Seo\SlugGenerator;
-use Psr\EventDispatcher\EventDispatcherInterface;
 use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Database\Query\QueryBuilder;
@@ -106,8 +105,7 @@ class DataHandlerHook
 
         $currentSlug = $updatedData['slug'] ?? '';
         if (\preg_match('/^(-[\\d]+)?$/', $currentSlug) === 1) {
-            $eventDispatcher = GeneralUtility::makeInstance(EventDispatcherInterface::class);
-            $slugGenerator = GeneralUtility::makeInstance(SlugGenerator::class, $eventDispatcher);
+            $slugGenerator = GeneralUtility::makeInstance(SlugGenerator::class);
             $updatedData['slug'] = $slugGenerator->generateSlug(['record' => $updatedData]);
         }
 

--- a/Classes/Seo/SlugGenerator.php
+++ b/Classes/Seo/SlugGenerator.php
@@ -32,9 +32,11 @@ class SlugGenerator
      */
     private $eventDispatcher;
 
-    public function __construct(EventDispatcherInterface $eventDispatcher)
+    public function __construct()
     {
-        $this->eventDispatcher = $eventDispatcher;
+        // We are not using constructor injection here because the slug generator also is referenced from the TCA,
+        // which creates the instance without constructor arguments.
+        $this->eventDispatcher = GeneralUtility::makeInstance(EventDispatcherInterface::class);
     }
 
     public function getPrefix(): string

--- a/Classes/UpgradeWizards/GenerateEventSlugsUpgradeWizard.php
+++ b/Classes/UpgradeWizards/GenerateEventSlugsUpgradeWizard.php
@@ -6,7 +6,6 @@ namespace OliverKlee\Seminars\UpgradeWizards;
 
 use Doctrine\DBAL\Driver\ResultStatement;
 use OliverKlee\Seminars\Seo\SlugGenerator;
-use Psr\EventDispatcher\EventDispatcherInterface;
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerAwareTrait;
 use TYPO3\CMS\Core\Database\Connection;
@@ -93,8 +92,7 @@ class GenerateEventSlugsUpgradeWizard implements UpgradeWizardInterface, Repeata
             $queryResult = $query->execute();
         }
 
-        $eventDispatcher = GeneralUtility::makeInstance(EventDispatcherInterface::class);
-        $slugGenerator = GeneralUtility::makeInstance(SlugGenerator::class, $eventDispatcher);
+        $slugGenerator = GeneralUtility::makeInstance(SlugGenerator::class);
         $connection = $this->getConnectionPool()->getConnectionForTable(self::TABLE_NAME_EVENTS);
         if ($queryResult instanceof ResultStatement) {
             if (\method_exists($queryResult, 'fetchAllAssociative')) {

--- a/Tests/Functional/Seo/SlugGeneratorTest.php
+++ b/Tests/Functional/Seo/SlugGeneratorTest.php
@@ -8,6 +8,8 @@ use Nimut\TestingFramework\TestCase\FunctionalTestCase;
 use OliverKlee\Seminars\Domain\Model\Event\EventInterface;
 use OliverKlee\Seminars\Seo\SlugGenerator;
 use OliverKlee\Seminars\Tests\Unit\Seo\Fixtures\TestingSlugEventDispatcher;
+use Psr\EventDispatcher\EventDispatcherInterface;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
  * @covers \OliverKlee\Seminars\Seo\SlugGenerator
@@ -36,7 +38,31 @@ final class SlugGeneratorTest extends FunctionalTestCase
 
         $this->eventDispatcher = new TestingSlugEventDispatcher();
 
-        $this->subject = new SlugGenerator($this->eventDispatcher);
+        GeneralUtility::addInstance(EventDispatcherInterface::class, $this->eventDispatcher);
+        $this->subject = new SlugGenerator();
+    }
+
+    /**
+     * @test
+     */
+    public function canBeConstructedWithMakeInstanceWithoutArguments(): void
+    {
+        $subject = GeneralUtility::makeInstance(SlugGenerator::class);
+
+        self::assertInstanceOf(SlugGenerator::class, $subject);
+    }
+
+    /**
+     * @test
+     */
+    public function instanceCreatedWithMakeInstanceCanGenerateSlug(): void
+    {
+        $subject = GeneralUtility::makeInstance(SlugGenerator::class);
+        $record = ['uid' => 1234, 'object_type' => EventInterface::TYPE_SINGLE_EVENT, 'title' => 'There will be cake!'];
+
+        $result = $subject->generateSlug(['record' => $record]);
+
+        self::assertSame('there-will-be-cake', $result);
     }
 
     /**

--- a/Tests/Unit/Seo/SlugGeneratorTest.php
+++ b/Tests/Unit/Seo/SlugGeneratorTest.php
@@ -7,6 +7,8 @@ namespace OliverKlee\Seminars\Tests\Unit\Seo;
 use Nimut\TestingFramework\TestCase\UnitTestCase;
 use OliverKlee\Seminars\Seo\SlugGenerator;
 use OliverKlee\Seminars\Tests\Unit\Seo\Fixtures\TestingSlugEventDispatcher;
+use Psr\EventDispatcher\EventDispatcherInterface;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
  * @covers \OliverKlee\Seminars\Seo\SlugGenerator
@@ -22,8 +24,16 @@ final class SlugGeneratorTest extends UnitTestCase
     {
         parent::setUp();
 
-        $slugEventDispatcher = new TestingSlugEventDispatcher();
-        $this->subject = new SlugGenerator($slugEventDispatcher);
+        GeneralUtility::addInstance(EventDispatcherInterface::class, new TestingSlugEventDispatcher());
+
+        $this->subject = new SlugGenerator();
+    }
+
+    protected function tearDown(): void
+    {
+        GeneralUtility::purgeInstances();
+
+        parent::tearDown();
     }
 
     /**


### PR DESCRIPTION
Classes referenced in the TCA cannot have constructor injection as they are instantiated using `GeneralUtility::makeInstance`.

Fixes #2611