### PR TITLE
[TASK] Switch code coverage from PCOV to Xdebug

### DIFF
--- a/.github/workflows/codecoverage.yml
+++ b/.github/workflows/codecoverage.yml
@@ -23,9 +23,8 @@ jobs:
         with:
           php-version: "${{ matrix.php-version }}"
           ini-file: development
-          coverage: pcov
+          coverage: xdebug
           extensions: mysqli
-          ini-values: pcov.directory=Classes
           tools: composer:v2, phive
       - name: "Show Composer version"
         run: composer --version


### PR DESCRIPTION
PCOV is no longer maintainted, and nowadays Xdebug is fast enough.