### PR TITLE
[TASK] Limit the runtime of the CI jobs

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -11,6 +11,8 @@ jobs:
 
     runs-on: ubuntu-24.04
 
+    timeout-minutes: 1
+
     if: ${{ github.actor == 'dependabot[bot]' }}
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ jobs:
   php-lint:
     name: "PHP linter"
     runs-on: ubuntu-24.04
+    timeout-minutes: 1
     steps:
       - name: "Checkout"
         uses: actions/checkout@v4
@@ -41,6 +42,7 @@ jobs:
   code-quality:
     name: "Code quality checks"
     runs-on: ubuntu-24.04
+    timeout-minutes: 1
     steps:
       - name: "Checkout"
         uses: actions/checkout@v4
@@ -83,6 +85,7 @@ jobs:
   unit-tests:
     name: "Unit tests"
     runs-on: ubuntu-24.04
+    timeout-minutes: 2
     needs: php-lint
     steps:
       - name: "Checkout"
@@ -181,6 +184,7 @@ jobs:
   functional-tests:
     name: "Functional tests"
     runs-on: ubuntu-24.04
+    timeout-minutes: 4
     needs: php-lint
     env:
       DB_DATABASE: typo3
@@ -296,6 +300,7 @@ jobs:
   legacy-functional-tests:
     name: "Legacy functional tests"
     runs-on: ubuntu-24.04
+    timeout-minutes: 5
     needs: php-lint
     env:
       DB_DATABASE: typo3

--- a/.github/workflows/codecoverage.yml
+++ b/.github/workflows/codecoverage.yml
@@ -9,6 +9,7 @@ jobs:
   code-coverage:
     name: "Calculate code coverage"
     runs-on: ubuntu-24.04
+    timeout-minutes: 9
     env:
       DATABASE_HOST: 127.0.0.1
       DATABASE_USER: root

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-24.04
+    timeout-minutes: 3
     steps:
       - name: "Checkout"
         uses: actions/checkout@v4


### PR DESCRIPTION
This avoids runaway jobs eating into the runners budget.