### PR TITLE
[TASK] Drop autologout for no-longer-supported onetimeaccount logins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Removed
 
+- Drop the autologout for no-longer-supported onetimeaccount logins (#3556)
 - Drop `$isFileName` parameter in `::getConfValueString()` (#2835)
 - Remove the `omitDateIfSameAsPrevious` setting (#2314)
 - Drop `SeparateBillingAddressUpgradeWizard` (#3496)

--- a/Classes/Service/OneTimeAccountConnector.php
+++ b/Classes/Service/OneTimeAccountConnector.php
@@ -36,14 +36,6 @@ class OneTimeAccountConnector implements SingletonInterface
     }
 
     /**
-     * Checks whether a login session is active, and that is has been created by the "onetimeaccount" extension.
-     */
-    public function existsOneTimeAccountLoginSession(): bool
-    {
-        return $this->frontEndUserAuthentication->getKey('user', 'onetimeaccount') === true;
-    }
-
-    /**
      * Returns the user UID of a FE user created by the "onetimeaccount" extension (without a FE login session).
      *
      * @return positive-int|null
@@ -59,19 +51,12 @@ class OneTimeAccountConnector implements SingletonInterface
     }
 
     /**
-     * Destroys any onetimeaccount sessions (with or without login).
+     * Destroys any onetimeaccount sessions (without login).
      *
-     * If a onetimeaccount login session is active, the user will be logged out.
-     *
-     * If no user is logged in, but a onetimeaccount user UID is available in the session, it will be deleted.
-     *
-     * If regular FE user is logged in, nothing happens.
+     * If a onetimeaccount user UID is available in the session, it will be deleted.
      */
     public function destroyOneTimeSession(): void
     {
-        if ($this->existsOneTimeAccountLoginSession()) {
-            $this->frontEndUserAuthentication->logoff();
-        }
         if (\is_int($this->getOneTimeAccountUserUid())) {
             $this->frontEndUserAuthentication->setAndSaveSessionData('onetimeaccountUserUid', null);
         }

--- a/Tests/Unit/Service/OneTimeAccountConnectorTest.php
+++ b/Tests/Unit/Service/OneTimeAccountConnectorTest.php
@@ -83,26 +83,6 @@ final class OneTimeAccountConnectorTest extends UnitTestCase
     /**
      * @test
      */
-    public function existsOneTimeAccountLoginSessionForNoSessionDataReturnsFalse(): void
-    {
-        $this->frontEndUserAuthenticationMock->method('getKey')->with('user', 'onetimeaccount')->willReturn(null);
-
-        self::assertFalse($this->subject->existsOneTimeAccountLoginSession());
-    }
-
-    /**
-     * @test
-     */
-    public function existsOneTimeAccountLoginSessionForSessionDataReturnsTrue(): void
-    {
-        $this->frontEndUserAuthenticationMock->method('getKey')->with('user', 'onetimeaccount')->willReturn(true);
-
-        self::assertTrue($this->subject->existsOneTimeAccountLoginSession());
-    }
-
-    /**
-     * @test
-     */
     public function getOneTimeAccountUserUidForNullUserUidReturnsNull(): void
     {
         $this->frontEndUserAuthenticationMock->method('getSessionData')->with('onetimeaccountUserUid')
@@ -146,35 +126,11 @@ final class OneTimeAccountConnectorTest extends UnitTestCase
     /**
      * @test
      */
-    public function destroyOneTimeSessionForRegularLoginDoesNotLogUserOut(): void
-    {
-        $this->frontEndUserAuthenticationMock->method('getKey')->with('user', 'onetimeaccount')->willReturn(null);
-
-        $this->frontEndUserAuthenticationMock->expects(self::never())->method('logoff');
-
-        $this->subject->destroyOneTimeSession();
-    }
-
-    /**
-     * @test
-     */
     public function destroyOneTimeSessionForRegularLoginDoesSetAnySessionDate(): void
     {
         $this->frontEndUserAuthenticationMock->method('getKey')->with('user', 'onetimeaccount')->willReturn(null);
 
         $this->frontEndUserAuthenticationMock->expects(self::never())->method('setAndSaveSessionData');
-
-        $this->subject->destroyOneTimeSession();
-    }
-
-    /**
-     * @test
-     */
-    public function destroyOneTimeSessionForOneTimeLoginLogsUserOut(): void
-    {
-        $this->frontEndUserAuthenticationMock->method('getKey')->with('user', 'onetimeaccount')->willReturn(true);
-
-        $this->frontEndUserAuthenticationMock->expects(self::once())->method('logoff');
 
         $this->subject->destroyOneTimeSession();
     }
@@ -190,20 +146,6 @@ final class OneTimeAccountConnectorTest extends UnitTestCase
 
         $this->frontEndUserAuthenticationMock->expects(self::once())->method('setAndSaveSessionData')
             ->with('onetimeaccountUserUid', null);
-
-        $this->subject->destroyOneTimeSession();
-    }
-
-    /**
-     * @test
-     */
-    public function destroyOneTimeSessionForRegularLoginAndOneTimeSessionDoesNotLogUserOut(): void
-    {
-        $this->frontEndUserAuthenticationMock->method('getKey')->with('user', 'onetimeaccount')->willReturn(null);
-        $this->frontEndUserAuthenticationMock->method('getSessionData')->with('onetimeaccountUserUid')
-            ->willReturn(5);
-
-        $this->frontEndUserAuthenticationMock->expects(self::never())->method('logoff');
 
         $this->subject->destroyOneTimeSession();
     }


### PR DESCRIPTION
As we no longer support real FE logins with the onetimeaccount extension, we no longer need the outologout.