### PR TITLE
[BUGFIX] Fix compatibility with `typo3fluid/fluid` 2.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Removed
 
 ### Fixed
+- Fix compatibility with `typo3fluid/fluid` 2.10.0 (#2689)
 - Make some type annotations more specific (#2673)
 - Set EUR as a fallback currency (#2674)
 - Only show the registrations CSV export button if there are any records (#2660)

--- a/Classes/Rendering/NullRenderingContext.php
+++ b/Classes/Rendering/NullRenderingContext.php
@@ -205,4 +205,20 @@ final class NullRenderingContext implements RenderingContextInterface
     {
         return new NullRequest();
     }
+
+    /**
+     * @return never
+     */
+    public function getAttribute(string $name): ?object
+    {
+        throw new \BadMethodCallException('Not implemented.', 1701345822);
+    }
+
+    /**
+     * @return never
+     */
+    public function withAttribute(string $name, object $value): RenderingContextInterface
+    {
+        throw new \BadMethodCallException('Not implemented.', 1701345830);
+    }
 }


### PR DESCRIPTION
Fluid 2.10.0 introduced two new methods to `RenderingContextInterface` which we need to implement.

Fixes #2686