### PR TITLE
[BUGFIX] Use the TYPO3 `Context` to check for logins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Removed
 
 ### Fixed
+- Use the TYPO3 `Context` to check for logins (#2864)
 - Stop using the deprecated oelib gender constants (#2859)
 - Avoid undefined array access in `DefaultController` (#2852)
 - Remove dependency on the CLI BE user from a test (#2829)

--- a/Classes/FrontEnd/DefaultController.php
+++ b/Classes/FrontEnd/DefaultController.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace OliverKlee\Seminars\FrontEnd;
 
-use OliverKlee\Oelib\Authentication\FrontEndLoginManager;
 use OliverKlee\Oelib\Configuration\ConfigurationRegistry;
 use OliverKlee\Oelib\Configuration\FallbackConfiguration;
 use OliverKlee\Oelib\Configuration\FlexformsConfiguration;
@@ -40,6 +39,7 @@ use OliverKlee\Seminars\Seo\SingleViewPageTitleProvider;
 use OliverKlee\Seminars\Service\RegistrationManager;
 use OliverKlee\Seminars\Service\SingleViewLinkBuilder;
 use OliverKlee\Seminars\Templating\TemplateHelper;
+use TYPO3\CMS\Core\Context\Context;
 use TYPO3\CMS\Core\Resource\FileReference;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Utility\MathUtility;
@@ -1164,7 +1164,7 @@ class DefaultController extends TemplateHelper
      */
     public function isLoggedIn(): bool
     {
-        return FrontEndLoginManager::getInstance()->isLoggedIn();
+        return GeneralUtility::makeInstance(Context::class)->getAspect('frontend.user')->isLoggedIn();
     }
 
     /**
@@ -1172,7 +1172,7 @@ class DefaultController extends TemplateHelper
      */
     protected function getLoggedInFrontEndUserUid(): int
     {
-        return FrontEndLoginManager::getInstance()->getLoggedInUserUid();
+        return GeneralUtility::makeInstance(Context::class)->getPropertyFromAspect('frontend.user', 'id');
     }
 
     /**
@@ -1496,7 +1496,7 @@ class DefaultController extends TemplateHelper
             $this->limitToTimeFrameSetting($builder);
         }
 
-        $userUid = FrontEndLoginManager::getInstance()->getLoggedInUserUid();
+        $userUid = GeneralUtility::makeInstance(Context::class)->getPropertyFromAspect('frontend.user', 'id');
         $user = $userUid > 0 ? MapperRegistry::get(FrontEndUserMapper::class)->find($userUid) : null;
 
         switch ($whatToDisplay) {
@@ -1819,7 +1819,7 @@ class DefaultController extends TemplateHelper
     {
         $registrationBagBuilder = GeneralUtility::makeInstance(RegistrationBagBuilder::class);
 
-        $userUid = FrontEndLoginManager::getInstance()->getLoggedInUserUid();
+        $userUid = GeneralUtility::makeInstance(Context::class)->getPropertyFromAspect('frontend.user', 'id');
         $user = $userUid > 0 ? MapperRegistry::get(FrontEndUserMapper::class)->find($userUid) : null;
         $registrationBagBuilder->limitToAttendee($user);
         $registrationBagBuilder->setOrderByEventColumn($this->getOrderByForListView());

--- a/Classes/SchedulerTasks/MailNotifier.php
+++ b/Classes/SchedulerTasks/MailNotifier.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace OliverKlee\Seminars\SchedulerTasks;
 
-use OliverKlee\Oelib\Authentication\BackEndLoginManager;
 use OliverKlee\Oelib\Configuration\ConfigurationRegistry;
 use OliverKlee\Oelib\Configuration\PageFinder;
 use OliverKlee\Oelib\Interfaces\Configuration;
@@ -20,6 +19,7 @@ use OliverKlee\Seminars\OldModel\LegacyOrganizer;
 use OliverKlee\Seminars\Service\DateFormatConverter;
 use OliverKlee\Seminars\Service\EmailService;
 use OliverKlee\Seminars\Service\EventStatusService;
+use TYPO3\CMS\Core\Context\Context;
 use TYPO3\CMS\Core\Localization\LanguageService;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Object\ObjectManager;
@@ -398,7 +398,7 @@ class MailNotifier extends AbstractTask
      */
     private function useUserConfiguredLanguage(): void
     {
-        $uid = BackEndLoginManager::getInstance()->getLoggedInUserUid();
+        $uid = GeneralUtility::makeInstance(Context::class)->getPropertyFromAspect('backend.user', 'id');
         if ($uid <= 0) {
             return;
         }

--- a/Classes/Service/RegistrationManager.php
+++ b/Classes/Service/RegistrationManager.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace OliverKlee\Seminars\Service;
 
-use OliverKlee\Oelib\Authentication\FrontEndLoginManager;
 use OliverKlee\Oelib\Configuration\ConfigurationRegistry;
 use OliverKlee\Oelib\Configuration\FallbackConfiguration;
 use OliverKlee\Oelib\Configuration\FlexformsConfiguration;
@@ -29,6 +28,7 @@ use OliverKlee\Seminars\OldModel\LegacyOrganizer;
 use OliverKlee\Seminars\OldModel\LegacyRegistration;
 use OliverKlee\Seminars\Templating\TemplateHelper;
 use Pelago\Emogrifier\CssInliner;
+use TYPO3\CMS\Core\Context\Context;
 use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -125,7 +125,7 @@ class RegistrationManager
         if ($event->getPriceOnRequest() || !$event->canSomebodyRegister()) {
             return false;
         }
-        if (!FrontEndLoginManager::getInstance()->isLoggedIn()) {
+        if (!GeneralUtility::makeInstance(Context::class)->getAspect('frontend.user')->isLoggedIn()) {
             return true;
         }
 
@@ -152,7 +152,7 @@ class RegistrationManager
     {
         $message = '';
 
-        $isLoggedIn = FrontEndLoginManager::getInstance()->isLoggedIn();
+        $isLoggedIn = GeneralUtility::makeInstance(Context::class)->getAspect('frontend.user')->isLoggedIn();
         if ($isLoggedIn && !$this->couldThisUserRegister($event)) {
             $message = $this->translate('message_alreadyRegistered');
         } elseif (!$event->canSomebodyRegister()) {
@@ -1207,7 +1207,7 @@ class RegistrationManager
      */
     protected function getLoggedInFrontEndUserUid(): int
     {
-        return FrontEndLoginManager::getInstance()->getLoggedInUserUid();
+        return GeneralUtility::makeInstance(Context::class)->getPropertyFromAspect('frontend.user', 'id');
     }
 
     private function getConnectionForTable(string $table): Connection

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -971,6 +971,11 @@ parameters:
 			path: Classes/FrontEnd/DefaultController.php
 
 		-
+			message: "#^Method OliverKlee\\\\Seminars\\\\FrontEnd\\\\DefaultController\\:\\:getLoggedInFrontEndUserUid\\(\\) should return int but returns mixed\\.$#"
+			count: 1
+			path: Classes/FrontEnd/DefaultController.php
+
+		-
 			message: "#^Method OliverKlee\\\\Seminars\\\\FrontEnd\\\\DefaultController\\:\\:getToDate\\(\\) should return int but returns int\\|false\\.$#"
 			count: 1
 			path: Classes/FrontEnd/DefaultController.php
@@ -1043,6 +1048,11 @@ parameters:
 		-
 			message: "#^Parameter \\#1 \\$minimumPrice of method OliverKlee\\\\Seminars\\\\BagBuilder\\\\EventBagBuilder\\:\\:limitToMinimumPrice\\(\\) expects int\\<0, max\\>, int given\\.$#"
 			count: 1
+			path: Classes/FrontEnd/DefaultController.php
+
+		-
+			message: "#^Parameter \\#1 \\$uid of method OliverKlee\\\\Oelib\\\\Mapper\\\\AbstractDataMapper\\<OliverKlee\\\\Seminars\\\\Model\\\\FrontEndUser\\>\\:\\:find\\(\\) expects int\\<1, max\\>, mixed given\\.$#"
+			count: 2
 			path: Classes/FrontEnd/DefaultController.php
 
 		-
@@ -1546,6 +1556,21 @@ parameters:
 			path: Classes/OldModel/LegacyEvent.php
 
 		-
+			message: "#^Parameter \\#1 \\$uid of method OliverKlee\\\\Oelib\\\\Mapper\\\\AbstractDataMapper\\<OliverKlee\\\\Seminars\\\\Model\\\\FrontEndUser\\>\\:\\:find\\(\\) expects int\\<1, max\\>, mixed given\\.$#"
+			count: 1
+			path: Classes/OldModel/LegacyEvent.php
+
+		-
+			message: "#^Parameter \\#1 \\$uid of method OliverKlee\\\\Seminars\\\\OldModel\\\\LegacyEvent\\:\\:isUserRegistered\\(\\) expects int, mixed given\\.$#"
+			count: 2
+			path: Classes/OldModel/LegacyEvent.php
+
+		-
+			message: "#^Parameter \\#1 \\$userUid of method OliverKlee\\\\Seminars\\\\OldModel\\\\LegacyEvent\\:\\:isUserVip\\(\\) expects int, mixed given\\.$#"
+			count: 9
+			path: Classes/OldModel/LegacyEvent.php
+
+		-
 			message: "#^Parameter \\#2 \\$callback of function array_filter expects \\(callable\\(int\\|string\\)\\: mixed\\)\\|null, Closure\\(string\\)\\: bool given\\.$#"
 			count: 1
 			path: Classes/OldModel/LegacyEvent.php
@@ -1672,6 +1697,11 @@ parameters:
 
 		-
 			message: "#^Method OliverKlee\\\\Seminars\\\\SchedulerTasks\\\\MailNotifier\\:\\:getLanguageService\\(\\) should return TYPO3\\\\CMS\\\\Core\\\\Localization\\\\LanguageService\\|null but returns mixed\\.$#"
+			count: 1
+			path: Classes/SchedulerTasks/MailNotifier.php
+
+		-
+			message: "#^Parameter \\#1 \\$uid of method OliverKlee\\\\Oelib\\\\Mapper\\\\AbstractDataMapper\\<OliverKlee\\\\Oelib\\\\Model\\\\BackEndUser\\>\\:\\:find\\(\\) expects int\\<1, max\\>, mixed given\\.$#"
 			count: 1
 			path: Classes/SchedulerTasks/MailNotifier.php
 
@@ -1817,6 +1847,11 @@ parameters:
 
 		-
 			message: "#^Instanceof between OliverKlee\\\\Seminars\\\\Service\\\\SingleViewLinkBuilder and OliverKlee\\\\Seminars\\\\Service\\\\SingleViewLinkBuilder will always evaluate to true\\.$#"
+			count: 1
+			path: Classes/Service/RegistrationManager.php
+
+		-
+			message: "#^Method OliverKlee\\\\Seminars\\\\Service\\\\RegistrationManager\\:\\:getLoggedInFrontEndUserUid\\(\\) should return int but returns mixed\\.$#"
 			count: 1
 			path: Classes/Service/RegistrationManager.php
 


### PR DESCRIPTION
This allows us to avoid using the deprecated oelib login managers.