### PR TITLE
[TASK] Avoid unnecessary DB cleanup in the legacy tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 - Migrate to the TYPO3 testing framework
-  (#2701, #2702, #2713, #2717, #2731, #2732)
+  (#2701, #2702, #2713, #2717, #2731, #2732, #2733)
 
 ### Deprecated
 

--- a/Tests/LegacyUnit/Bag/AbstractBagTest.php
+++ b/Tests/LegacyUnit/Bag/AbstractBagTest.php
@@ -59,7 +59,7 @@ final class AbstractBagTest extends FunctionalTestCase
 
     protected function tearDown(): void
     {
-        $this->testingFramework->cleanUp();
+        $this->testingFramework->cleanUpWithoutDatabase();
 
         parent::tearDown();
     }

--- a/Tests/LegacyUnit/Bag/CategoryBagTest.php
+++ b/Tests/LegacyUnit/Bag/CategoryBagTest.php
@@ -42,7 +42,7 @@ final class CategoryBagTest extends FunctionalTestCase
 
     protected function tearDown(): void
     {
-        $this->testingFramework->cleanUp();
+        $this->testingFramework->cleanUpWithoutDatabase();
 
         parent::tearDown();
     }

--- a/Tests/LegacyUnit/Bag/EventBagTest.php
+++ b/Tests/LegacyUnit/Bag/EventBagTest.php
@@ -46,7 +46,7 @@ final class EventBagTest extends FunctionalTestCase
 
     protected function tearDown(): void
     {
-        $this->testingFramework->cleanUp();
+        $this->testingFramework->cleanUpWithoutDatabase();
 
         RegistrationManager::purgeInstance();
 

--- a/Tests/LegacyUnit/Bag/OrganizerBagTest.php
+++ b/Tests/LegacyUnit/Bag/OrganizerBagTest.php
@@ -41,7 +41,7 @@ final class OrganizerBagTest extends FunctionalTestCase
 
     protected function tearDown(): void
     {
-        $this->testingFramework->cleanUp();
+        $this->testingFramework->cleanUpWithoutDatabase();
 
         parent::tearDown();
     }

--- a/Tests/LegacyUnit/BagBuilder/AbstractBagBuilderTest.php
+++ b/Tests/LegacyUnit/BagBuilder/AbstractBagBuilderTest.php
@@ -52,7 +52,7 @@ final class AbstractBagBuilderTest extends FunctionalTestCase
 
     protected function tearDown(): void
     {
-        $this->testingFramework->cleanUp();
+        $this->testingFramework->cleanUpWithoutDatabase();
 
         parent::tearDown();
     }

--- a/Tests/LegacyUnit/BagBuilder/CategoryBagBuilderTest.php
+++ b/Tests/LegacyUnit/BagBuilder/CategoryBagBuilderTest.php
@@ -42,7 +42,7 @@ final class CategoryBagBuilderTest extends FunctionalTestCase
 
     protected function tearDown(): void
     {
-        $this->testingFramework->cleanUp();
+        $this->testingFramework->cleanUpWithoutDatabase();
 
         parent::tearDown();
     }

--- a/Tests/LegacyUnit/BagBuilder/EventBagBuilderTest.php
+++ b/Tests/LegacyUnit/BagBuilder/EventBagBuilderTest.php
@@ -62,7 +62,7 @@ final class EventBagBuilderTest extends FunctionalTestCase
 
     protected function tearDown(): void
     {
-        $this->testingFramework->cleanUp();
+        $this->testingFramework->cleanUpWithoutDatabase();
 
         RegistrationManager::purgeInstance();
 

--- a/Tests/LegacyUnit/BagBuilder/OrganizerBagBuilderTest.php
+++ b/Tests/LegacyUnit/BagBuilder/OrganizerBagBuilderTest.php
@@ -42,7 +42,7 @@ final class OrganizerBagBuilderTest extends FunctionalTestCase
 
     protected function tearDown(): void
     {
-        $this->testingFramework->cleanUp();
+        $this->testingFramework->cleanUpWithoutDatabase();
 
         parent::tearDown();
     }

--- a/Tests/LegacyUnit/BagBuilder/RegistrationBagBuilderTest.php
+++ b/Tests/LegacyUnit/BagBuilder/RegistrationBagBuilderTest.php
@@ -49,7 +49,7 @@ final class RegistrationBagBuilderTest extends FunctionalTestCase
 
     protected function tearDown(): void
     {
-        $this->testingFramework->cleanUp();
+        $this->testingFramework->cleanUpWithoutDatabase();
 
         RegistrationManager::purgeInstance();
 

--- a/Tests/LegacyUnit/BagBuilder/SpeakerBagBuilderTest.php
+++ b/Tests/LegacyUnit/BagBuilder/SpeakerBagBuilderTest.php
@@ -42,7 +42,7 @@ final class SpeakerBagBuilderTest extends FunctionalTestCase
 
     protected function tearDown(): void
     {
-        $this->testingFramework->cleanUp();
+        $this->testingFramework->cleanUpWithoutDatabase();
 
         parent::tearDown();
     }

--- a/Tests/LegacyUnit/Csv/AbstractRegistrationListViewTest.php
+++ b/Tests/LegacyUnit/Csv/AbstractRegistrationListViewTest.php
@@ -133,7 +133,7 @@ final class AbstractRegistrationListViewTest extends FunctionalTestCase
         $this->purgeMockedInstances();
         $GLOBALS['TYPO3_CONF_VARS']['EXTCONF'] = $this->extConfBackup;
 
-        $this->testingFramework->cleanUp();
+        $this->testingFramework->cleanUpWithoutDatabase();
 
         parent::tearDown();
     }

--- a/Tests/LegacyUnit/Csv/CsvDownloaderTest.php
+++ b/Tests/LegacyUnit/Csv/CsvDownloaderTest.php
@@ -71,7 +71,7 @@ final class CsvDownloaderTest extends FunctionalTestCase
     protected function tearDown(): void
     {
         RegistrationManager::purgeInstance();
-        $this->testingFramework->cleanUp();
+        $this->testingFramework->cleanUpWithoutDatabase();
         $this->restoreOriginalEnvironment();
 
         parent::tearDown();

--- a/Tests/LegacyUnit/Csv/DownloadRegistrationListViewTest.php
+++ b/Tests/LegacyUnit/Csv/DownloadRegistrationListViewTest.php
@@ -72,7 +72,7 @@ final class DownloadRegistrationListViewTest extends FunctionalTestCase
 
     protected function tearDown(): void
     {
-        $this->testingFramework->cleanUp();
+        $this->testingFramework->cleanUpWithoutDatabase();
 
         parent::tearDown();
     }

--- a/Tests/LegacyUnit/Csv/EmailRegistrationListViewTest.php
+++ b/Tests/LegacyUnit/Csv/EmailRegistrationListViewTest.php
@@ -72,7 +72,7 @@ final class EmailRegistrationListViewTest extends FunctionalTestCase
 
     protected function tearDown(): void
     {
-        $this->testingFramework->cleanUp();
+        $this->testingFramework->cleanUpWithoutDatabase();
 
         parent::tearDown();
     }

--- a/Tests/LegacyUnit/Csv/EventListViewTest.php
+++ b/Tests/LegacyUnit/Csv/EventListViewTest.php
@@ -64,7 +64,7 @@ final class EventListViewTest extends FunctionalTestCase
 
     protected function tearDown(): void
     {
-        $this->testingFramework->cleanUp();
+        $this->testingFramework->cleanUpWithoutDatabase();
 
         parent::tearDown();
     }

--- a/Tests/LegacyUnit/Email/SalutationTest.php
+++ b/Tests/LegacyUnit/Email/SalutationTest.php
@@ -105,7 +105,7 @@ final class SalutationTest extends FunctionalTestCase
     protected function tearDown(): void
     {
         ConfigurationRegistry::purgeInstance();
-        $this->testingFramework->cleanUp();
+        $this->testingFramework->cleanUpWithoutDatabase();
         $GLOBALS['TYPO3_CONF_VARS']['EXTCONF'] = $this->extConfBackup;
 
         parent::tearDown();

--- a/Tests/LegacyUnit/FrontEnd/AbstractViewTest.php
+++ b/Tests/LegacyUnit/FrontEnd/AbstractViewTest.php
@@ -46,7 +46,7 @@ final class AbstractViewTest extends FunctionalTestCase
 
     protected function tearDown(): void
     {
-        $this->testingFramework->cleanUp();
+        $this->testingFramework->cleanUpWithoutDatabase();
 
         parent::tearDown();
     }

--- a/Tests/LegacyUnit/FrontEnd/CategoryListTest.php
+++ b/Tests/LegacyUnit/FrontEnd/CategoryListTest.php
@@ -67,7 +67,7 @@ final class CategoryListTest extends FunctionalTestCase
 
     protected function tearDown(): void
     {
-        $this->testingFramework->cleanUp();
+        $this->testingFramework->cleanUpWithoutDatabase();
 
         parent::tearDown();
     }

--- a/Tests/LegacyUnit/FrontEnd/DefaultControllerTest.php
+++ b/Tests/LegacyUnit/FrontEnd/DefaultControllerTest.php
@@ -180,7 +180,7 @@ final class DefaultControllerTest extends FunctionalTestCase
 
     protected function tearDown(): void
     {
-        $this->testingFramework->cleanUp();
+        $this->testingFramework->cleanUpWithoutDatabase();
 
         ConfigurationRegistry::purgeInstance();
         ConfigurationProxy::purgeInstances();

--- a/Tests/LegacyUnit/FrontEnd/RegistrationsListTest.php
+++ b/Tests/LegacyUnit/FrontEnd/RegistrationsListTest.php
@@ -89,7 +89,7 @@ final class RegistrationsListTest extends FunctionalTestCase
 
     protected function tearDown(): void
     {
-        $this->testingFramework->cleanUp();
+        $this->testingFramework->cleanUpWithoutDatabase();
 
         RegistrationManager::purgeInstance();
 

--- a/Tests/LegacyUnit/FrontEnd/RequirementsListTest.php
+++ b/Tests/LegacyUnit/FrontEnd/RequirementsListTest.php
@@ -80,7 +80,7 @@ final class RequirementsListTest extends FunctionalTestCase
 
     protected function tearDown(): void
     {
-        $this->testingFramework->cleanUp();
+        $this->testingFramework->cleanUpWithoutDatabase();
 
         ConfigurationRegistry::purgeInstance();
         RegistrationManager::purgeInstance();

--- a/Tests/LegacyUnit/FrontEnd/SelectorWidgetTest.php
+++ b/Tests/LegacyUnit/FrontEnd/SelectorWidgetTest.php
@@ -62,7 +62,7 @@ final class SelectorWidgetTest extends FunctionalTestCase
 
     protected function tearDown(): void
     {
-        $this->testingFramework->cleanUp();
+        $this->testingFramework->cleanUpWithoutDatabase();
 
         RegistrationManager::purgeInstance();
 

--- a/Tests/LegacyUnit/Mapper/CategoryMapperTest.php
+++ b/Tests/LegacyUnit/Mapper/CategoryMapperTest.php
@@ -41,7 +41,7 @@ final class CategoryMapperTest extends FunctionalTestCase
 
     protected function tearDown(): void
     {
-        $this->testingFramework->cleanUp();
+        $this->testingFramework->cleanUpWithoutDatabase();
 
         parent::tearDown();
     }

--- a/Tests/LegacyUnit/Mapper/CheckboxMapperTest.php
+++ b/Tests/LegacyUnit/Mapper/CheckboxMapperTest.php
@@ -41,7 +41,7 @@ final class CheckboxMapperTest extends FunctionalTestCase
 
     protected function tearDown(): void
     {
-        $this->testingFramework->cleanUp();
+        $this->testingFramework->cleanUpWithoutDatabase();
 
         parent::tearDown();
     }

--- a/Tests/LegacyUnit/Mapper/EventDateMapperTest.php
+++ b/Tests/LegacyUnit/Mapper/EventDateMapperTest.php
@@ -56,7 +56,7 @@ final class EventDateMapperTest extends FunctionalTestCase
 
     protected function tearDown(): void
     {
-        $this->testingFramework->cleanUp();
+        $this->testingFramework->cleanUpWithoutDatabase();
 
         parent::tearDown();
     }

--- a/Tests/LegacyUnit/Mapper/EventMapperTest.php
+++ b/Tests/LegacyUnit/Mapper/EventMapperTest.php
@@ -57,7 +57,7 @@ final class EventMapperTest extends FunctionalTestCase
 
     protected function tearDown(): void
     {
-        $this->testingFramework->cleanUp();
+        $this->testingFramework->cleanUpWithoutDatabase();
 
         parent::tearDown();
     }

--- a/Tests/LegacyUnit/Mapper/EventTopicMapperTest.php
+++ b/Tests/LegacyUnit/Mapper/EventTopicMapperTest.php
@@ -55,7 +55,7 @@ final class EventTopicMapperTest extends FunctionalTestCase
 
     protected function tearDown(): void
     {
-        $this->testingFramework->cleanUp();
+        $this->testingFramework->cleanUpWithoutDatabase();
 
         parent::tearDown();
     }

--- a/Tests/LegacyUnit/Mapper/EventTypeMapperTest.php
+++ b/Tests/LegacyUnit/Mapper/EventTypeMapperTest.php
@@ -38,7 +38,7 @@ final class EventTypeMapperTest extends FunctionalTestCase
 
     protected function tearDown(): void
     {
-        $this->testingFramework->cleanUp();
+        $this->testingFramework->cleanUpWithoutDatabase();
 
         parent::tearDown();
     }

--- a/Tests/LegacyUnit/Mapper/FoodMapperTest.php
+++ b/Tests/LegacyUnit/Mapper/FoodMapperTest.php
@@ -41,7 +41,7 @@ final class FoodMapperTest extends FunctionalTestCase
 
     protected function tearDown(): void
     {
-        $this->testingFramework->cleanUp();
+        $this->testingFramework->cleanUpWithoutDatabase();
 
         parent::tearDown();
     }

--- a/Tests/LegacyUnit/Mapper/LodgingMapperTest.php
+++ b/Tests/LegacyUnit/Mapper/LodgingMapperTest.php
@@ -41,7 +41,7 @@ final class LodgingMapperTest extends FunctionalTestCase
 
     protected function tearDown(): void
     {
-        $this->testingFramework->cleanUp();
+        $this->testingFramework->cleanUpWithoutDatabase();
 
         parent::tearDown();
     }

--- a/Tests/LegacyUnit/Mapper/OrganizerMapperTest.php
+++ b/Tests/LegacyUnit/Mapper/OrganizerMapperTest.php
@@ -41,7 +41,7 @@ final class OrganizerMapperTest extends FunctionalTestCase
 
     protected function tearDown(): void
     {
-        $this->testingFramework->cleanUp();
+        $this->testingFramework->cleanUpWithoutDatabase();
 
         parent::tearDown();
     }

--- a/Tests/LegacyUnit/Mapper/PaymentMethodMapperTest.php
+++ b/Tests/LegacyUnit/Mapper/PaymentMethodMapperTest.php
@@ -41,7 +41,7 @@ final class PaymentMethodMapperTest extends FunctionalTestCase
 
     protected function tearDown(): void
     {
-        $this->testingFramework->cleanUp();
+        $this->testingFramework->cleanUpWithoutDatabase();
 
         parent::tearDown();
     }

--- a/Tests/LegacyUnit/Mapper/PlaceMapperTest.php
+++ b/Tests/LegacyUnit/Mapper/PlaceMapperTest.php
@@ -41,7 +41,7 @@ final class PlaceMapperTest extends FunctionalTestCase
 
     protected function tearDown(): void
     {
-        $this->testingFramework->cleanUp();
+        $this->testingFramework->cleanUpWithoutDatabase();
 
         parent::tearDown();
     }

--- a/Tests/LegacyUnit/Mapper/RegistrationMapperTest.php
+++ b/Tests/LegacyUnit/Mapper/RegistrationMapperTest.php
@@ -53,7 +53,7 @@ final class RegistrationMapperTest extends FunctionalTestCase
 
     protected function tearDown(): void
     {
-        $this->testingFramework->cleanUp();
+        $this->testingFramework->cleanUpWithoutDatabase();
 
         parent::tearDown();
     }

--- a/Tests/LegacyUnit/Mapper/SingleEventMapperTest.php
+++ b/Tests/LegacyUnit/Mapper/SingleEventMapperTest.php
@@ -55,7 +55,7 @@ final class SingleEventMapperTest extends FunctionalTestCase
 
     protected function tearDown(): void
     {
-        $this->testingFramework->cleanUp();
+        $this->testingFramework->cleanUpWithoutDatabase();
 
         parent::tearDown();
     }

--- a/Tests/LegacyUnit/Mapper/SkillMapperTest.php
+++ b/Tests/LegacyUnit/Mapper/SkillMapperTest.php
@@ -41,7 +41,7 @@ final class SkillMapperTest extends FunctionalTestCase
 
     protected function tearDown(): void
     {
-        $this->testingFramework->cleanUp();
+        $this->testingFramework->cleanUpWithoutDatabase();
 
         parent::tearDown();
     }

--- a/Tests/LegacyUnit/Mapper/SpeakerMapperTest.php
+++ b/Tests/LegacyUnit/Mapper/SpeakerMapperTest.php
@@ -41,7 +41,7 @@ final class SpeakerMapperTest extends FunctionalTestCase
 
     protected function tearDown(): void
     {
-        $this->testingFramework->cleanUp();
+        $this->testingFramework->cleanUpWithoutDatabase();
 
         parent::tearDown();
     }

--- a/Tests/LegacyUnit/Mapper/TargetGroupMapperTest.php
+++ b/Tests/LegacyUnit/Mapper/TargetGroupMapperTest.php
@@ -41,7 +41,7 @@ final class TargetGroupMapperTest extends FunctionalTestCase
 
     protected function tearDown(): void
     {
-        $this->testingFramework->cleanUp();
+        $this->testingFramework->cleanUpWithoutDatabase();
 
         parent::tearDown();
     }

--- a/Tests/LegacyUnit/Mapper/TimeSlotMapperTest.php
+++ b/Tests/LegacyUnit/Mapper/TimeSlotMapperTest.php
@@ -49,7 +49,7 @@ final class TimeSlotMapperTest extends FunctionalTestCase
 
     protected function tearDown(): void
     {
-        $this->testingFramework->cleanUp();
+        $this->testingFramework->cleanUpWithoutDatabase();
 
         parent::tearDown();
     }

--- a/Tests/LegacyUnit/Model/FrontEndUserTest.php
+++ b/Tests/LegacyUnit/Model/FrontEndUserTest.php
@@ -40,7 +40,7 @@ final class FrontEndUserTest extends FunctionalTestCase
 
     protected function tearDown(): void
     {
-        $this->testingFramework->cleanUp();
+        $this->testingFramework->cleanUpWithoutDatabase();
 
         parent::tearDown();
     }

--- a/Tests/LegacyUnit/Model/RegistrationTest.php
+++ b/Tests/LegacyUnit/Model/RegistrationTest.php
@@ -49,7 +49,7 @@ final class RegistrationTest extends FunctionalTestCase
 
     protected function tearDown(): void
     {
-        $this->testingFramework->cleanUp();
+        $this->testingFramework->cleanUpWithoutDatabase();
 
         parent::tearDown();
     }

--- a/Tests/LegacyUnit/OldModel/AbstractModelTest.php
+++ b/Tests/LegacyUnit/OldModel/AbstractModelTest.php
@@ -67,7 +67,7 @@ final class AbstractModelTest extends FunctionalTestCase
 
     protected function tearDown(): void
     {
-        $this->testingFramework->cleanUp();
+        $this->testingFramework->cleanUpWithoutDatabase();
 
         parent::tearDown();
     }

--- a/Tests/LegacyUnit/OldModel/LegacyEventTest.php
+++ b/Tests/LegacyUnit/OldModel/LegacyEventTest.php
@@ -111,7 +111,7 @@ final class LegacyEventTest extends FunctionalTestCase
 
     protected function tearDown(): void
     {
-        $this->testingFramework->cleanUp();
+        $this->testingFramework->cleanUpWithoutDatabase();
 
         ConfigurationRegistry::purgeInstance();
         RegistrationManager::purgeInstance();

--- a/Tests/LegacyUnit/OldModel/LegacyOrganizerTest.php
+++ b/Tests/LegacyUnit/OldModel/LegacyOrganizerTest.php
@@ -65,7 +65,7 @@ final class LegacyOrganizerTest extends FunctionalTestCase
 
     protected function tearDown(): void
     {
-        $this->testingFramework->cleanUp();
+        $this->testingFramework->cleanUpWithoutDatabase();
 
         parent::tearDown();
     }

--- a/Tests/LegacyUnit/OldModel/LegacyRegistrationTest.php
+++ b/Tests/LegacyUnit/OldModel/LegacyRegistrationTest.php
@@ -120,7 +120,7 @@ final class LegacyRegistrationTest extends FunctionalTestCase
 
     protected function tearDown(): void
     {
-        $this->testingFramework->cleanUp();
+        $this->testingFramework->cleanUpWithoutDatabase();
 
         RegistrationManager::purgeInstance();
 

--- a/Tests/LegacyUnit/OldModel/LegacyTimeSlotTest.php
+++ b/Tests/LegacyUnit/OldModel/LegacyTimeSlotTest.php
@@ -66,7 +66,7 @@ final class LegacyTimeSlotTest extends FunctionalTestCase
 
     protected function tearDown(): void
     {
-        $this->testingFramework->cleanUp();
+        $this->testingFramework->cleanUpWithoutDatabase();
 
         parent::tearDown();
     }

--- a/Tests/LegacyUnit/SchedulerTasks/MailNotifierTest.php
+++ b/Tests/LegacyUnit/SchedulerTasks/MailNotifierTest.php
@@ -150,7 +150,7 @@ final class MailNotifierTest extends FunctionalTestCase
     protected function tearDown(): void
     {
         if ($this->testingFramework instanceof TestingFramework) {
-            $this->testingFramework->cleanUp();
+            $this->testingFramework->cleanUpWithoutDatabase();
         }
 
         $GLOBALS['LANG'] = $this->languageBackup;

--- a/Tests/LegacyUnit/Service/EmailServiceTest.php
+++ b/Tests/LegacyUnit/Service/EmailServiceTest.php
@@ -129,7 +129,7 @@ final class EmailServiceTest extends FunctionalTestCase
 
     protected function tearDown(): void
     {
-        $this->testingFramework->cleanUp();
+        $this->testingFramework->cleanUpWithoutDatabase();
         $GLOBALS['LANG'] = $this->languageBackup;
 
         parent::tearDown();

--- a/Tests/LegacyUnit/Service/EventStatusServiceTest.php
+++ b/Tests/LegacyUnit/Service/EventStatusServiceTest.php
@@ -72,7 +72,7 @@ final class EventStatusServiceTest extends FunctionalTestCase
 
     protected function tearDown(): void
     {
-        $this->testingFramework->cleanUp();
+        $this->testingFramework->cleanUpWithoutDatabase();
 
         parent::tearDown();
     }

--- a/Tests/LegacyUnit/Service/RegistrationManagerTest.php
+++ b/Tests/LegacyUnit/Service/RegistrationManagerTest.php
@@ -198,7 +198,7 @@ final class RegistrationManagerTest extends FunctionalTestCase
 
     protected function tearDown(): void
     {
-        $this->testingFramework->cleanUp();
+        $this->testingFramework->cleanUpWithoutDatabase();
 
         $this->purgeMockedInstances();
 


### PR DESCRIPTION
The TYPO3 testing framework now takes care of providing a clean database for the tests.

This change should speed the tests up a bit.