### PR TITLE
[TASK] Stop using the deprecated `Mock::setMethods()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Removed
 
 ### Fixed
+- Stop using the deprecated `Mock::setMethods()` (#2815)
 - Avoid usage of the deprecated `strftime` (#2814)
 - Avoid warnings in the tests with PHP 8.3 (#2812)
 - Drop obsolete option from the plugin registration (#2801)

--- a/Tests/LegacyUnit/FrontEnd/SelectorWidgetTest.php
+++ b/Tests/LegacyUnit/FrontEnd/SelectorWidgetTest.php
@@ -471,7 +471,7 @@ final class SelectorWidgetTest extends TestCase
     public function itemsInSearchBoxAreSortedAlphabetically(): void
     {
         $subject = $this->getMockBuilder(SelectorWidget::class)
-            ->setMethods(
+            ->onlyMethods(
                 [
                     'hasSearchField',
                     'getEventTypeData',

--- a/Tests/LegacyUnit/Service/RegistrationManagerTest.php
+++ b/Tests/LegacyUnit/Service/RegistrationManagerTest.php
@@ -926,7 +926,7 @@ final class RegistrationManagerTest extends TestCase
     public function notifyAttendeeForUnregistrationMailDoesNotAppendUnregistrationNotice(): void
     {
         $subject = $this->getMockBuilder(RegistrationManager::class)
-            ->setMethods(['getUnregistrationNotice'])->getMock();
+            ->onlyMethods(['getUnregistrationNotice'])->getMock();
         $subject->expects(self::never())->method('getUnregistrationNotice');
 
         $this->configuration->setAsBoolean('sendConfirmationOnUnregistration', true);
@@ -956,7 +956,7 @@ final class RegistrationManagerTest extends TestCase
         $this->configuration->setAsBoolean('allowUnregistrationWithEmptyWaitingList', false);
 
         $subject = $this->getMockBuilder(RegistrationManager::class)
-            ->setMethods(['getUnregistrationNotice'])->getMock();
+            ->onlyMethods(['getUnregistrationNotice'])->getMock();
         $subject->expects(self::never())->method('getUnregistrationNotice');
         $this->configuration->setAsBoolean('sendConfirmation', true);
 
@@ -983,7 +983,7 @@ final class RegistrationManagerTest extends TestCase
         $this->configuration->setAsBoolean('allowUnregistrationWithEmptyWaitingList', true);
 
         $subject = $this->getMockBuilder(RegistrationManager::class)
-            ->setMethods(['getUnregistrationNotice'])->getMock();
+            ->onlyMethods(['getUnregistrationNotice'])->getMock();
         $subject->expects(self::atLeast(1))->method('getUnregistrationNotice');
         $this->configuration->setAsBoolean('sendConfirmation', true);
 
@@ -1015,7 +1015,7 @@ final class RegistrationManagerTest extends TestCase
         $this->configuration->setAsBoolean('sendConfirmationOnRegistrationForQueue', true);
 
         $subject = $this->getMockBuilder(RegistrationManager::class)
-            ->setMethods(['getUnregistrationNotice'])->getMock();
+            ->onlyMethods(['getUnregistrationNotice'])->getMock();
         $subject->expects(self::atLeast(1))->method('getUnregistrationNotice');
 
         $registration = $this->createRegistration();
@@ -1054,7 +1054,7 @@ final class RegistrationManagerTest extends TestCase
         $this->configuration->setAsBoolean('sendConfirmationOnQueueUpdate', true);
 
         $subject = $this->getMockBuilder(RegistrationManager::class)
-            ->setMethods(['getUnregistrationNotice'])->getMock();
+            ->onlyMethods(['getUnregistrationNotice'])->getMock();
         $subject->expects(self::atLeast(1))->method('getUnregistrationNotice');
 
         $registration = $this->createRegistration();

--- a/Tests/Unit/Traits/EmailTrait.php
+++ b/Tests/Unit/Traits/EmailTrait.php
@@ -31,7 +31,7 @@ trait EmailTrait
             ->disableOriginalClone()
             ->disableArgumentCloning()
             ->disallowMockingUnknownTypes()
-            ->setMethods(['send'])
+            ->onlyMethods(['send'])
             ->getMock();
     }
 


### PR DESCRIPTION
Fixes #2789