### PR TITLE
[TASK] De-deprecate singleton-related `RegistrationManager` methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Do not require jQuery anymore (#2807)
 
 ### Deprecated
+- De-deprecate the singleton-related `RegistrationManager` methods (#2816)
 
 ### Removed
 

--- a/Classes/Service/RegistrationManager.php
+++ b/Classes/Service/RegistrationManager.php
@@ -57,8 +57,6 @@ class RegistrationManager
     public const SEND_USER_MAIL = 2;
 
     /**
-     * @deprecated #1904 will be removed in seminars 6.0
-     *
      * @var static|null
      */
     private static $instance;
@@ -85,8 +83,6 @@ class RegistrationManager
 
     /**
      * @return static the current singleton instance
-     *
-     * @deprecated #1904 will be removed in seminars 6.0
      */
     public static function getInstance(): RegistrationManager
     {
@@ -100,8 +96,6 @@ class RegistrationManager
 
     /**
      * Purges the current instance so that `getInstance` will create a new instance.
-     *
-     * @deprecated #1904 will be removed in seminars 6.0
      */
     public static function purgeInstance(): void
     {


### PR DESCRIPTION
Instead of removing these method, the `RegistrationManager` will be completely removed at some time.

Fixes #2790