### PR TITLE
[CLEANUP] Drop residual entries for `helhum/typo3-console`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,7 +21,6 @@ updates:
         versions: [ ">= 2.20.0" ]
       - dependency-name: "friendsofphp/php-cs-fixer"
         versions: [ ">= 3.4.0" ]
-      - dependency-name: "helhum/typo3-console"
       - dependency-name: "helmich/typo3-typoscript-lint"
         versions: [ ">= 3.0.0" ]
       - dependency-name: "pelago/emogrifier"

--- a/composer.json
+++ b/composer.json
@@ -89,7 +89,6 @@
 	"config": {
 		"allow-plugins": {
 			"ergebnis/composer-normalize": true,
-			"helhum/typo3-console-plugin": true,
 			"phpstan/extension-installer": true,
 			"typo3/class-alias-loader": true,
 			"typo3/cms-composer-installers": true
@@ -105,9 +104,6 @@
 	"extra": {
 		"branch-alias": {
 			"dev-main": "5.7.x-dev"
-		},
-		"helhum/typo3-console": {
-			"install-extension-dummy": "0"
 		},
 		"typo3/cms": {
 			"app-dir": ".Build",


### PR DESCRIPTION
This package no longer is a dependency of ours.