### PR TITLE
[TASK] Drop duplicate permissions check when (un)hiding events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 - Convert the "hide event" button-links in the BE module to real buttons
-  (#3136, #3137, #3148)
+  (#3136, #3137, #3148, #3149, #3150)
 - Allow up to 50 attached files per event (#3125)
 - Allow installations with oelib 6.x (#3009)
 - Mark some classes as `@internal` (#2975)

--- a/Classes/Controller/BackEnd/EventController.php
+++ b/Classes/Controller/BackEnd/EventController.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace OliverKlee\Seminars\Controller\BackEnd;
 
-use OliverKlee\Seminars\BackEnd\Permissions;
 use OliverKlee\Seminars\Csv\CsvDownloader;
 use OliverKlee\Seminars\Csv\CsvResponse;
 use OliverKlee\Seminars\Domain\Repository\Event\EventRepository;
@@ -32,15 +31,9 @@ class EventController extends ActionController
      */
     private $eventRepository;
 
-    /**
-     * @var Permissions
-     */
-    private $permissions;
-
-    public function __construct(EventRepository $eventRepository, Permissions $permissions)
+    public function __construct(EventRepository $eventRepository)
     {
         $this->eventRepository = $eventRepository;
-        $this->permissions = $permissions;
     }
 
     /**
@@ -73,9 +66,7 @@ class EventController extends ActionController
      */
     public function hideAction(int $eventUid): void
     {
-        if ($this->permissions->hasWriteAccessToEvents()) {
-            $this->eventRepository->hide($eventUid);
-        }
+        $this->eventRepository->hide($eventUid);
 
         $this->redirect('overview', 'BackEnd\\Module');
     }
@@ -85,9 +76,7 @@ class EventController extends ActionController
      */
     public function unhideAction(int $eventUid): void
     {
-        if ($this->permissions->hasWriteAccessToEvents()) {
-            $this->eventRepository->unhide($eventUid);
-        }
+        $this->eventRepository->unhide($eventUid);
 
         $this->redirect('overview', 'BackEnd\\Module');
     }

--- a/Classes/Domain/Repository/Event/EventRepository.php
+++ b/Classes/Domain/Repository/Event/EventRepository.php
@@ -153,6 +153,8 @@ class EventRepository extends AbstractRawDataCapableRepository implements Direct
      *
      * Note: As this method uses the `DataHandler`, it can only be used within a backend context.
      *
+     * The `DataHandler` will also take care of checking the permissions of the logged-in BE user.
+     *
      * @param positive-int $uid
      */
     public function hide(int $uid): void
@@ -164,6 +166,8 @@ class EventRepository extends AbstractRawDataCapableRepository implements Direct
      * Unhides the event with the given UID.
      *
      * Note: As this method uses the `DataHandler`, it can only be used within a backend context.
+     *
+     * The `DataHandler` will also take care of checking the permissions of the logged-in BE user.
      *
      * @param positive-int $uid
      */

--- a/Tests/Unit/Controller/BackEnd/EventControllerTest.php
+++ b/Tests/Unit/Controller/BackEnd/EventControllerTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace OliverKlee\Seminars\Tests\Unit\Controller\BackEnd;
 
-use OliverKlee\Seminars\BackEnd\Permissions;
 use OliverKlee\Seminars\Controller\BackEnd\EventController;
 use OliverKlee\Seminars\Csv\CsvDownloader;
 use OliverKlee\Seminars\Domain\Repository\Event\EventRepository;
@@ -32,11 +31,6 @@ final class EventControllerTest extends UnitTestCase
     private $eventRepositoryMock;
 
     /**
-     * @var Permissions&MockObject
-     */
-    private $permissionsMock;
-
-    /**
      * @var CsvDownloader&MockObject
      */
     private $csvDownloaderMock;
@@ -51,13 +45,12 @@ final class EventControllerTest extends UnitTestCase
         parent::setUp();
 
         $this->eventRepositoryMock = $this->createMock(EventRepository::class);
-        $this->permissionsMock = $this->createMock(Permissions::class);
 
         /** @var EventController&AccessibleObjectInterface&MockObject $subject */
         $subject = $this->getAccessibleMock(
             EventController::class,
             ['redirect', 'forward', 'redirectToUri'],
-            [$this->eventRepositoryMock, $this->permissionsMock]
+            [$this->eventRepositoryMock]
         );
         $this->subject = $subject;
 
@@ -172,10 +165,9 @@ final class EventControllerTest extends UnitTestCase
     /**
      * @test
      */
-    public function hideActionWithEventWritePermissionGrantedHidesEvent(): void
+    public function hideActionHidesEvent(): void
     {
         $uid = 15;
-        $this->permissionsMock->method('hasWriteAccessToEvents')->willReturn(true);
         $this->eventRepositoryMock->expects(self::once())->method('hide')->with($uid);
 
         $this->subject->hideAction($uid);
@@ -184,21 +176,8 @@ final class EventControllerTest extends UnitTestCase
     /**
      * @test
      */
-    public function hideActionWithEventWritePermissionDeniedDoesNotHideEvent(): void
+    public function hideActionRedirectsToModuleOverviewAction(): void
     {
-        $uid = 15;
-        $this->permissionsMock->method('hasWriteAccessToEvents')->willReturn(false);
-        $this->eventRepositoryMock->expects(self::never())->method('hide');
-
-        $this->subject->hideAction($uid);
-    }
-
-    /**
-     * @test
-     */
-    public function hideActionWithEventWritePermissionGrantedRedirectsToModuleOverviewAction(): void
-    {
-        $this->permissionsMock->method('hasWriteAccessToEvents')->willReturn(true);
         $this->subject->expects(self::once())->method('redirect')->with('overview', 'BackEnd\\Module');
 
         $this->subject->hideAction(15);
@@ -207,21 +186,9 @@ final class EventControllerTest extends UnitTestCase
     /**
      * @test
      */
-    public function hideActionWithEventWritePermissionDeniedRedirectsToModuleOverviewAction(): void
-    {
-        $this->permissionsMock->method('hasWriteAccessToEvents')->willReturn(false);
-        $this->subject->expects(self::once())->method('redirect')->with('overview', 'BackEnd\\Module');
-
-        $this->subject->hideAction(15);
-    }
-
-    /**
-     * @test
-     */
-    public function unhideWithEventWritePermissionGrantedActionUnhidesEvent(): void
+    public function unhideActionUnhidesEvent(): void
     {
         $uid = 15;
-        $this->permissionsMock->method('hasWriteAccessToEvents')->willReturn(true);
         $this->eventRepositoryMock->expects(self::once())->method('unhide')->with($uid);
 
         $this->subject->unhideAction($uid);
@@ -230,32 +197,8 @@ final class EventControllerTest extends UnitTestCase
     /**
      * @test
      */
-    public function unhideWithEventWritePermissionDeniedActionDoesNotUnhideEvent(): void
+    public function unhideActionRedirectsToModuleOverviewAction(): void
     {
-        $uid = 15;
-        $this->permissionsMock->method('hasWriteAccessToEvents')->willReturn(false);
-        $this->eventRepositoryMock->expects(self::never())->method('unhide');
-
-        $this->subject->unhideAction($uid);
-    }
-
-    /**
-     * @test
-     */
-    public function unhideActionWithEventWritePermissionGrantedRedirectsToModuleOverviewAction(): void
-    {
-        $this->permissionsMock->method('hasWriteAccessToEvents')->willReturn(true);
-        $this->subject->expects(self::once())->method('redirect')->with('overview', 'BackEnd\\Module');
-
-        $this->subject->unhideAction(15);
-    }
-
-    /**
-     * @test
-     */
-    public function unhideActionWithEventWritePermissionDeniedRedirectsToModuleOverviewAction(): void
-    {
-        $this->permissionsMock->method('hasWriteAccessToEvents')->willReturn(false);
         $this->subject->expects(self::once())->method('redirect')->with('overview', 'BackEnd\\Module');
 
         $this->subject->unhideAction(15);


### PR DESCRIPTION
Now that we're using the `DataHandler`, we can rely on it doing the permission check for the current BE user.

This reverts commit 45a726d85ca01ef4baca886bb8ef423f133dcbf6.