### PR TITLE
[TASK] Stop using the deprecated `Mock::setMethods()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Removed
 
 ### Fixed
+- Stop using the deprecated `Mock::setMethods()` (#2815)
 - Avoid usage of the deprecated `strftime` (#2814)
 - Avoid warnings in the tests with PHP 8.3 (#2812)
 - Drop obsolete option from the plugin registration (#2801)

--- a/Tests/LegacyFunctional/FrontEnd/SelectorWidgetTest.php
+++ b/Tests/LegacyFunctional/FrontEnd/SelectorWidgetTest.php
@@ -512,7 +512,7 @@ final class SelectorWidgetTest extends FunctionalTestCase
     public function itemsInSearchBoxAreSortedAlphabetically(): void
     {
         $subject = $this->getMockBuilder(SelectorWidget::class)
-            ->setMethods(
+            ->onlyMethods(
                 [
                     'hasSearchField',
                     'getEventTypeData',

--- a/Tests/LegacyFunctional/Service/RegistrationManagerTest.php
+++ b/Tests/LegacyFunctional/Service/RegistrationManagerTest.php
@@ -921,7 +921,7 @@ final class RegistrationManagerTest extends FunctionalTestCase
     public function notifyAttendeeForUnregistrationMailDoesNotAppendUnregistrationNotice(): void
     {
         $subject = $this->getMockBuilder(RegistrationManager::class)
-            ->setMethods(['getUnregistrationNotice'])->getMock();
+            ->onlyMethods(['getUnregistrationNotice'])->getMock();
         $subject->expects(self::never())->method('getUnregistrationNotice');
 
         $this->configuration->setAsBoolean('sendConfirmationOnUnregistration', true);
@@ -951,7 +951,7 @@ final class RegistrationManagerTest extends FunctionalTestCase
         $this->configuration->setAsBoolean('allowUnregistrationWithEmptyWaitingList', false);
 
         $subject = $this->getMockBuilder(RegistrationManager::class)
-            ->setMethods(['getUnregistrationNotice'])->getMock();
+            ->onlyMethods(['getUnregistrationNotice'])->getMock();
         $subject->expects(self::never())->method('getUnregistrationNotice');
         $this->configuration->setAsBoolean('sendConfirmation', true);
 
@@ -978,7 +978,7 @@ final class RegistrationManagerTest extends FunctionalTestCase
         $this->configuration->setAsBoolean('allowUnregistrationWithEmptyWaitingList', true);
 
         $subject = $this->getMockBuilder(RegistrationManager::class)
-            ->setMethods(['getUnregistrationNotice'])->getMock();
+            ->onlyMethods(['getUnregistrationNotice'])->getMock();
         $subject->expects(self::atLeast(1))->method('getUnregistrationNotice');
         $this->configuration->setAsBoolean('sendConfirmation', true);
 
@@ -1010,7 +1010,7 @@ final class RegistrationManagerTest extends FunctionalTestCase
         $this->configuration->setAsBoolean('sendConfirmationOnRegistrationForQueue', true);
 
         $subject = $this->getMockBuilder(RegistrationManager::class)
-            ->setMethods(['getUnregistrationNotice'])->getMock();
+            ->onlyMethods(['getUnregistrationNotice'])->getMock();
         $subject->expects(self::atLeast(1))->method('getUnregistrationNotice');
 
         $registration = $this->createRegistration();
@@ -1049,7 +1049,7 @@ final class RegistrationManagerTest extends FunctionalTestCase
         $this->configuration->setAsBoolean('sendConfirmationOnQueueUpdate', true);
 
         $subject = $this->getMockBuilder(RegistrationManager::class)
-            ->setMethods(['getUnregistrationNotice'])->getMock();
+            ->onlyMethods(['getUnregistrationNotice'])->getMock();
         $subject->expects(self::atLeast(1))->method('getUnregistrationNotice');
 
         $registration = $this->createRegistration();

--- a/Tests/Unit/Traits/EmailTrait.php
+++ b/Tests/Unit/Traits/EmailTrait.php
@@ -31,7 +31,7 @@ trait EmailTrait
             ->disableOriginalClone()
             ->disableArgumentCloning()
             ->disallowMockingUnknownTypes()
-            ->setMethods(['send'])
+            ->onlyMethods(['send'])
             ->getMock();
     }
 


### PR DESCRIPTION
Fixes #2789