### PR TITLE
[BUGFIX] Add `typo3/cms-extensionmanager` as a dev dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -61,6 +61,7 @@
 		"squizlabs/php_codesniffer": "^3.10.2",
 		"symfony/translation": "^5.4 || ^6.4 || ^7.0",
 		"symfony/yaml": "^5.4 || ^6.4 || ^7.0",
+		"typo3/cms-extensionmanager": "^10.4.33 || ^11.5.17",
 		"typo3/cms-install": "^10.4.33 || ^11.5.17",
 		"typo3/cms-scheduler": "^10.4.33 || ^11.5.17",
 		"typo3/coding-standards": "~0.6.1",


### PR DESCRIPTION
This is necessary due to a bug in static_info_tables.