### PR TITLE
[TASK] Always call `parent::setUp()` in unit and functional tests

### DIFF
--- a/Tests/Functional/FrontEnd/DefaultController/ListViewTest.php
+++ b/Tests/Functional/FrontEnd/DefaultController/ListViewTest.php
@@ -32,6 +32,7 @@ final class ListViewTest extends FunctionalTestCase
     protected function setUp(): void
     {
         parent::setUp();
+
         $this->testingFramework = new TestingFramework('tx_seminars');
 
         $this->initializeBackEndLanguage();

--- a/Tests/Functional/Localization/TranslateTraitTest.php
+++ b/Tests/Functional/Localization/TranslateTraitTest.php
@@ -24,6 +24,7 @@ final class TranslateTraitTest extends FunctionalTestCase
     protected function setUp(): void
     {
         parent::setUp();
+
         $this->setUpLanguageService();
     }
 

--- a/Tests/Functional/ViewHelpers/SalutationAwareTranslateViewHelperTest.php
+++ b/Tests/Functional/ViewHelpers/SalutationAwareTranslateViewHelperTest.php
@@ -29,6 +29,7 @@ final class SalutationAwareTranslateViewHelperTest extends FunctionalTestCase
     protected function setUp(): void
     {
         parent::setUp();
+
         $this->setUpLanguageService();
         $this->variableProvider = new StandardVariableProvider();
     }

--- a/Tests/Unit/BackEnd/PermissionsTest.php
+++ b/Tests/Unit/BackEnd/PermissionsTest.php
@@ -32,6 +32,8 @@ final class PermissionsTest extends UnitTestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $this->backendUserMock = $this->createMock(BackendUserAuthentication::class);
         $GLOBALS['BE_USER'] = $this->backendUserMock;
     }

--- a/Tests/Unit/Configuration/CategoryListConfigurationCheckTest.php
+++ b/Tests/Unit/Configuration/CategoryListConfigurationCheckTest.php
@@ -21,6 +21,8 @@ final class CategoryListConfigurationCheckTest extends UnitTestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $this->subject = new CategoryListConfigurationCheck(new DummyConfiguration(), 'plugin.tx_seminars_pi1');
     }
 

--- a/Tests/Unit/Configuration/CsvExportConfigurationCheckTest.php
+++ b/Tests/Unit/Configuration/CsvExportConfigurationCheckTest.php
@@ -21,6 +21,8 @@ final class CsvExportConfigurationCheckTest extends UnitTestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $configuration = new DummyConfiguration();
 
         $this->subject = new CsvExportConfigurationCheck($configuration, 'plugin.tx_seminars');

--- a/Tests/Unit/Configuration/ListViewConfigurationCheckTest.php
+++ b/Tests/Unit/Configuration/ListViewConfigurationCheckTest.php
@@ -26,6 +26,8 @@ final class ListViewConfigurationCheckTest extends UnitTestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $this->configuration = new DummyConfiguration();
 
         $this->subject = new ListViewConfigurationCheck($this->configuration, 'plugin.tx_seminars_pi1');

--- a/Tests/Unit/Configuration/MyVipEventsConfigurationCheckTest.php
+++ b/Tests/Unit/Configuration/MyVipEventsConfigurationCheckTest.php
@@ -26,6 +26,8 @@ final class MyVipEventsConfigurationCheckTest extends UnitTestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $this->configuration = new DummyConfiguration();
 
         $this->subject = new MyVipEventsConfigurationCheck($this->configuration, 'plugin.tx_seminars_pi1');

--- a/Tests/Unit/Configuration/RegistrationListConfigurationCheckTest.php
+++ b/Tests/Unit/Configuration/RegistrationListConfigurationCheckTest.php
@@ -21,6 +21,8 @@ final class RegistrationListConfigurationCheckTest extends UnitTestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $this->subject = new RegistrationListConfigurationCheck(new DummyConfiguration(), 'plugin.tx_seminars_pi1');
     }
 

--- a/Tests/Unit/Configuration/SharedConfigurationCheckTest.php
+++ b/Tests/Unit/Configuration/SharedConfigurationCheckTest.php
@@ -21,6 +21,8 @@ final class SharedConfigurationCheckTest extends UnitTestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $configuration = new DummyConfiguration();
 
         $this->subject = new SharedConfigurationCheck($configuration, 'plugin.tx_seminars');

--- a/Tests/Unit/Configuration/SingleViewConfigurationCheckTest.php
+++ b/Tests/Unit/Configuration/SingleViewConfigurationCheckTest.php
@@ -26,6 +26,8 @@ final class SingleViewConfigurationCheckTest extends UnitTestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $this->configuration = new DummyConfiguration();
 
         $this->subject = new SingleViewConfigurationCheck($this->configuration, 'plugin.tx_seminars_pi1');

