### PR TITLE
[TASK] Do not require jQuery anymore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Add support for PHP 8.3 (#2676)
 
 ### Changed
+- Do not require jQuery anymore (#2807)
 - Drop the additional icon placeholders from the BE module (#2804)
 - Drop unused Composer scripts and add script descriptions (#2740)
 - Migrate the tests to the TYPO3 testing framework

--- a/Resources/Public/JavaScript/FrontEnd/FrontEnd.js
+++ b/Resources/Public/JavaScript/FrontEnd/FrontEnd.js
@@ -3,7 +3,7 @@
  * editor and the registration form.
  */
 
-;((root, exports, $) => {
+;((root, exports) => {
   'use strict'
 
   class Seminars {
@@ -66,13 +66,13 @@
      * Initializes the search widget.
      */
     initializeSearchWidget() {
-      if ($('.tx-seminars-pi1-selectorwidget').length === 0) {
+      const searchWidget = document.querySelector('.tx-seminars-pi1-selectorwidget');
+      const clearSearchWidgetButton = document.querySelector('#tx-seminars-pi1-clear-search-widget');
+      if (!(searchWidget instanceof Element) || !(clearSearchWidgetButton instanceof Element)) {
         return;
       }
 
-      $('#tx-seminars-pi1-clear-search-widget').click(() => {
-        this.clearSearchWidgetFields();
-      });
+      clearSearchWidgetButton.addEventListener('click', this.clearSearchWidgetFields);
     }
 
     findRegistrationFormElements() {


### PR DESCRIPTION
Now the event list selector widget (the last place still using jQuery) is VanillaJS instead.

Fixes #246