### PR TITLE
[BUGFIX] Avoid accessing the deprecated `TYPO3_MODE` constant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Removed
 
 ### Fixed
+- Avoid accessing the deprecated `TYPO3_MODE` constant (#2906)
 - Upgrade the XLIFF files to XLIFF 1.2 (#2890)
 - Access superglobals directly (#2878)
 - Replace `SIM_EXEC_TIME` with `Context` (#2877)

--- a/Classes/Templating/TemplateHelper.php
+++ b/Classes/Templating/TemplateHelper.php
@@ -526,7 +526,7 @@ abstract class TemplateHelper
         // configuration array is not initialized properly.
         // As flexforms can be used in FE mode only, `$ignoreFlexform` is set true if we are in the BE mode.
         // By this, `$this->cObj->fileResource` can be sheltered from being called.
-        if (TYPO3_MODE === 'BE') {
+        if (!($GLOBALS['TSFE'] ?? null) instanceof TypoScriptFrontendController) {
             $ignoreFlexform = true;
         }
 


### PR DESCRIPTION
Fixes #2834