### PR TITLE
[BUGFIX] Avoid usage of deprecated `strftime` in `MailNotifier`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Removed
 
 ### Fixed
+- Avoid usage of the deprecated `strftime` (#2814)
 - Avoid warnings in the tests with PHP 8.3 (#2812)
 - Drop obsolete option from the plugin registration (#2801)
 - Stabilize the legacy tests (#2746, #2749, #2794)

--- a/Classes/SchedulerTasks/MailNotifier.php
+++ b/Classes/SchedulerTasks/MailNotifier.php
@@ -17,6 +17,7 @@ use OliverKlee\Seminars\Email\EmailBuilder;
 use OliverKlee\Seminars\Mapper\EventMapper;
 use OliverKlee\Seminars\OldModel\LegacyEvent;
 use OliverKlee\Seminars\OldModel\LegacyOrganizer;
+use OliverKlee\Seminars\Service\DateFormatConverter;
 use OliverKlee\Seminars\Service\EmailService;
 use OliverKlee\Seminars\Service\EventStatusService;
 use TYPO3\CMS\Core\Localization\LanguageService;
@@ -336,7 +337,10 @@ class MailNotifier extends AbstractTask
      */
     private function getDate(int $timestamp): string
     {
-        return strftime($this->getConfiguration()->getAsString('dateFormatYMD'), $timestamp);
+        $format = $this->getConfiguration()->getAsString('dateFormatYMD');
+        $newFormat = DateFormatConverter::convert($format);
+
+        return \date($newFormat, $timestamp);
     }
 
     /**

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1666,11 +1666,6 @@ parameters:
 			path: Classes/SchedulerTasks/MailNotifier.php
 
 		-
-			message: "#^Method OliverKlee\\\\Seminars\\\\SchedulerTasks\\\\MailNotifier\\:\\:getDate\\(\\) should return string but returns string\\|false\\.$#"
-			count: 1
-			path: Classes/SchedulerTasks/MailNotifier.php
-
-		-
 			message: "#^Method OliverKlee\\\\Seminars\\\\SchedulerTasks\\\\MailNotifier\\:\\:getLanguageService\\(\\) should return TYPO3\\\\CMS\\\\Core\\\\Localization\\\\LanguageService\\|null but returns mixed\\.$#"
 			count: 1
 			path: Classes/SchedulerTasks/MailNotifier.php


### PR DESCRIPTION
Fixes #2813