### PR TITLE
[TASK] Drop an overly specific test

### DIFF
--- a/Tests/Unit/OldModel/LegacyRegistrationTest.php
+++ b/Tests/Unit/OldModel/LegacyRegistrationTest.php
@@ -220,7 +220,6 @@ final class LegacyRegistrationTest extends UnitTestCase
     public function nameUserDataDataProvider(): array
     {
         return [
-            'user name only' => [['username' => 'max', 'name' => ''], 'max'],
             'first name' => [['username' => 'max', 'name' => '', 'first_name' => 'Max'], 'Max'],
             'last name' => [['username' => 'max', 'name' => '', 'last_name' => 'Caulfield'], 'Caulfield'],
             'first and last name' => [


### PR DESCRIPTION
Here, we should rely on the (already tested) behavior of oelib.

Fixes #2848