### PR TITLE
[TASK] Stop explicitly tracking dummy records in the tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   (#2701, #2702, #2713, #2717, #2731, #2732, #2733, #2734, #2735, #2737, #2739,
   #2742, #2743, #2744, #2754, #2756, #2757, #2760, #2764, #2767, #2768, #2770,
   #2771, #2772, #2773, #2774, #2776, #2778, #2782, #2783, #2786, #2792, #2795,
-  #2851, #2856)
+  #2851, #2856, #2867)
 
 ### Deprecated
 - De-deprecate the singleton-related `RegistrationManager` methods (#2816)

--- a/Classes/OldModel/AbstractModel.php
+++ b/Classes/OldModel/AbstractModel.php
@@ -417,14 +417,6 @@ abstract class AbstractModel
     }
 
     /**
-     * Marks this object as a dummy record (when it is written to the DB).
-     */
-    public function enableTestMode(): void
-    {
-        $this->setRecordPropertyBoolean('is_dummy_record', true);
-    }
-
-    /**
      * Returns this record's page UID.
      *
      * @return int the page UID for this record, will be >= 0

--- a/Tests/Functional/OldModel/LegacyRegistrationTest.php
+++ b/Tests/Functional/OldModel/LegacyRegistrationTest.php
@@ -267,11 +267,11 @@ final class LegacyRegistrationTest extends FunctionalTestCase
      */
     public function dumpUserValuesCanContainNonRegisteredField(): void
     {
-        $this->subject->setUserData(['is_dummy_record' => true]);
+        $this->subject->setUserData(['pid' => 1]);
 
-        $result = $this->subject->dumpUserValues('is_dummy_record');
+        $result = $this->subject->dumpUserValues('pid');
 
-        self::assertStringContainsString('Is_dummy_record: 1', $result);
+        self::assertStringContainsString('Pid: 1', $result);
     }
 
     /**

--- a/Tests/LegacyFunctional/Bag/AbstractBagTest.php
+++ b/Tests/LegacyFunctional/Bag/AbstractBagTest.php
@@ -55,7 +55,7 @@ final class AbstractBagTest extends FunctionalTestCase
             ['title' => 'test 2']
         );
 
-        $this->subject = new TestingBag('is_dummy_record=1');
+        $this->subject = new TestingBag();
     }
 
     protected function tearDown(): void
@@ -183,12 +183,9 @@ final class AbstractBagTest extends FunctionalTestCase
      */
     public function countForBagWithTwoMatchesElementsAndLimitOfOneReturnsOne(): void
     {
-        $bag = new TestingBag('is_dummy_record = 1', '', '', '', '1');
+        $bag = new TestingBag('1=1', '', '', '', '1');
 
-        self::assertEquals(
-            1,
-            $bag->count()
-        );
+        self::assertSame(1, $bag->count());
     }
 
     ///////////////////////////////////////
@@ -251,7 +248,7 @@ final class AbstractBagTest extends FunctionalTestCase
      */
     public function countWithoutLimitForBagWithTwoMatchesElementsAndLimitOfOneReturnsTwo(): void
     {
-        $bag = new TestingBag('is_dummy_record = 1', '', '', '', '1');
+        $bag = new TestingBag('', '', '', '', '1');
 
         self::assertEquals(
             2,

--- a/Tests/LegacyFunctional/Bag/CategoryBagTest.php
+++ b/Tests/LegacyFunctional/Bag/CategoryBagTest.php
@@ -38,7 +38,7 @@ final class CategoryBagTest extends FunctionalTestCase
 
         $this->testingFramework->createRecord('tx_seminars_categories');
 
-        $this->subject = new CategoryBag('is_dummy_record=1');
+        $this->subject = new CategoryBag();
     }
 
     protected function tearDown(): void

--- a/Tests/LegacyFunctional/Bag/EventBagTest.php
+++ b/Tests/LegacyFunctional/Bag/EventBagTest.php
@@ -42,7 +42,7 @@ final class EventBagTest extends FunctionalTestCase
             ['title' => 'test event']
         );
 
-        $this->subject = new EventBag('is_dummy_record=1');
+        $this->subject = new EventBag();
     }
 
     protected function tearDown(): void

--- a/Tests/LegacyFunctional/Bag/OrganizerBagTest.php
+++ b/Tests/LegacyFunctional/Bag/OrganizerBagTest.php
@@ -38,7 +38,7 @@ final class OrganizerBagTest extends FunctionalTestCase
 
         $this->testingFramework->createRecord('tx_seminars_organizers');
 
-        $this->subject = new OrganizerBag('is_dummy_record=1');
+        $this->subject = new OrganizerBag();
     }
 
     protected function tearDown(): void

--- a/Tests/LegacyFunctional/BagBuilder/AbstractBagBuilderTest.php
+++ b/Tests/LegacyFunctional/BagBuilder/AbstractBagBuilderTest.php
@@ -848,19 +848,4 @@ final class AbstractBagBuilderTest extends FunctionalTestCase
             $bag->count()
         );
     }
-
-    ///////////////////////////////////
-    // Tests concerning setTestMode()
-    ///////////////////////////////////
-
-    /**
-     * @test
-     */
-    public function setTestModeAddsTheTableNameBeforeIsDummy(): void
-    {
-        self::assertStringContainsString(
-            'tx_seminars_test.is_dummy_record = 1',
-            $this->subject->getWhereClause()
-        );
-    }
 }

--- a/Tests/LegacyFunctional/OldModel/LegacyRegistrationTest.php
+++ b/Tests/LegacyFunctional/OldModel/LegacyRegistrationTest.php
@@ -443,8 +443,8 @@ final class LegacyRegistrationTest extends FunctionalTestCase
     public function dumpAttendanceValuesCanContainNonRegisteredField(): void
     {
         self::assertStringContainsString(
-            'label_is_dummy_record: 1',
-            $this->subject->dumpAttendanceValues('is_dummy_record')
+            'label_pid: 0',
+            $this->subject->dumpAttendanceValues('pid')
         );
     }
 
@@ -514,8 +514,6 @@ final class LegacyRegistrationTest extends FunctionalTestCase
     public function commitToDbCanCreateNewRecord(): void
     {
         $registration = new LegacyRegistration();
-        $registration->enableTestMode();
-        $this->testingFramework->markTableAsDirty('tx_seminars_attendances');
         $connection = $this->connectionPool->getConnectionForTable('tx_seminars_attendances');
 
         self::assertTrue(


### PR DESCRIPTION
This removes usage of deprecated oelib functionality.