### PR TITLE
[BUGFIX] Avoid deprecated HTTP functions in `RegistrationsManager`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Drop dead code (#2967)
 
 ### Fixed
-- Stop using deprecated HTTP functions (#2991, #3006)
+- Stop using deprecated HTTP functions (#2991, #3006, #3007)
 - Redirect to the events list after sending an email in the BE module (#2971)
 - Add `resname` to all language labels (#2952)
 - Display registration statistics in the BE in all cases (#2909)

--- a/Classes/Service/RegistrationManager.php
+++ b/Classes/Service/RegistrationManager.php
@@ -7,7 +7,6 @@ namespace OliverKlee\Seminars\Service;
 use OliverKlee\Oelib\Configuration\ConfigurationRegistry;
 use OliverKlee\Oelib\Configuration\FallbackConfiguration;
 use OliverKlee\Oelib\Configuration\FlexformsConfiguration;
-use OliverKlee\Oelib\Http\HeaderProxyFactory;
 use OliverKlee\Oelib\Mapper\MapperRegistry;
 use OliverKlee\Oelib\Templating\Template;
 use OliverKlee\Oelib\Templating\TemplateRegistry;
@@ -20,6 +19,7 @@ use OliverKlee\Seminars\Hooks\HookProvider;
 use OliverKlee\Seminars\Hooks\Interfaces\RegistrationEmail;
 use OliverKlee\Seminars\Mapper\EventMapper;
 use OliverKlee\Seminars\Mapper\RegistrationMapper;
+use OliverKlee\Seminars\Middleware\ResponseHeadersModifier;
 use OliverKlee\Seminars\Model\FrontEndUser;
 use OliverKlee\Seminars\Model\Place;
 use OliverKlee\Seminars\Model\Registration;
@@ -81,6 +81,16 @@ class RegistrationManager
      * @var SingleViewLinkBuilder
      */
     private $linkBuilder;
+
+    /**
+     * @var ResponseHeadersModifier
+     */
+    private $responseHeadersModifier;
+
+    public function __construct()
+    {
+        $this->responseHeadersModifier = GeneralUtility::makeInstance(ResponseHeadersModifier::class);
+    }
 
     /**
      * @return static the current singleton instance
@@ -291,11 +301,11 @@ class RegistrationManager
     public function existsSeminarMessage(int $uid): string
     {
         if ($uid <= 0) {
-            HeaderProxyFactory::getInstance()->getHeaderProxy()->addHeader('Status: 404 Not Found');
+            $this->responseHeadersModifier->setOverrideStatusCode(404);
             return $this->translate('message_missingSeminarNumber');
         }
         if (!$this->existsSeminar($uid)) {
-            HeaderProxyFactory::getInstance()->getHeaderProxy()->addHeader('Status: 404 Not Found');
+            $this->responseHeadersModifier->setOverrideStatusCode(404);
             return $this->translate('message_wrongSeminarNumber');
         }
 

--- a/Tests/Unit/Service/RegistrationManagerTest.php
+++ b/Tests/Unit/Service/RegistrationManagerTest.php
@@ -14,6 +14,8 @@ use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
  */
 final class RegistrationManagerTest extends UnitTestCase
 {
+    protected $resetSingletonInstances = true;
+
     /**
      * @var RegistrationManager
      */


### PR DESCRIPTION
Part of #2720