### PR TITLE
[BUGFIX] Avoid warnings in the tests with PHP 8.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Removed
 
 ### Fixed
+- Avoid warnings in the tests with PHP 8.3 (#2812)
 - Drop obsolete option from the plugin registration (#2801)
 - Stabilize the legacy tests
   (#2746, #2748, #2749, #2750, #2751, #2752, #2753, #2763, #2765, #2769, #2777,

--- a/composer.json
+++ b/composer.json
@@ -64,7 +64,8 @@
 		"typo3/cms-install": "^10.4.22 || ^11.5.4",
 		"typo3/cms-scheduler": "^10.4.22 || ^11.5.4",
 		"typo3/coding-standards": "~0.6.1",
-		"typo3/testing-framework": "^6.16.9"
+		"typo3/testing-framework": "^6.16.9",
+		"webmozart/assert": "^1.11.0"
 	},
 	"replace": {
 		"typo3-ter/seminars": "self.version"


### PR DESCRIPTION
Require a version of `webmozart/assert` that fixes those warnings.