### PR TITLE
[BUGFIX] Use `Context` for login checks in the tests

### DIFF
--- a/Tests/LegacyFunctional/FrontEnd/DefaultControllerTest.php
+++ b/Tests/LegacyFunctional/FrontEnd/DefaultControllerTest.php
@@ -20,6 +20,7 @@ use OliverKlee\Seminars\Tests\Functional\FrontEnd\Fixtures\TestingDefaultControl
 use OliverKlee\Seminars\Tests\Support\LanguageHelper;
 use OliverKlee\Seminars\Tests\Unit\OldModel\Fixtures\TestingLegacyEvent;
 use Psr\Log\NullLogger;
+use TYPO3\CMS\Core\Context\Context;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
@@ -423,9 +424,7 @@ final class DefaultControllerTest extends FunctionalTestCase
     {
         $this->createLogInAndAddFeUserAsVip();
 
-        self::assertTrue(
-            $this->testingFramework->isLoggedIn()
-        );
+        self::assertTrue(GeneralUtility::makeInstance(Context::class)->getAspect('frontend.user')->isLoggedIn());
     }
 
     /**

--- a/Tests/LegacyFunctional/FrontEnd/RegistrationsListTest.php
+++ b/Tests/LegacyFunctional/FrontEnd/RegistrationsListTest.php
@@ -10,6 +10,7 @@ use OliverKlee\Seminars\Domain\Model\Event\EventInterface;
 use OliverKlee\Seminars\FrontEnd\RegistrationsList;
 use OliverKlee\Seminars\Service\RegistrationManager;
 use OliverKlee\Seminars\Tests\Support\LanguageHelper;
+use TYPO3\CMS\Core\Context\Context;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
@@ -141,9 +142,7 @@ final class RegistrationsListTest extends FunctionalTestCase
     {
         $this->createLogInAndRegisterFrontEndUser();
 
-        self::assertTrue(
-            $this->testingFramework->isLoggedIn()
-        );
+        self::assertTrue(GeneralUtility::makeInstance(Context::class)->getAspect('frontend.user')->isLoggedIn());
     }
 
     /**

--- a/Tests/LegacyFunctional/Service/RegistrationManagerTest.php
+++ b/Tests/LegacyFunctional/Service/RegistrationManagerTest.php
@@ -24,6 +24,7 @@ use OliverKlee\Seminars\Tests\Unit\OldModel\Fixtures\TestingLegacyEvent;
 use OliverKlee\Seminars\Tests\Unit\Traits\EmailTrait;
 use OliverKlee\Seminars\Tests\Unit\Traits\MakeInstanceTrait;
 use PHPUnit\Framework\MockObject\MockObject;
+use TYPO3\CMS\Core\Context\Context;
 use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Mail\MailMessage;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -375,9 +376,8 @@ final class RegistrationManagerTest extends FunctionalTestCase
     public function createAndLogInFrontEndUserLogsInFrontEndUser(): void
     {
         $this->createAndLogInFrontEndUser();
-        self::assertTrue(
-            $this->testingFramework->isLoggedIn()
-        );
+
+        self::assertTrue(GeneralUtility::makeInstance(Context::class)->getAspect('frontend.user')->isLoggedIn());
     }
 
     /**


### PR DESCRIPTION
`TestingFramework::isLoggedIn()` is deprecated and should be avoided.