### PR TITLE
[TASK] Switch the BE module to use event UIDs instead of models.

### DIFF
--- a/Resources/Private/Partials/BackEnd/EventList.html
+++ b/Resources/Private/Partials/BackEnd/EventList.html
@@ -103,7 +103,7 @@
                         <f:if condition="({statistics} && {visible})">
                             <f:if condition="{statistics.regularSeatsCount}">
                                 <f:link.action
-                                    controller="BackEnd\Registration" action="showForEvent" arguments="{event: event}"
+                                    controller="BackEnd\Registration" action="showForEvent" arguments="{eventUid: event.uid}"
                                     title="{f:translate(key: '{actionLabelPrefix}.showRegistrations.long')}"
                                     class="btn btn-default" additionalAttributes="{role: 'button'}">
                                     <core:icon identifier="actions-list"/>

--- a/Resources/Private/Templates/BackEnd/Registration/ShowForEvent.html
+++ b/Resources/Private/Templates/BackEnd/Registration/ShowForEvent.html
@@ -25,7 +25,7 @@
                 </h1>
                 <div class="col-auto">
                     <f:if condition="{regularRegistrations}">
-                        <f:link.action action="exportCsvForEvent" arguments="{event: event}"
+                        <f:link.action action="exportCsvForEvent" arguments="{eventUid: event.uid}"
                                        class="btn btn-default btn-sm">
                             <core:icon identifier="actions-document-export-csv"/>
                             <f:translate key="backEndModule.action.csvDownload"/>

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -231,16 +231,6 @@ parameters:
 			path: Classes/Controller/BackEnd/RegistrationController.php
 
 		-
-			message: "#^Parameter \\#1 \\$eventUid of method OliverKlee\\\\Seminars\\\\Domain\\\\Repository\\\\Registration\\\\RegistrationRepository\\:\\:findRegularRegistrationsByEvent\\(\\) expects int\\<1, max\\>, int\\|null given\\.$#"
-			count: 1
-			path: Classes/Controller/BackEnd/RegistrationController.php
-
-		-
-			message: "#^Parameter \\#1 \\$eventUid of method OliverKlee\\\\Seminars\\\\Domain\\\\Repository\\\\Registration\\\\RegistrationRepository\\:\\:findWaitingListRegistrationsByEvent\\(\\) expects int\\<1, max\\>, int\\|null given\\.$#"
-			count: 1
-			path: Classes/Controller/BackEnd/RegistrationController.php
-
-		-
 			message: "#^Parameter \\#2 \\$storageFolderUid of method OliverKlee\\\\Seminars\\\\Service\\\\RegistrationProcessor\\:\\:createAdditionalPersons\\(\\) expects int\\<0, max\\>, int given\\.$#"
 			count: 1
 			path: Classes/Controller/EventRegistrationController.php


### PR DESCRIPTION
This allows handling hidden events as well.

This is a pre-patch to #2653.