### PR TITLE
[TASK] De-deprecate the singleton-related `RegistrationManager` methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   #2771, #2772, #2773, #2774, #2776, #2778, #2782, #2783, #2786, #2792, #2795)
 
 ### Deprecated
+- De-deprecate the singleton-related `RegistrationManager` methods (#2816)
 
 ### Removed
 

--- a/Classes/Service/RegistrationManager.php
+++ b/Classes/Service/RegistrationManager.php
@@ -58,8 +58,6 @@ class RegistrationManager
     public const SEND_USER_MAIL = 2;
 
     /**
-     * @deprecated #1904 will be removed in seminars 6.0
-     *
      * @var static|null
      */
     private static $instance;
@@ -86,8 +84,6 @@ class RegistrationManager
 
     /**
      * @return static the current singleton instance
-     *
-     * @deprecated #1904 will be removed in seminars 6.0
      */
     public static function getInstance(): RegistrationManager
     {
@@ -101,8 +97,6 @@ class RegistrationManager
 
     /**
      * Purges the current instance so that `getInstance` will create a new instance.
-     *
-     * @deprecated #1904 will be removed in seminars 6.0
      */
     public static function purgeInstance(): void
     {


### PR DESCRIPTION
Instead of removing these method, the `RegistratonManager` will be completely removed at some time.

Fixes #2790