### PR TITLE
[BUGFIX] Display registration statistics in the BE in all cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Removed
 
 ### Fixed
+- Display registration statistics in the BE in all cases (#2909)
 - Avoid accessing the deprecated `TYPO3_MODE` constant (#2906)
 - Upgrade the XLIFF files to XLIFF 1.2 (#2890)
 - Access superglobals directly (#2878)

--- a/Classes/Controller/BackEnd/RegistrationController.php
+++ b/Classes/Controller/BackEnd/RegistrationController.php
@@ -72,12 +72,9 @@ class RegistrationController extends ActionController
             $this->registrationRepository->enrichWithRawData($regularRegistrations);
             $this->view->assign('regularRegistrations', $regularRegistrations);
 
-            if ($event->hasWaitingList()) {
-                $waitingListRegistrations = $this->registrationRepository
-                    ->findWaitingListRegistrationsByEvent($eventUid);
-                $this->registrationRepository->enrichWithRawData($waitingListRegistrations);
-                $this->view->assign('waitingListRegistrations', $waitingListRegistrations);
-            }
+            $waitingListRegistrations = $this->registrationRepository->findWaitingListRegistrationsByEvent($eventUid);
+            $this->registrationRepository->enrichWithRawData($waitingListRegistrations);
+            $this->view->assign('waitingListRegistrations', $waitingListRegistrations);
         }
     }
 

--- a/Classes/Service/EventStatisticsCalculator.php
+++ b/Classes/Service/EventStatisticsCalculator.php
@@ -31,7 +31,7 @@ class EventStatisticsCalculator implements SingletonInterface
      */
     public function enrichWithStatistics(Event $event): void
     {
-        if (!$event instanceof EventDateInterface || !$event->isRegistrationRequired()) {
+        if (!$event instanceof EventDateInterface) {
             return;
         }
 
@@ -39,11 +39,7 @@ class EventStatisticsCalculator implements SingletonInterface
         // This mostly is for making unit tests less of a hassle.
         if (\is_int($eventUid)) {
             $regularSeatsFromRegistrations = $this->registrationRepository->countRegularSeatsByEvent($eventUid);
-            if ($event->hasWaitingList()) {
-                $waitingListSeats = $this->registrationRepository->countWaitingListSeatsByEvent($eventUid);
-            } else {
-                $waitingListSeats = 0;
-            }
+            $waitingListSeats = $this->registrationRepository->countWaitingListSeatsByEvent($eventUid);
         } else {
             $regularSeatsFromRegistrations = 0;
             $waitingListSeats = 0;


### PR DESCRIPTION
Some organizers manually close registration for an event when a certain number of registrations has been reached, and some organizers close the waiting list when it's getting too full.

In those cases, it should still be possible to see both the regular registrations as well as the waiting list registrations in the BE module.

Fixes #2654