### PR TITLE
[TASK] Sync the allowed DBAL versions with the Core dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- Drop the `ext-pdo` dependency (#3504)
 - Use short class names in type annotations (#2876)
 - Require oelib >= 6.0.0 (#3500)
 

--- a/composer.json
+++ b/composer.json
@@ -27,8 +27,7 @@
 	"require": {
 		"php": "^7.4.0 || ~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0",
 		"ext-json": "*",
-		"ext-pdo": "*",
-		"doctrine/dbal": "^2.10 || ^3.7.1",
+		"doctrine/dbal": "^2.13.8 || ^3.9",
 		"oliverklee/feuserextrafields": "^5.3.0 || ^6.0.0",
 		"oliverklee/oelib": "^6.0.0",
 		"pelago/emogrifier": "^6.0.0 || ^7.0.0",


### PR DESCRIPTION
Also drop the now obsolete `ext-pdo` dependency.