### PR TITLE
[TASK] Use fewer flash messages in the backend module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Add support for PHP 8.3 (#2676)
 
 ### Changed
+- Use fewer flash messages in the backend module (#2913)
 - Require higher TYPO3 Core bugfix versions (#2852)
 - Switch to our own copy of `TemplateHelper` (#2833, #2836, #2838, #2840, #2855)
 - Allow installations with static_info_tables V12 (#2824)

--- a/Resources/Private/Templates/BackEnd/Module/Overview.html
+++ b/Resources/Private/Templates/BackEnd/Module/Overview.html
@@ -10,6 +10,10 @@
     <f:section name="Content">
         <f:variable name="propertyLabelPrefix" value="backEndModule.events.property"/>
 
+        <f:if condition="{pageUid} <= 0">
+            <f:render partial="BackEnd/FlashMessage" arguments="{severity: 'info', messageBodyKey: 'selectFolder'}"/>
+        </f:if>
+
         <f:if condition="{permissions.readAccessToEvents}">
             <div class="row">
                 <h1 class="col-auto me-auto">
@@ -26,21 +30,14 @@
                 </div>
             </div>
 
-            <f:if condition="{pageUid} > 0">
+            <f:if condition="{events}">
                 <f:then>
-                    <f:if condition="{events}">
-                        <f:then>
-                            <f:render partial="BackEnd/EventList" arguments="{_all}"/>
-                        </f:then>
-                        <f:else>
-                            <f:render partial="BackEnd/FlashMessage"
-                                      arguments="{severity: 'info', messageBodyKey: 'noEventsInFolder'}"/>
-                        </f:else>
-                    </f:if>
+                    <f:render partial="BackEnd/EventList" arguments="{_all}"/>
                 </f:then>
                 <f:else>
-                    <f:render partial="BackEnd/FlashMessage"
-                              arguments="{severity: 'info', messageBodyKey: 'selectFolder'}"/>
+                    <p>
+                        <f:translate key="backEndModule.message.noEventsInFolder"/>
+                    </p>
                 </f:else>
             </f:if>
         </f:if>
@@ -77,8 +74,9 @@
                     </table>
                 </f:then>
                 <f:else>
-                    <f:render partial="BackEnd/FlashMessage"
-                              arguments="{severity: 'info', messageBodyKey: 'noRegistrationsInFolder'}"/>
+                    <p>
+                        <f:translate key="backEndModule.message.noRegistrationsInFolder"/>
+                    </p>
                 </f:else>
             </f:if>
         </f:if>


### PR DESCRIPTION
Also move the flash message about selecting a folder above the Events headline.

Fixes #2910