### PR TITLE
[BUGFIX] Exclude `egulias/email-validator` from Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,7 @@ updates:
       - dependency-type: "development"
     ignore:
       - dependency-name: "doctrine/dbal"
+      - dependency-name: "egulias/email-validator"
       - dependency-name: "ergebnis/composer-normalize"
         versions: [ ">= 2.20.0" ]
       - dependency-name: "friendsofphp/php-cs-fixer"


### PR DESCRIPTION
We need to keep allowing the lower version as well for TYPO3 10LTS.