### PR TITLE
[BUGFIX] Avoid warnings in the tests with PHP 8.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Removed
 
 ### Fixed
+- Avoid warnings in the tests with PHP 8.3 (#2812)
 - Drop obsolete option from the plugin registration (#2801)
 - Stabilize the legacy tests (#2746, #2749, #2794)
 - Avoid using the deprecated `LanguageService::create()` (#2712)

--- a/composer.json
+++ b/composer.json
@@ -64,7 +64,8 @@
 		"squizlabs/php_codesniffer": "^3.10.1",
 		"typo3/cms-install": "^10.4.22 || ^11.5.4",
 		"typo3/cms-scheduler": "^10.4.22 || ^11.5.4",
-		"typo3/coding-standards": "~0.6.1"
+		"typo3/coding-standards": "~0.6.1",
+		"webmozart/assert": "^1.11.0"
 	},
 	"replace": {
 		"typo3-ter/seminars": "self.version"


### PR DESCRIPTION
Require a version of `webmozart/assert` that fixes those warnings.