### PR TITLE
[BUGFIX] Always also load static_info_tables in the tests

### DIFF
--- a/Tests/Functional/BackEnd/AbstractEventMailFormTest.php
+++ b/Tests/Functional/BackEnd/AbstractEventMailFormTest.php
@@ -21,6 +21,7 @@ final class AbstractEventMailFormTest extends FunctionalTestCase
     use MakeInstanceTrait;
 
     protected $testExtensionsToLoad = [
+        'typo3conf/ext/static_info_tables',
         'typo3conf/ext/feuserextrafields',
         'typo3conf/ext/oelib',
         'typo3conf/ext/seminars',

--- a/Tests/Functional/BackEnd/GeneralEventMailFormTest.php
+++ b/Tests/Functional/BackEnd/GeneralEventMailFormTest.php
@@ -24,6 +24,7 @@ final class GeneralEventMailFormTest extends FunctionalTestCase
     use MakeInstanceTrait;
 
     protected $testExtensionsToLoad = [
+        'typo3conf/ext/static_info_tables',
         'typo3conf/ext/feuserextrafields',
         'typo3conf/ext/oelib',
         'typo3conf/ext/seminars',

--- a/Tests/Functional/Bag/SpeakerBagTest.php
+++ b/Tests/Functional/Bag/SpeakerBagTest.php
@@ -16,6 +16,7 @@ final class SpeakerBagTest extends FunctionalTestCase
     use BagHelper;
 
     protected $testExtensionsToLoad = [
+        'typo3conf/ext/static_info_tables',
         'typo3conf/ext/feuserextrafields',
         'typo3conf/ext/oelib',
         'typo3conf/ext/seminars',

--- a/Tests/Functional/BagBuilder/AbstractBagBuilderTest.php
+++ b/Tests/Functional/BagBuilder/AbstractBagBuilderTest.php
@@ -16,6 +16,7 @@ final class AbstractBagBuilderTest extends FunctionalTestCase
     use BagHelper;
 
     protected $testExtensionsToLoad = [
+        'typo3conf/ext/static_info_tables',
         'typo3conf/ext/feuserextrafields',
         'typo3conf/ext/oelib',
         'typo3conf/ext/seminars',

--- a/Tests/Functional/BagBuilder/EventBagBuilderTest.php
+++ b/Tests/Functional/BagBuilder/EventBagBuilderTest.php
@@ -15,6 +15,7 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
 final class EventBagBuilderTest extends FunctionalTestCase
 {
     protected $testExtensionsToLoad = [
+        'typo3conf/ext/static_info_tables',
         'typo3conf/ext/feuserextrafields',
         'typo3conf/ext/oelib',
         'typo3conf/ext/seminars',

--- a/Tests/Functional/Configuration/CsvExportConfigurationCheckTest.php
+++ b/Tests/Functional/Configuration/CsvExportConfigurationCheckTest.php
@@ -14,6 +14,7 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
 final class CsvExportConfigurationCheckTest extends FunctionalTestCase
 {
     protected $testExtensionsToLoad = [
+        'typo3conf/ext/static_info_tables',
         'typo3conf/ext/feuserextrafields',
         'typo3conf/ext/oelib',
         'typo3conf/ext/seminars',

--- a/Tests/Functional/Configuration/RegistrationListConfigurationCheckTest.php
+++ b/Tests/Functional/Configuration/RegistrationListConfigurationCheckTest.php
@@ -15,6 +15,7 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
 final class RegistrationListConfigurationCheckTest extends FunctionalTestCase
 {
     protected $testExtensionsToLoad = [
+        'typo3conf/ext/static_info_tables',
         'typo3conf/ext/feuserextrafields',
         'typo3conf/ext/oelib',
         'typo3conf/ext/seminars',

--- a/Tests/Functional/Configuration/SharedConfigurationCheckTest.php
+++ b/Tests/Functional/Configuration/SharedConfigurationCheckTest.php
@@ -14,10 +14,10 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
 final class SharedConfigurationCheckTest extends FunctionalTestCase
 {
     protected $testExtensionsToLoad = [
+        'typo3conf/ext/static_info_tables',
         'typo3conf/ext/feuserextrafields',
         'typo3conf/ext/oelib',
         'typo3conf/ext/seminars',
-        'typo3conf/ext/static_info_tables',
     ];
 
     /**

--- a/Tests/Functional/Configuration/TypoScriptSetupTest.php
+++ b/Tests/Functional/Configuration/TypoScriptSetupTest.php
@@ -13,6 +13,7 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
 final class TypoScriptSetupTest extends FunctionalTestCase
 {
     protected $testExtensionsToLoad = [
+        'typo3conf/ext/static_info_tables',
         'typo3conf/ext/feuserextrafields',
         'typo3conf/ext/oelib',
         'typo3conf/ext/seminars',

--- a/Tests/Functional/Csv/CsvDownloaderTest.php
+++ b/Tests/Functional/Csv/CsvDownloaderTest.php
@@ -18,6 +18,7 @@ final class CsvDownloaderTest extends FunctionalTestCase
     use LanguageHelper;
 
     protected $testExtensionsToLoad = [
+        'typo3conf/ext/static_info_tables',
         'typo3conf/ext/feuserextrafields',
         'typo3conf/ext/oelib',
         'typo3conf/ext/seminars',

--- a/Tests/Functional/Domain/Repository/AccommodationOptionRepositoryTest.php
+++ b/Tests/Functional/Domain/Repository/AccommodationOptionRepositoryTest.php
@@ -18,6 +18,7 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
 final class AccommodationOptionRepositoryTest extends FunctionalTestCase
 {
     protected $testExtensionsToLoad = [
+        'typo3conf/ext/static_info_tables',
         'typo3conf/ext/feuserextrafields',
         'typo3conf/ext/oelib',
         'typo3conf/ext/seminars',

--- a/Tests/Functional/Domain/Repository/Event/EventRepositoryTest.php
+++ b/Tests/Functional/Domain/Repository/Event/EventRepositoryTest.php
@@ -38,6 +38,7 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
 final class EventRepositoryTest extends FunctionalTestCase
 {
     protected $testExtensionsToLoad = [
+        'typo3conf/ext/static_info_tables',
         'typo3conf/ext/feuserextrafields',
         'typo3conf/ext/oelib',
         'typo3conf/ext/seminars',

--- a/Tests/Functional/Domain/Repository/EventTypeRepositoryTest.php
+++ b/Tests/Functional/Domain/Repository/EventTypeRepositoryTest.php
@@ -19,6 +19,7 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
 final class EventTypeRepositoryTest extends FunctionalTestCase
 {
     protected $testExtensionsToLoad = [
+        'typo3conf/ext/static_info_tables',
         'typo3conf/ext/feuserextrafields',
         'typo3conf/ext/oelib',
         'typo3conf/ext/seminars',

--- a/Tests/Functional/Domain/Repository/FoodOptionRepositoryTest.php
+++ b/Tests/Functional/Domain/Repository/FoodOptionRepositoryTest.php
@@ -18,6 +18,7 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
 final class FoodOptionRepositoryTest extends FunctionalTestCase
 {
     protected $testExtensionsToLoad = [
+        'typo3conf/ext/static_info_tables',
         'typo3conf/ext/feuserextrafields',
         'typo3conf/ext/oelib',
         'typo3conf/ext/seminars',

--- a/Tests/Functional/Domain/Repository/OrganizerRepositoryTest.php
+++ b/Tests/Functional/Domain/Repository/OrganizerRepositoryTest.php
@@ -18,6 +18,7 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
 final class OrganizerRepositoryTest extends FunctionalTestCase
 {
     protected $testExtensionsToLoad = [
+        'typo3conf/ext/static_info_tables',
         'typo3conf/ext/feuserextrafields',
         'typo3conf/ext/oelib',
         'typo3conf/ext/seminars',

--- a/Tests/Functional/Domain/Repository/PaymentMethodRepositoryTest.php
+++ b/Tests/Functional/Domain/Repository/PaymentMethodRepositoryTest.php
@@ -18,6 +18,7 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
 final class PaymentMethodRepositoryTest extends FunctionalTestCase
 {
     protected $testExtensionsToLoad = [
+        'typo3conf/ext/static_info_tables',
         'typo3conf/ext/feuserextrafields',
         'typo3conf/ext/oelib',
         'typo3conf/ext/seminars',

--- a/Tests/Functional/Domain/Repository/Registration/RegistrationRepositoryTest.php
+++ b/Tests/Functional/Domain/Repository/Registration/RegistrationRepositoryTest.php
@@ -35,6 +35,7 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
 final class RegistrationRepositoryTest extends FunctionalTestCase
 {
     protected $testExtensionsToLoad = [
+        'typo3conf/ext/static_info_tables',
         'typo3conf/ext/feuserextrafields',
         'typo3conf/ext/oelib',
         'typo3conf/ext/seminars',

--- a/Tests/Functional/Domain/Repository/RegistrationCheckboxRepositoryTest.php
+++ b/Tests/Functional/Domain/Repository/RegistrationCheckboxRepositoryTest.php
@@ -18,6 +18,7 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
 final class RegistrationCheckboxRepositoryTest extends FunctionalTestCase
 {
     protected $testExtensionsToLoad = [
+        'typo3conf/ext/static_info_tables',
         'typo3conf/ext/feuserextrafields',
         'typo3conf/ext/oelib',
         'typo3conf/ext/seminars',

--- a/Tests/Functional/Domain/Repository/SpeakerRepositoryTest.php
+++ b/Tests/Functional/Domain/Repository/SpeakerRepositoryTest.php
@@ -18,6 +18,7 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
 final class SpeakerRepositoryTest extends FunctionalTestCase
 {
     protected $testExtensionsToLoad = [
+        'typo3conf/ext/static_info_tables',
         'typo3conf/ext/feuserextrafields',
         'typo3conf/ext/oelib',
         'typo3conf/ext/seminars',

--- a/Tests/Functional/Domain/Repository/VenueRepositoryTest.php
+++ b/Tests/Functional/Domain/Repository/VenueRepositoryTest.php
@@ -18,6 +18,7 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
 final class VenueRepositoryTest extends FunctionalTestCase
 {
     protected $testExtensionsToLoad = [
+        'typo3conf/ext/static_info_tables',
         'typo3conf/ext/feuserextrafields',
         'typo3conf/ext/oelib',
         'typo3conf/ext/seminars',

--- a/Tests/Functional/FrontEnd/CategoryListTest.php
+++ b/Tests/Functional/FrontEnd/CategoryListTest.php
@@ -21,6 +21,7 @@ final class CategoryListTest extends FunctionalTestCase
     use LanguageHelper;
 
     protected $testExtensionsToLoad = [
+        'typo3conf/ext/static_info_tables',
         'typo3conf/ext/feuserextrafields',
         'typo3conf/ext/oelib',
         'typo3conf/ext/seminars',

--- a/Tests/Functional/FrontEnd/DefaultController/ListViewTest.php
+++ b/Tests/Functional/FrontEnd/DefaultController/ListViewTest.php
@@ -21,6 +21,7 @@ final class ListViewTest extends FunctionalTestCase
     use LanguageHelper;
 
     protected $testExtensionsToLoad = [
+        'typo3conf/ext/static_info_tables',
         'typo3conf/ext/feuserextrafields',
         'typo3conf/ext/oelib',
         'typo3conf/ext/seminars',

--- a/Tests/Functional/FrontEnd/DefaultController/PluginDefinitionTest.php
+++ b/Tests/Functional/FrontEnd/DefaultController/PluginDefinitionTest.php
@@ -13,6 +13,7 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
 final class PluginDefinitionTest extends FunctionalTestCase
 {
     protected $testExtensionsToLoad = [
+        'typo3conf/ext/static_info_tables',
         'typo3conf/ext/feuserextrafields',
         'typo3conf/ext/oelib',
         'typo3conf/ext/seminars',

--- a/Tests/Functional/FrontEnd/DefaultController/SingleViewTest.php
+++ b/Tests/Functional/FrontEnd/DefaultController/SingleViewTest.php
@@ -23,6 +23,7 @@ final class SingleViewTest extends FunctionalTestCase
     use LanguageHelper;
 
     protected $testExtensionsToLoad = [
+        'typo3conf/ext/static_info_tables',
         'typo3conf/ext/feuserextrafields',
         'typo3conf/ext/oelib',
         'typo3conf/ext/seminars',

--- a/Tests/Functional/Hooks/DataHandlerHookTest.php
+++ b/Tests/Functional/Hooks/DataHandlerHookTest.php
@@ -22,6 +22,7 @@ final class DataHandlerHookTest extends FunctionalTestCase
     private const TABLE_SEMINARS = 'tx_seminars_seminars';
 
     protected $testExtensionsToLoad = [
+        'typo3conf/ext/static_info_tables',
         'typo3conf/ext/feuserextrafields',
         'typo3conf/ext/oelib',
         'typo3conf/ext/seminars',

--- a/Tests/Functional/Localization/TranslateTraitTest.php
+++ b/Tests/Functional/Localization/TranslateTraitTest.php
@@ -19,6 +19,7 @@ final class TranslateTraitTest extends FunctionalTestCase
     use TranslateTrait;
 
     protected $testExtensionsToLoad = [
+        'typo3conf/ext/static_info_tables',
         'typo3conf/ext/feuserextrafields',
         'typo3conf/ext/oelib',
         'typo3conf/ext/seminars',

--- a/Tests/Functional/Mapper/EventDateMapperTest.php
+++ b/Tests/Functional/Mapper/EventDateMapperTest.php
@@ -19,6 +19,7 @@ final class EventDateMapperTest extends FunctionalTestCase
     use CollectionHelper;
 
     protected $testExtensionsToLoad = [
+        'typo3conf/ext/static_info_tables',
         'typo3conf/ext/feuserextrafields',
         'typo3conf/ext/oelib',
         'typo3conf/ext/seminars',

--- a/Tests/Functional/Mapper/EventMapperTest.php
+++ b/Tests/Functional/Mapper/EventMapperTest.php
@@ -19,6 +19,7 @@ final class EventMapperTest extends FunctionalTestCase
     use CollectionHelper;
 
     protected $testExtensionsToLoad = [
+        'typo3conf/ext/static_info_tables',
         'typo3conf/ext/feuserextrafields',
         'typo3conf/ext/oelib',
         'typo3conf/ext/seminars',

--- a/Tests/Functional/Mapper/EventTopicMapperTest.php
+++ b/Tests/Functional/Mapper/EventTopicMapperTest.php
@@ -19,6 +19,7 @@ final class EventTopicMapperTest extends FunctionalTestCase
     use CollectionHelper;
 
     protected $testExtensionsToLoad = [
+        'typo3conf/ext/static_info_tables',
         'typo3conf/ext/feuserextrafields',
         'typo3conf/ext/oelib',
         'typo3conf/ext/seminars',

--- a/Tests/Functional/Mapper/RegistrationMapperTest.php
+++ b/Tests/Functional/Mapper/RegistrationMapperTest.php
@@ -14,6 +14,7 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
 final class RegistrationMapperTest extends FunctionalTestCase
 {
     protected $testExtensionsToLoad = [
+        'typo3conf/ext/static_info_tables',
         'typo3conf/ext/feuserextrafields',
         'typo3conf/ext/oelib',
         'typo3conf/ext/seminars',

--- a/Tests/Functional/OldModel/AbstractModelTest.php
+++ b/Tests/Functional/OldModel/AbstractModelTest.php
@@ -20,6 +20,7 @@ final class AbstractModelTest extends FunctionalTestCase
     private const NOW = 1574714414;
 
     protected $testExtensionsToLoad = [
+        'typo3conf/ext/static_info_tables',
         'typo3conf/ext/feuserextrafields',
         'typo3conf/ext/oelib',
         'typo3conf/ext/seminars',

--- a/Tests/Functional/OldModel/AbstractTimeSpanTest.php
+++ b/Tests/Functional/OldModel/AbstractTimeSpanTest.php
@@ -38,6 +38,7 @@ final class AbstractTimeSpanTest extends FunctionalTestCase
     ];
 
     protected $testExtensionsToLoad = [
+        'typo3conf/ext/static_info_tables',
         'typo3conf/ext/feuserextrafields',
         'typo3conf/ext/oelib',
         'typo3conf/ext/seminars',

--- a/Tests/Functional/OldModel/LegacyCategoryTest.php
+++ b/Tests/Functional/OldModel/LegacyCategoryTest.php
@@ -17,6 +17,7 @@ final class LegacyCategoryTest extends FunctionalTestCase
     use FalHelper;
 
     protected $testExtensionsToLoad = [
+        'typo3conf/ext/static_info_tables',
         'typo3conf/ext/feuserextrafields',
         'typo3conf/ext/oelib',
         'typo3conf/ext/seminars',

--- a/Tests/Functional/OldModel/LegacyEventTest.php
+++ b/Tests/Functional/OldModel/LegacyEventTest.php
@@ -36,10 +36,10 @@ final class LegacyEventTest extends FunctionalTestCase
     ];
 
     protected $testExtensionsToLoad = [
+        'typo3conf/ext/static_info_tables',
         'typo3conf/ext/feuserextrafields',
         'typo3conf/ext/oelib',
         'typo3conf/ext/seminars',
-        'typo3conf/ext/static_info_tables',
     ];
 
     /**

--- a/Tests/Functional/OldModel/LegacyRegistrationTest.php
+++ b/Tests/Functional/OldModel/LegacyRegistrationTest.php
@@ -31,6 +31,7 @@ final class LegacyRegistrationTest extends FunctionalTestCase
     private const TIME_FORMAT = '%H:%M';
 
     protected $testExtensionsToLoad = [
+        'typo3conf/ext/static_info_tables',
         'typo3conf/ext/feuserextrafields',
         'typo3conf/ext/oelib',
         'typo3conf/ext/seminars',

--- a/Tests/Functional/OldModel/LegacySpeakerTest.php
+++ b/Tests/Functional/OldModel/LegacySpeakerTest.php
@@ -17,6 +17,7 @@ final class LegacySpeakerTest extends FunctionalTestCase
     use FalHelper;
 
     protected $testExtensionsToLoad = [
+        'typo3conf/ext/static_info_tables',
         'typo3conf/ext/feuserextrafields',
         'typo3conf/ext/oelib',
         'typo3conf/ext/seminars',

--- a/Tests/Functional/SchedulerTasks/MailNotifierConfigurationTest.php
+++ b/Tests/Functional/SchedulerTasks/MailNotifierConfigurationTest.php
@@ -30,6 +30,7 @@ final class MailNotifierConfigurationTest extends FunctionalTestCase
     protected $coreExtensionsToLoad = ['scheduler'];
 
     protected $testExtensionsToLoad = [
+        'typo3conf/ext/static_info_tables',
         'typo3conf/ext/feuserextrafields',
         'typo3conf/ext/oelib',
         'typo3conf/ext/seminars',

--- a/Tests/Functional/SchedulerTasks/MailNotifierTest.php
+++ b/Tests/Functional/SchedulerTasks/MailNotifierTest.php
@@ -29,6 +29,7 @@ final class MailNotifierTest extends FunctionalTestCase
     protected $coreExtensionsToLoad = ['scheduler'];
 
     protected $testExtensionsToLoad = [
+        'typo3conf/ext/static_info_tables',
         'typo3conf/ext/feuserextrafields',
         'typo3conf/ext/oelib',
         'typo3conf/ext/seminars',

--- a/Tests/Functional/SchedulerTasks/RegistrationDigestTest.php
+++ b/Tests/Functional/SchedulerTasks/RegistrationDigestTest.php
@@ -14,6 +14,7 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
 final class RegistrationDigestTest extends FunctionalTestCase
 {
     protected $testExtensionsToLoad = [
+        'typo3conf/ext/static_info_tables',
         'typo3conf/ext/feuserextrafields',
         'typo3conf/ext/oelib',
         'typo3conf/ext/seminars',

--- a/Tests/Functional/Seo/SlugGeneratorTest.php
+++ b/Tests/Functional/Seo/SlugGeneratorTest.php
@@ -17,6 +17,7 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
 final class SlugGeneratorTest extends FunctionalTestCase
 {
     protected $testExtensionsToLoad = [
+        'typo3conf/ext/static_info_tables',
         'typo3conf/ext/feuserextrafields',
         'typo3conf/ext/oelib',
         'typo3conf/ext/seminars',

--- a/Tests/Functional/Service/EmailServiceTest.php
+++ b/Tests/Functional/Service/EmailServiceTest.php
@@ -37,6 +37,7 @@ final class EmailServiceTest extends FunctionalTestCase
     private const DATE_FORMAT_YMD = '%d.%m.%Y';
 
     protected $testExtensionsToLoad = [
+        'typo3conf/ext/static_info_tables',
         'typo3conf/ext/feuserextrafields',
         'typo3conf/ext/oelib',
         'typo3conf/ext/seminars',

--- a/Tests/Functional/Service/RegistrationManagerTest.php
+++ b/Tests/Functional/Service/RegistrationManagerTest.php
@@ -49,10 +49,10 @@ final class RegistrationManagerTest extends FunctionalTestCase
     private const NOW = 1524751343;
 
     protected $testExtensionsToLoad = [
+        'typo3conf/ext/static_info_tables',
         'typo3conf/ext/feuserextrafields',
         'typo3conf/ext/oelib',
         'typo3conf/ext/seminars',
-        'typo3conf/ext/static_info_tables',
     ];
 
     /**

--- a/Tests/Functional/Service/RegistrationProcessorTest.php
+++ b/Tests/Functional/Service/RegistrationProcessorTest.php
@@ -20,6 +20,7 @@ final class RegistrationProcessorTest extends FunctionalTestCase
     use LanguageHelper;
 
     protected $testExtensionsToLoad = [
+        'typo3conf/ext/static_info_tables',
         'typo3conf/ext/feuserextrafields',
         'typo3conf/ext/oelib',
         'typo3conf/ext/seminars',

--- a/Tests/Functional/Service/SingleViewLinkBuilderTest.php
+++ b/Tests/Functional/Service/SingleViewLinkBuilderTest.php
@@ -22,6 +22,7 @@ final class SingleViewLinkBuilderTest extends FunctionalTestCase
     private const DEFAULT_SINGLE_VIEW_PAGE_UID = 3;
 
     protected $testExtensionsToLoad = [
+        'typo3conf/ext/static_info_tables',
         'typo3conf/ext/feuserextrafields',
         'typo3conf/ext/oelib',
         'typo3conf/ext/seminars',

--- a/Tests/Functional/UpgradeWizards/GenerateEventSlugsUpgradeWizardTest.php
+++ b/Tests/Functional/UpgradeWizards/GenerateEventSlugsUpgradeWizardTest.php
@@ -14,6 +14,7 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
 class GenerateEventSlugsUpgradeWizardTest extends FunctionalTestCase
 {
     protected $testExtensionsToLoad = [
+        'typo3conf/ext/static_info_tables',
         'typo3conf/ext/feuserextrafields',
         'typo3conf/ext/oelib',
         'typo3conf/ext/seminars',

--- a/Tests/Functional/UpgradeWizards/SeparateBillingAddressUpgradeWizardTest.php
+++ b/Tests/Functional/UpgradeWizards/SeparateBillingAddressUpgradeWizardTest.php
@@ -14,6 +14,7 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
 class SeparateBillingAddressUpgradeWizardTest extends FunctionalTestCase
 {
     protected $testExtensionsToLoad = [
+        'typo3conf/ext/static_info_tables',
         'typo3conf/ext/feuserextrafields',
         'typo3conf/ext/oelib',
         'typo3conf/ext/seminars',

--- a/Tests/Functional/ViewHelpers/SalutationAwareTranslateViewHelperTest.php
+++ b/Tests/Functional/ViewHelpers/SalutationAwareTranslateViewHelperTest.php
@@ -19,6 +19,7 @@ use TYPO3Fluid\Fluid\Core\Variables\VariableProviderInterface;
 final class SalutationAwareTranslateViewHelperTest extends FunctionalTestCase
 {
     protected $testExtensionsToLoad = [
+        'typo3conf/ext/static_info_tables',
         'typo3conf/ext/feuserextrafields',
         'typo3conf/ext/oelib',
         'typo3conf/ext/seminars',


### PR DESCRIPTION
Also change the loading order to follow the dependency tree.