--- a/Tests/Unit/Controller/BackEnd/EmailControllerTest.php
+++ b/Tests/Unit/Controller/BackEnd/EmailControllerTest.php
@@ -43,6 +43,8 @@ final class EmailControllerTest extends UnitTestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         /** @var EmailController&AccessibleMockObjectInterface&MockObject $subject */
         $subject = $this->getAccessibleMock(
             EmailController::class,

--- a/Tests/Unit/Controller/BackEnd/EventControllerTest.php
+++ b/Tests/Unit/Controller/BackEnd/EventControllerTest.php
@@ -36,6 +36,8 @@ final class EventControllerTest extends UnitTestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         /** @var EventController&AccessibleMockObjectInterface&MockObject $subject */
         $subject = $this->getAccessibleMock(
             EventController::class,

--- a/Tests/Unit/Controller/BackEnd/ModuleControllerTest.php
+++ b/Tests/Unit/Controller/BackEnd/ModuleControllerTest.php
@@ -56,6 +56,8 @@ final class ModuleControllerTest extends UnitTestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $this->eventRepositoryMock = $this->createMock(EventRepository::class);
         $this->registrationRepositoryMock = $this->createMock(RegistrationRepository::class);
 

--- a/Tests/Unit/Controller/BackEnd/RegistrationControllerTest.php
+++ b/Tests/Unit/Controller/BackEnd/RegistrationControllerTest.php
@@ -72,6 +72,8 @@ final class RegistrationControllerTest extends UnitTestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $this->registrationRepositoryMock = $this->createMock(RegistrationRepository::class);
         $this->eventRepositoryMock = $this->createMock(EventRepository::class);
 

--- a/Tests/Unit/Csv/CsvResponseTest.php
+++ b/Tests/Unit/Csv/CsvResponseTest.php
@@ -22,6 +22,8 @@ final class CsvResponseTest extends UnitTestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $this->configuration = new DummyConfiguration();
         ConfigurationRegistry::getInstance()->set('plugin.tx_seminars', $this->configuration);
     }

--- a/Tests/Unit/Email/EmailBuilderTest.php
+++ b/Tests/Unit/Email/EmailBuilderTest.php
@@ -22,6 +22,8 @@ final class EmailBuilderTest extends UnitTestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $this->subject = new EmailBuilder();
     }
 

--- a/Tests/Unit/Hooks/HookProviderTest.php
+++ b/Tests/Unit/Hooks/HookProviderTest.php
@@ -28,6 +28,8 @@ final class HookProviderTest extends UnitTestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $this->extConfBackup = $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['seminars'] ?? null;
         unset($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['seminars']);
         TestingHookImplementor::$wasCalled = 0;

--- a/Tests/Unit/Mapper/FrontEndUserMapperTest.php
+++ b/Tests/Unit/Mapper/FrontEndUserMapperTest.php
@@ -21,6 +21,8 @@ final class FrontEndUserMapperTest extends UnitTestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $this->subject = new FrontEndUserMapper();
     }
 

--- a/Tests/Unit/Model/AbstractTimeSpanTest.php
+++ b/Tests/Unit/Model/AbstractTimeSpanTest.php
@@ -21,6 +21,7 @@ final class AbstractTimeSpanTest extends UnitTestCase
     protected function setUp(): void
     {
         parent::setUp();
+
         $this->subject = $this->getMockForAbstractClass(AbstractTimeSpan::class);
     }
 

--- a/Tests/Unit/Model/CategoryTest.php
+++ b/Tests/Unit/Model/CategoryTest.php
@@ -20,6 +20,7 @@ final class CategoryTest extends UnitTestCase
     protected function setUp(): void
     {
         parent::setUp();
+
         $this->subject = new Category();
     }
 

--- a/Tests/Unit/Model/CheckboxTest.php
+++ b/Tests/Unit/Model/CheckboxTest.php
@@ -20,6 +20,7 @@ final class CheckboxTest extends UnitTestCase
     protected function setUp(): void
     {
         parent::setUp();
+
         $this->subject = new Checkbox();
     }
 

--- a/Tests/Unit/Model/EventDateTest.php
+++ b/Tests/Unit/Model/EventDateTest.php
@@ -26,6 +26,7 @@ final class EventDateTest extends UnitTestCase
     protected function setUp(): void
     {
         parent::setUp();
+
         $this->subject = new Event();
     }
 

--- a/Tests/Unit/Model/EventTopicTest.php
+++ b/Tests/Unit/Model/EventTopicTest.php
@@ -26,6 +26,7 @@ final class EventTopicTest extends UnitTestCase
     protected function setUp(): void
     {
         parent::setUp();
+
         $GLOBALS['SIM_EXEC_TIME'] = 1524751343;
 
         $this->subject = new Event();

--- a/Tests/Unit/Model/EventTypeTest.php
+++ b/Tests/Unit/Model/EventTypeTest.php
@@ -19,6 +19,8 @@ final class EventTypeTest extends UnitTestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $this->subject = new EventType();
     }
 

