### PR TITLE
[TASK] Avoid using the deprecated mapper testing mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Migrate the tests to the TYPO3 testing framework
   (#2701, #2702, #2713, #2717, #2731, #2732, #2733, #2734, #2735, #2737, #2739,
   #2742, #2743, #2744, #2754, #2756, #2757, #2760, #2764, #2767, #2768, #2770,
-  #2771, #2772, #2773, #2774, #2776, #2778, #2782, #2783, #2786, #2792, #2795)
+  #2771, #2772, #2773, #2774, #2776, #2778, #2782, #2783, #2786, #2792, #2795,
+  #2851)
 
 ### Deprecated
 - De-deprecate the singleton-related `RegistrationManager` methods (#2816)

--- a/Tests/LegacyFunctional/Mapper/EventMapperTest.php
+++ b/Tests/LegacyFunctional/Mapper/EventMapperTest.php
@@ -51,7 +51,6 @@ final class EventMapperTest extends FunctionalTestCase
         parent::setUp();
 
         $this->testingFramework = new TestingFramework('tx_seminars');
-        MapperRegistry::getInstance()->activateTestingMode($this->testingFramework);
 
         $this->subject = MapperRegistry::get(EventMapper::class);
     }

--- a/Tests/LegacyFunctional/Service/EventStatusServiceTest.php
+++ b/Tests/LegacyFunctional/Service/EventStatusServiceTest.php
@@ -6,7 +6,6 @@ namespace OliverKlee\Seminars\Tests\LegacyFunctional\Service;
 
 use OliverKlee\Oelib\DataStructures\Collection;
 use OliverKlee\Oelib\Mapper\MapperRegistry;
-use OliverKlee\Oelib\Testing\TestingFramework;
 use OliverKlee\Seminars\Domain\Model\Event\EventInterface;
 use OliverKlee\Seminars\Mapper\EventMapper;
 use OliverKlee\Seminars\Model\Event;
@@ -35,11 +34,6 @@ final class EventStatusServiceTest extends FunctionalTestCase
     private $subject;
 
     /**
-     * @var TestingFramework
-     */
-    private $testingFramework;
-
-    /**
      * @var EventMapper&MockObject
      */
     private $eventMapper;
@@ -62,11 +56,6 @@ final class EventStatusServiceTest extends FunctionalTestCase
         $this->past = $GLOBALS['SIM_EXEC_TIME'] - 1;
         $this->future = $GLOBALS['SIM_EXEC_TIME'] + 1;
 
-        $this->testingFramework = new TestingFramework('tx_seminars');
-
-        MapperRegistry::denyDatabaseAccess();
-        MapperRegistry::getInstance()->activateTestingMode($this->testingFramework);
-
         $this->eventMapper = $this->createMock(EventMapper::class);
         MapperRegistry::set(EventMapper::class, $this->eventMapper);
 
@@ -75,7 +64,7 @@ final class EventStatusServiceTest extends FunctionalTestCase
 
     protected function tearDown(): void
     {
-        $this->testingFramework->cleanUpWithoutDatabase();
+        MapperRegistry::purgeInstance();
 
         parent::tearDown();
     }


### PR DESCRIPTION
Now that we have switched to the TYPO3 testing framework, this is no longer necessary.