### PR TITLE
[TASK] Drop the `symfony/property-info` development dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -58,7 +58,6 @@
 		"phpunit/phpunit": "8.5.39",
 		"saschaegerer/phpstan-typo3": "1.10.2",
 		"squizlabs/php_codesniffer": "3.10.2",
-		"symfony/property-info": "^4.4.49 || ^5.4.42 || ^6.4.10 || ^7.1.3",
 		"symfony/translation": "^5.4 || ^6.4 || ^7.0",
 		"symfony/yaml": "^5.4 || ^6.4 || ^7.0",
 		"typo3/cms-extensionmanager": "^11.5.17",


### PR DESCRIPTION
Fixes #3351