### PR TITLE
[TASK] Use the development PHP INI file on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: "${{ matrix.php-version }}"
+          ini-file: development
           tools: composer:v2
           coverage: none
       - name: "Show Composer version"
@@ -49,6 +50,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           php-version: "${{ matrix.php-version }}"
+          ini-file: development
           tools: composer:v2
           extensions: zip
           coverage: none
@@ -90,6 +92,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           php-version: "${{ matrix.php-version }}"
+          ini-file: development
           tools: composer:v2
           extensions: dom, json, libxml, zip
           coverage: none
@@ -192,6 +195,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           php-version: "${{ matrix.php-version }}"
+          ini-file: development
           tools: composer:v2
           extensions: dom, json, libxml, mysqli, zip
           coverage: none
@@ -306,6 +310,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           php-version: "${{ matrix.php-version }}"
+          ini-file: development
           tools: composer:v2
           extensions: dom, json, libxml, mysqli, zip
           coverage: none

--- a/.github/workflows/codecoverage.yml
+++ b/.github/workflows/codecoverage.yml
@@ -21,6 +21,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: "${{ matrix.php-version }}"
+          ini-file: development
           coverage: pcov
           extensions: mysqli
           ini-values: pcov.directory=Classes


### PR DESCRIPTION
This allows us to see (and fail on) PHP warnings and notices.

Fixes #2929