### PR TITLE
[TASK] Require oelib >= 6.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Require feuserextrafields >= 6.3.0 (#3505)
 - Drop the `ext-pdo` dependency (#3504)
 - Use short class names in type annotations (#2876)
-- Require oelib >= 6.0.0 (#3500)
+- Require oelib >= 6.0.1 (#3500, #3555)
 
 ### Deprecated
 

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
 		"ext-json": "*",
 		"doctrine/dbal": "^2.13.8 || ^3.9",
 		"oliverklee/feuserextrafields": "^6.3.0",
-		"oliverklee/oelib": "^6.0.0",
+		"oliverklee/oelib": "^6.0.1",
 		"pelago/emogrifier": "^7.2.0",
 		"psr/event-dispatcher": "^1.0",
 		"psr/http-message": "^1.0 || ^2.0",

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -11,7 +11,7 @@ $EM_CONF[$_EXTKEY] = [
             'typo3' => '11.5.37-11.5.99',
             'extbase' => '11.5.37-11.5.99',
             'feuserextrafields' => '6.3.0-6.99.99',
-            'oelib' => '6.0.0-6.99.99',
+            'oelib' => '6.0.1-6.99.99',
             'static_info_tables' => '11.5.5-12.4.99',
         ],
         'conflicts' => [


### PR DESCRIPTION
This version includes a fix for functional tests with TYPO3 12LTS.