### PR TITLE
[TASK] Switch (un)hiding events to using the `DataHandler`

### DIFF
--- a/Tests/Functional/Domain/Repository/Event/EventRepositoryTest.php
+++ b/Tests/Functional/Domain/Repository/Event/EventRepositoryTest.php
@@ -18,6 +18,7 @@ use OliverKlee\Seminars\Domain\Model\RegistrationCheckbox;
 use OliverKlee\Seminars\Domain\Model\Speaker;
 use OliverKlee\Seminars\Domain\Model\Venue;
 use OliverKlee\Seminars\Domain\Repository\Event\EventRepository;
+use OliverKlee\Seminars\Tests\Support\BackEndTestsTrait;
 use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
 
 /**
@@ -34,6 +35,8 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
  */
 final class EventRepositoryTest extends FunctionalTestCase
 {
+    use BackEndTestsTrait;
+
     protected $testExtensionsToLoad = [
         'typo3conf/ext/static_info_tables',
         'typo3conf/ext/feuserextrafields',
@@ -51,6 +54,13 @@ final class EventRepositoryTest extends FunctionalTestCase
         parent::setUp();
 
         $this->subject = $this->get(EventRepository::class);
+    }
+
+    private function initializeBackEndUser(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/BackEndUser.csv');
+        $this->setUpBackendUser(1);
+        $this->unifyBackEndLanguage();
     }
 
     /**
@@ -990,6 +1000,7 @@ final class EventRepositoryTest extends FunctionalTestCase
      */
     public function hideWithUidOfExistingVisibleEventMarksEventAsHidden(): void
     {
+        $this->initializeBackEndUser();
         $this->importCSVDataSet(__DIR__ . '/Fixtures/SingleEventOnPage.csv');
 
         $this->subject->hide(1);
@@ -1002,6 +1013,7 @@ final class EventRepositoryTest extends FunctionalTestCase
      */
     public function hideWithUidOfInexistentEventKeepsOtherVisibleEventsUnchanged(): void
     {
+        $this->initializeBackEndUser();
         $this->importCSVDataSet(__DIR__ . '/Fixtures/SingleEventOnPage.csv');
 
         $this->subject->hide(2);
@@ -1014,6 +1026,7 @@ final class EventRepositoryTest extends FunctionalTestCase
      */
     public function hideWithUidOfExistingHiddenEventKeepsEventHidden(): void
     {
+        $this->initializeBackEndUser();
         $this->importCSVDataSet(__DIR__ . '/Fixtures/HiddenSingleEventOnPage.csv');
 
         $this->subject->hide(1);
@@ -1026,6 +1039,7 @@ final class EventRepositoryTest extends FunctionalTestCase
      */
     public function hideWithUidOfDeletedVisibleEventKeepsDeletedEventVisible(): void
     {
+        $this->initializeBackEndUser();
         $this->importCSVDataSet(__DIR__ . '/Fixtures/DeletedSingleEventOnPage.csv');
 
         $this->subject->hide(1);
@@ -1038,6 +1052,7 @@ final class EventRepositoryTest extends FunctionalTestCase
      */
     public function unhideWithUidOfExistingHiddenEventMarksEventAsVisible(): void
     {
+        $this->initializeBackEndUser();
         $this->importCSVDataSet(__DIR__ . '/Fixtures/HiddenSingleEventOnPage.csv');
 
         $this->subject->unhide(1);
@@ -1050,6 +1065,7 @@ final class EventRepositoryTest extends FunctionalTestCase
      */
     public function unhideWithUidOfInexistentEventKeepsOtherHiddenEventsUnchanged(): void
     {
+        $this->initializeBackEndUser();
         $this->importCSVDataSet(__DIR__ . '/Fixtures/HiddenSingleEventOnPage.csv');
 
         $this->subject->unhide(2);
@@ -1062,6 +1078,7 @@ final class EventRepositoryTest extends FunctionalTestCase
      */
     public function unhideWithUidOfExistingVisibleEventKeepsEventVisible(): void
     {
+        $this->initializeBackEndUser();
         $this->importCSVDataSet(__DIR__ . '/Fixtures/SingleEventOnPage.csv');
 
         $this->subject->unhide(1);
@@ -1074,6 +1091,7 @@ final class EventRepositoryTest extends FunctionalTestCase
      */
     public function unhideWithUidOfDeletedHiddenEventKeepsDeletedEventHidden(): void
     {
+        $this->initializeBackEndUser();
         $this->importCSVDataSet(__DIR__ . '/Fixtures/DeletedHiddenSingleEventOnPage.csv');
 
         $this->subject->unhide(1);

--- a/Tests/Functional/Domain/Repository/Event/Fixtures/BackEndUser.csv
+++ b/Tests/Functional/Domain/Repository/Event/Fixtures/BackEndUser.csv
@@ -1,0 +1,3 @@
+"be_users"
+,"uid","username","admin"
+,1,"admin",1

--- a/Tests/Functional/Domain/Repository/Event/Fixtures/DeletedHiddenSingleEventOnPage.csv
+++ b/Tests/Functional/Domain/Repository/Event/Fixtures/DeletedHiddenSingleEventOnPage.csv
@@ -1,3 +1,7 @@
+"pages"
+,"uid","pid","doktype","title"
+,1,0,254,"Record for pages"
+
 "tx_seminars_seminars"
 ,"uid","pid","object_type","deleted","hidden"
 ,1,1,0,1,1

--- a/Tests/Functional/Domain/Repository/Event/Fixtures/DeletedSingleEventOnPage.csv
+++ b/Tests/Functional/Domain/Repository/Event/Fixtures/DeletedSingleEventOnPage.csv
@@ -1,3 +1,7 @@
+"pages"
+,"uid","pid","doktype","title"
+,1,0,254,"Record for pages"
+
 "tx_seminars_seminars"
 ,"uid","pid","object_type","deleted"
 ,1,1,0,1

--- a/Tests/Functional/Domain/Repository/Event/Fixtures/HiddenSingleEventOnPage.csv
+++ b/Tests/Functional/Domain/Repository/Event/Fixtures/HiddenSingleEventOnPage.csv
@@ -1,3 +1,7 @@
+"pages"
+,"uid","pid","doktype","title"
+,1,0,254,"Record for pages"
+
 "tx_seminars_seminars"
 ,"uid","pid","object_type","hidden"
 ,1,1,0,1

--- a/Tests/Functional/Domain/Repository/Event/Fixtures/SingleEventOnPage.csv
+++ b/Tests/Functional/Domain/Repository/Event/Fixtures/SingleEventOnPage.csv
@@ -1,3 +1,7 @@
+"pages"
+,"uid","pid","doktype","title"
+,1,0,254,"Record for pages"
+
 "tx_seminars_seminars"
 ,"uid","pid","object_type"
 ,1,1,0

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -2296,13 +2296,43 @@ parameters:
 			path: Tests/Functional/BagBuilder/EventBagBuilderTest.php
 
 		-
+			message: "#^Cannot access offset 'EXTCONF' on mixed\\.$#"
+			count: 3
+			path: Tests/Functional/Domain/Repository/Event/EventRepositoryTest.php
+
+		-
+			message: "#^Cannot access offset 'getUserObj' on mixed\\.$#"
+			count: 2
+			path: Tests/Functional/Domain/Repository/Event/EventRepositoryTest.php
+
+		-
+			message: "#^Cannot access offset 'seminars' on mixed\\.$#"
+			count: 1
+			path: Tests/Functional/Domain/Repository/Event/EventRepositoryTest.php
+
+		-
 			message: "#^Cannot cast mixed to int\\.$#"
-			count: 4
+			count: 5
 			path: Tests/Functional/Domain/Repository/Event/EventRepositoryTest.php
 
 		-
 			message: "#^Parameter \\#1 \\$event of method OliverKlee\\\\Seminars\\\\Domain\\\\Repository\\\\Event\\\\EventRepository\\:\\:updateRegistrationCounterCache\\(\\) expects OliverKlee\\\\Seminars\\\\Domain\\\\Model\\\\Event\\\\Event, OliverKlee\\\\Seminars\\\\Domain\\\\Model\\\\Event\\\\Event\\|null given\\.$#"
 			count: 4
+			path: Tests/Functional/Domain/Repository/Event/EventRepositoryTest.php
+
+		-
+			message: "#^Property OliverKlee\\\\Seminars\\\\Tests\\\\Functional\\\\Domain\\\\Repository\\\\Event\\\\EventRepositoryTest\\:\\:\\$extConfBackup type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: Tests/Functional/Domain/Repository/Event/EventRepositoryTest.php
+
+		-
+			message: "#^Property OliverKlee\\\\Seminars\\\\Tests\\\\Functional\\\\Domain\\\\Repository\\\\Event\\\\EventRepositoryTest\\:\\:\\$now \\(int\\<1, max\\>\\) does not accept int\\.$#"
+			count: 1
+			path: Tests/Functional/Domain/Repository/Event/EventRepositoryTest.php
+
+		-
+			message: "#^Property OliverKlee\\\\Seminars\\\\Tests\\\\Functional\\\\Domain\\\\Repository\\\\Event\\\\EventRepositoryTest\\:\\:\\$t3VarBackup type has no value type specified in iterable type array\\.$#"
+			count: 1
 			path: Tests/Functional/Domain/Repository/Event/EventRepositoryTest.php
 
 		-


### PR DESCRIPTION
This allows cache clearing.

Fixes #3140
Closes #2915