### PR TITLE
[TASK] Remove the button for (un-)hiding registrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ## x.y.z
 
 ### Added
-- Add a button for (un)hiding registrations in the BE module (#2805)
 - Add support for PHP 8.3 (#2676)
 
 ### Changed

--- a/Resources/Private/Partials/BackEnd/RegistrationList.html
+++ b/Resources/Private/Partials/BackEnd/RegistrationList.html
@@ -25,8 +25,6 @@
         <tbody>
             <f:for each="{registrations}" as="registration">
                 <tr>
-                    <f:variable name="visible"
-                                value="{f:if(condition: '{registrations.rawData.hidden}', then: 0, else: 1)}"/>
                     <td class="text-end text-right nowrap">
                         {registration.uid}
                     </td>
@@ -56,23 +54,9 @@
                                     <core:icon identifier="actions-open"/>
                                 </be:link.editRecord>
 
-                                <f:if condition="{visible}">
-                                    <f:then>
-                                        <a href="{be:moduleLink(route: 'tce_db', query: 'data[{tableName}][{registration.uid}][hidden]=1', currentUrlParameterName:'redirect')}"
-                                           class="btn btn-default"
-                                           title="{f:translate(key: '{actionLabelPrefix}.hide')}">
-                                            <core:icon identifier="actions-edit-hide"/>
-                                        </a>
-                                    </f:then>
-                                    <f:else>
-                                        <a href="{be:moduleLink(route: 'tce_db', query: 'data[{tableName}][{registration.uid}][hidden]=0', currentUrlParameterName:'redirect')}"
-                                           class="btn btn-default"
-                                           title="{f:translate(key: '{actionLabelPrefix}.unhide')}">
-                                            <core:icon identifier="actions-edit-unhide"/>
-                                        </a>
-                                    </f:else>
-                                </f:if>
-
+                                <span class="btn btn-default disabled">
+                                    <core:icon identifier="empty-empty"/>
+                                </span>
                                 <span class="btn btn-default disabled">
                                     <core:icon identifier="empty-empty"/>
                                 </span>


### PR DESCRIPTION
Hiding registration records is broken as a concept and creates all kinds of problems. We should not exacerbate this by providing a nice UI fot it.

This reverts commit f3676f26a039f8d5c378adcc7e54390d4b3e3010.