### PR TITLE
[TASK] Drop obsolete TypoScript option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Deprecated
 
 ### Removed
+- Drop obsolete TypoScript option (#3294)
 - Drop unused `AbstractPlugin` code from `TemplateHelper`
   (#3237, #3238, #3240, #3241, #3242, #3243, #3245, #3246, #3250, #3251, #3253,
   #3255, #3256, #3258, #3260, #3261, #3263, #3264, #3265, #3266, #3268, #3269,

--- a/Configuration/TypoScript/FrontEnd.typoscript
+++ b/Configuration/TypoScript/FrontEnd.typoscript
@@ -8,9 +8,6 @@ plugin.tx_seminars_pi1 {
   # location of the HTML template file
   templateFile = EXT:seminars/Resources/Private/Templates/FrontEnd/FrontEnd.html
 
-  # activate Javascript framework from global config
-  loadJsFramework =< config.loadJsFramework
-
   # the strftime format code for the full date, @deprecated #2342 will be removed in seminars 6.0
   dateFormatYMD < plugin.tx_seminars.dateFormatYMD
 


### PR DESCRIPTION
The option `loadJsFramework` is a left-over from FORMidable, which we're not using anymore.

Fixes #3292

[ci skip]