### PR TITLE
[BUGFIX] Avoid deprecated HTTP functions in `RegistrationsList`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Drop dead code (#2967)
 
 ### Fixed
+- Stop using deprecated HTTP functions (#2991, #3006)
 - Redirect to the events list after sending an email in the BE module (#2971)
 - Add `resname` to all language labels (#2952)
 - Display registration statistics in the BE in all cases (#2909)


### PR DESCRIPTION
Part of #2720