### PR TITLE
[BUGFIX] Avoid usage of `empty` in `TemplateHelper`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Removed
 
 ### Fixed
+- Avoid usage of `empty` in `TemplateHelper` (#3214)
 - Always call `htmlspecialchars` with flags (#3209)
 - Improve some type annotations (#3205, #3206, #3211)
 

--- a/Classes/Templating/TemplateHelper.php
+++ b/Classes/Templating/TemplateHelper.php
@@ -1260,7 +1260,7 @@ abstract class TemplateHelper
     {
         $word = null;
         if (
-            !empty($this->LOCAL_LANG[$this->LLkey][$key][0]['target'])
+            \is_string($this->LOCAL_LANG[$this->LLkey][$key][0]['target'] ?? null)
             || isset($this->LOCAL_LANG_UNSET[$this->LLkey][$key])
         ) {
             $word = $this->LOCAL_LANG[$this->LLkey][$key][0]['target'];
@@ -1269,7 +1269,7 @@ abstract class TemplateHelper
             $alternativeLanguageKeys = array_reverse($alternativeLanguageKeys);
             foreach ($alternativeLanguageKeys as $languageKey) {
                 if (
-                    !empty($this->LOCAL_LANG[$languageKey][$key][0]['target'])
+                    \is_string($this->LOCAL_LANG[$languageKey][$key][0]['target'] ?? null)
                     || isset($this->LOCAL_LANG_UNSET[$languageKey][$key])
                 ) {
                     // Alternative language translation for key exists
@@ -1280,7 +1280,7 @@ abstract class TemplateHelper
         }
         if ($word === null) {
             if (
-                !empty($this->LOCAL_LANG['default'][$key][0]['target'])
+                \is_string($this->LOCAL_LANG['default'][$key][0]['target'] ?? null)
                 || isset($this->LOCAL_LANG_UNSET['default'][$key])
             ) {
                 // Get default translation (without charset conversion, english)
@@ -1535,7 +1535,7 @@ abstract class TemplateHelper
         //	 		 2: only the text "Displaying results..." will be shown
         $showResultCount = (int)$showResultCount;
         // If this is set, two links named "<< First" and "LAST >>" will be shown and point to the very first or last page.
-        $showFirstLast = !empty($this->internal['showFirstLast']);
+        $showFirstLast = (bool)($this->internal['showFirstLast'] ?? false);
         // If this has a value the "previous" button is always visible (will be forced if "showFirstLast" is set)
         $alwaysPrev = $showFirstLast ? 1 : $this->pi_alwaysPrev;
         if (isset($this->internal['pagefloat'])) {
@@ -1813,7 +1813,7 @@ abstract class TemplateHelper
             }
         }
 
-        if (empty($tempPiVars)) {
+        if ($tempPiVars === []) {
             // @TODO: How do we deal with this? return TRUE would be the right thing to do here but that might be breaking
             return 1;
         }
@@ -1907,7 +1907,7 @@ abstract class TemplateHelper
             }
         }
 
-        if (empty($inArray)) {
+        if ($inArray === []) {
             // @TODO: How do we deal with this? return TRUE would be the right thing to do here but that might be breaking
             return 1;
         }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1916,6 +1916,11 @@ parameters:
 			path: Classes/Templating/TemplateHelper.php
 
 		-
+			message: "#^Casting to bool something that's already false\\.$#"
+			count: 1
+			path: Classes/Templating/TemplateHelper.php
+
+		-
 			message: "#^Casting to int something that's already int\\.$#"
 			count: 2
 			path: Classes/Templating/TemplateHelper.php
@@ -1923,11 +1928,6 @@ parameters:
 		-
 			message: "#^Comparison operation \"\\>\" between \\-1 and \\-1 is always false\\.$#"
 			count: 1
-			path: Classes/Templating/TemplateHelper.php
-
-		-
-			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
-			count: 6
 			path: Classes/Templating/TemplateHelper.php
 
 		-
@@ -2021,7 +2021,7 @@ parameters:
 			path: Classes/Templating/TemplateHelper.php
 
 		-
-			message: "#^Offset 'showFirstLast' on array\\{currentRow\\: array, currentTable\\: string, descFlag\\: bool, maxPages\\: int, res_count\\: int, results_at_a_time\\: int\\} in empty\\(\\) does not exist\\.$#"
+			message: "#^Offset 'showFirstLast' on array\\{currentRow\\: array, currentTable\\: string, descFlag\\: bool, maxPages\\: int, res_count\\: int, results_at_a_time\\: int\\} on left side of \\?\\? does not exist\\.$#"
 			count: 1
 			path: Classes/Templating/TemplateHelper.php
 


### PR DESCRIPTION
`empty` checks too loosely.