### PR TITLE
[BUGFIX] Redirect to events list after sending email in the BE module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Removed
 
 ### Fixed
+- Redirect to the events list after sending an email in the BE module (#2971)
 - Avoid crash with `typo3fluid/fluid` 2.14.0 due to signature change (#3158)
 
 ## 5.5.2

--- a/Classes/Controller/BackEnd/EmailController.php
+++ b/Classes/Controller/BackEnd/EmailController.php
@@ -53,7 +53,7 @@ class EmailController extends ActionController
         $emailService->setPostData(['subject' => $subject, 'messageBody' => $body]);
         $emailService->sendEmailToAttendees();
 
-        $this->redirect('index', 'BackEnd\\Event');
+        $this->redirect('overview', 'BackEnd\\Module');
     }
 
     /**

--- a/Tests/Unit/Controller/BackEnd/EmailControllerTest.php
+++ b/Tests/Unit/Controller/BackEnd/EmailControllerTest.php
@@ -298,7 +298,7 @@ final class EmailControllerTest extends UnitTestCase
     /**
      * @test
      */
-    public function sendActionRedirectsToEventsList(): void
+    public function sendActionRedirectsToOverview(): void
     {
         $this->permissionsMock->method('hasReadAccessToEvents')->willReturn(true);
         $this->permissionsMock->method('hasReadAccessToRegistrations')->willReturn(true);
@@ -306,7 +306,7 @@ final class EmailControllerTest extends UnitTestCase
         $eventUid = 9;
         $event = $this->buildSingleEventMockWithUid($eventUid);
 
-        $this->subject->expects(self::once())->method('redirect')->with('index', 'BackEnd\\Event');
+        $this->subject->expects(self::once())->method('redirect')->with('overview', 'BackEnd\\Module');
 
         $this->subject->sendAction($event, 1, '', '');
     }


### PR DESCRIPTION
This is the 5.5.x backport of #2968.

Fixes #3153