### PR TITLE
[TASK] Do not use the event subtitle as calendar invite description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Allow viewing event UIDs in the TCEforms (#3337)
 
 ### Changed
+- Do not use the event subtitle as calendar invite description anymore (#3398)
 
 ### Deprecated
 

--- a/Classes/Service/RegistrationManager.php
+++ b/Classes/Service/RegistrationManager.php
@@ -516,7 +516,6 @@ class RegistrationManager
             'UID:' . uniqid('event/' . $event->getUid() . '/', true) . "\r\n" .
             'DTSTAMP:' . $this->formatDateForCalendar($this->nowAsTimestamp()) . "\r\n" .
             'SUMMARY:' . $event->getTitle() . "\r\n" .
-            'DESCRIPTION:' . $event->getSubtitle() . "\r\n" .
             'DTSTART:' . $this->formatDateForCalendar($event->getBeginDateAsUnixTimeStamp()) . "\r\n";
 
         if ($event->hasEndDate()) {

--- a/Tests/Functional/Service/RegistrationManagerTest.php
+++ b/Tests/Functional/Service/RegistrationManagerTest.php
@@ -1811,29 +1811,6 @@ final class RegistrationManagerTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function notifyAttendeeIncludesEventSubtitleAsDescriptionInCalendarInvite(): void
-    {
-        $this->setUpFakeFrontEnd();
-        $this->configuration->setAsBoolean('sendConfirmation', true);
-        $this->createEventWithOrganizer();
-
-        $controller = new DefaultController();
-        $controller->init();
-
-        $registration = $this->createRegistration();
-        $this->subject->notifyAttendee($registration, $controller);
-
-        $icsAttachments = $this->filterEmailAttachmentsByType($this->email, 'text/calendar');
-        $firstIcsAttachment = $icsAttachments[0] ?? null;
-        self::assertInstanceOf(DataPart::class, $firstIcsAttachment);
-
-        $body = $firstIcsAttachment->getBody();
-        self::assertStringContainsString('DESCRIPTION:juggling with burning chainsaws', $body);
-    }
-
-    /**
-     * @test
-     */
     public function notifyAttendeeForOnSiteEventWithoutVenuesHasNoLocationInCalendarInvite(): void
     {
         $this->setUpFakeFrontEnd();


### PR DESCRIPTION
A subtitle is not description, and having it in the calendar invite does not make any sense.