### PR TITLE
[TASK] Allow higher versions of `helmich/typo3-typoscript-lint`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,7 +20,6 @@ updates:
       - dependency-name: "ergebnis/composer-normalize"
         versions: [ ">= 2.20.0" ]
       - dependency-name: "helmich/typo3-typoscript-lint"
-        versions: [ ">= 3.0.0" ]
       - dependency-name: "pelago/emogrifier"
       - dependency-name: "phpunit/phpunit"
         versions: [ ">= 9" ]

--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,7 @@
 		"egulias/email-validator": "^2.1.0 || ^3.2.1",
 		"ergebnis/composer-normalize": "2.19.0",
 		"friendsofphp/php-cs-fixer": "3.9.5",
-		"helmich/typo3-typoscript-lint": "2.5.2",
+		"helmich/typo3-typoscript-lint": "2.5.2 || 3.2.1",
 		"phpstan/extension-installer": "1.4.3",
 		"phpstan/phpstan": "1.12.3",
 		"phpstan/phpstan-phpunit": "1.4.0",


### PR DESCRIPTION
This paves to way to Symfony 6 and 7.