--- a/Tests/Unit/Model/SkillTest.php
+++ b/Tests/Unit/Model/SkillTest.php
@@ -19,6 +19,8 @@ final class SkillTest extends UnitTestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $this->subject = new Skill();
     }
 

--- a/Tests/Unit/OldModel/AbstractModelTest.php
+++ b/Tests/Unit/OldModel/AbstractModelTest.php
@@ -20,6 +20,8 @@ final class AbstractModelTest extends UnitTestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $this->subject = new TestingModel();
     }
 

--- a/Tests/Unit/OldModel/AbstractTimeSpanTest.php
+++ b/Tests/Unit/OldModel/AbstractTimeSpanTest.php
@@ -20,6 +20,8 @@ final class AbstractTimeSpanTest extends UnitTestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $GLOBALS['SIM_EXEC_TIME'] = 1524751343;
 
         $this->subject = new TestingTimeSpan();

--- a/Tests/Unit/OldModel/LegacyCategoryTest.php
+++ b/Tests/Unit/OldModel/LegacyCategoryTest.php
@@ -20,6 +20,8 @@ final class LegacyCategoryTest extends UnitTestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $this->subject = new LegacyCategory();
     }
 

--- a/Tests/Unit/OldModel/LegacyEventTest.php
+++ b/Tests/Unit/OldModel/LegacyEventTest.php
@@ -26,6 +26,8 @@ final class LegacyEventTest extends UnitTestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $GLOBALS['TYPO3_CONF_VARS']['LOG'] = [];
         $this->subject = TestingLegacyEvent::fromData(
             [

--- a/Tests/Unit/OldModel/LegacyOrganizerTest.php
+++ b/Tests/Unit/OldModel/LegacyOrganizerTest.php
@@ -20,6 +20,8 @@ final class LegacyOrganizerTest extends UnitTestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $this->subject = new LegacyOrganizer();
     }
 

--- a/Tests/Unit/OldModel/LegacyRegistrationTest.php
+++ b/Tests/Unit/OldModel/LegacyRegistrationTest.php
@@ -21,6 +21,8 @@ final class LegacyRegistrationTest extends UnitTestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $this->subject = LegacyRegistration::fromData([]);
     }
 

--- a/Tests/Unit/OldModel/LegacySpeakerTest.php
+++ b/Tests/Unit/OldModel/LegacySpeakerTest.php
@@ -20,6 +20,8 @@ final class LegacySpeakerTest extends UnitTestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $this->subject = new LegacySpeaker();
     }
 

--- a/Tests/Unit/OldModel/LegacyTimeSlotTest.php
+++ b/Tests/Unit/OldModel/LegacyTimeSlotTest.php
@@ -20,6 +20,8 @@ final class LegacyTimeSlotTest extends UnitTestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $this->subject = new LegacyTimeSlot();
     }
 

--- a/Tests/Unit/Rendering/NullRenderingContextTest.php
+++ b/Tests/Unit/Rendering/NullRenderingContextTest.php
@@ -30,6 +30,8 @@ final class NullRenderingContextTest extends UnitTestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $this->subject = new NullRenderingContext();
     }
 

--- a/Tests/Unit/Rendering/NullRequestTest.php
+++ b/Tests/Unit/Rendering/NullRequestTest.php
@@ -24,6 +24,8 @@ final class NullRequestTest extends UnitTestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $this->subject = new NullRequest();
     }
 

--- a/Tests/Unit/SchedulerTasks/MailNotifierConfigurationTest.php
+++ b/Tests/Unit/SchedulerTasks/MailNotifierConfigurationTest.php
@@ -18,6 +18,8 @@ final class MailNotifierConfigurationTest extends UnitTestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $this->subject = new MailNotifierConfiguration();
     }
 

--- a/Tests/Unit/SchedulerTasks/RegistrationDigestTest.php
+++ b/Tests/Unit/SchedulerTasks/RegistrationDigestTest.php
@@ -20,6 +20,8 @@ final class RegistrationDigestTest extends UnitTestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $this->subject = new RegistrationDigest();
     }
 

--- a/Tests/Unit/Service/EventStatisticsCalculatorTest.php
+++ b/Tests/Unit/Service/EventStatisticsCalculatorTest.php
@@ -31,6 +31,8 @@ final class EventStatisticsCalculatorTest extends UnitTestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $this->subject = new EventStatisticsCalculator();
 
         $this->registrationRepositoryMock = $this->createMock(RegistrationRepository::class);

--- a/Tests/Unit/Service/RegistrationManagerTest.php
+++ b/Tests/Unit/Service/RegistrationManagerTest.php
@@ -21,6 +21,7 @@ final class RegistrationManagerTest extends UnitTestCase
     protected function setUp(): void
     {
         parent::setUp();
+
         $this->subject = new RegistrationManager();
     }
 


### PR DESCRIPTION
Part of #1061