### PR TITLE
[BUGFIX] Allow keeping an existing slugs when re-generating it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Removed
 
 ### Fixed
+- Allow keeping an existing slugs when re-generating it (#2615)
 - Fix crash when editing an event in the BE (#2614)
 - Provide the non-suffixed slugified title to `AfterSlugGeneratedEvent` (#2612)
 

--- a/Tests/Functional/Seo/SlugGeneratorTest.php
+++ b/Tests/Functional/Seo/SlugGeneratorTest.php
@@ -299,6 +299,20 @@ final class SlugGeneratorTest extends FunctionalTestCase
     /**
      * @test
      */
+    public function generateSlugKeepsCurrentSlugIfTheGeneratedSlugIsTheSame(): void
+    {
+        $this->importDataSet(__DIR__ . '/Fixtures/SingleEventWithSlug.xml');
+
+        $record = ['uid' => 1, 'object_type' => EventInterface::TYPE_SINGLE_EVENT, 'title' => 'some-event'];
+
+        $result = $this->subject->generateSlug(['record' => $record]);
+
+        self::assertSame('some-event', $result);
+    }
+
+    /**
+     * @test
+     */
     public function generateSlugAddsIncreasedSuffixIfEventWithThePossibleSuffixedSlugAlreadyExists(): void
     {
         $this->importDataSet(__DIR__ . '/Fixtures/TwoSingleEventsWithSlug.xml');


### PR DESCRIPTION
When the slug generator makes a slug unique, the new slug should be allowed to be identical to the current slug.

Fixes #2613