### PR TITLE
[BUGFIX] Switch `OneTimeAccountConnector` to use the session API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- Switch `OneTimeAccountConnector` to use the session API (#3558)
 - Stop calling outdated DBAL methods (#2159, #3527, #3533, #3542)
 
 ## 5.7.0: New fields, BE usability features, and deprecations

--- a/Tests/Unit/Service/OneTimeAccountConnectorTest.php
+++ b/Tests/Unit/Service/OneTimeAccountConnectorTest.php
@@ -6,7 +6,10 @@ namespace OliverKlee\Seminars\Tests\Unit\Service;
 
 use OliverKlee\Seminars\Service\OneTimeAccountConnector;
 use PHPUnit\Framework\MockObject\MockObject;
+use TYPO3\CMS\Core\Session\UserSession;
+use TYPO3\CMS\Core\Session\UserSessionManager;
 use TYPO3\CMS\Core\SingletonInterface;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Frontend\Authentication\FrontendUserAuthentication;
 use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
 use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
@@ -26,6 +29,16 @@ final class OneTimeAccountConnectorTest extends UnitTestCase
      */
     private $frontEndUserAuthenticationMock;
 
+    /**
+     * @var UserSessionManager&MockObject
+     */
+    private $userSessionManagerMock;
+
+    /**
+     * @var UserSession&MockObject
+     */
+    private $userSessionMock;
+
     protected function setUp(): void
     {
         parent::setUp();
@@ -35,13 +48,25 @@ final class OneTimeAccountConnectorTest extends UnitTestCase
         $mockFrontEndController->fe_user = $this->frontEndUserAuthenticationMock;
         $GLOBALS['TSFE'] = $mockFrontEndController;
 
+        $this->setUpSession();
+
         $this->subject = new OneTimeAccountConnector();
     }
 
     protected function tearDown(): void
     {
+        GeneralUtility::purgeInstances();
+
         unset($GLOBALS['TSFE']);
         parent::tearDown();
+    }
+
+    private function setUpSession(): void {
+        $this->userSessionMock = $this->createMock(UserSession::class);
+        $this->userSessionManagerMock = $this->createMock(UserSessionManager::class);
+        $this->userSessionManagerMock->method('createAnonymousSession')->willReturn($this->userSessionMock);
+        $this->userSessionManagerMock->method('createFromRequestOrAnonymous')->willReturn($this->userSessionMock);
+        GeneralUtility::addInstance(UserSessionManager::class, $this->userSessionManagerMock);
     }
 
     /**
@@ -87,6 +112,7 @@ final class OneTimeAccountConnectorTest extends UnitTestCase
     {
         $this->frontEndUserAuthenticationMock->method('getSessionData')->with('onetimeaccountUserUid')
             ->willReturn(null);
+        $this->userSessionMock->method('get')->with('onetimeaccountUserUid')->willReturn(null);
 
         self::assertNull($this->subject->getOneTimeAccountUserUid());
     }
@@ -97,6 +123,7 @@ final class OneTimeAccountConnectorTest extends UnitTestCase
     public function getOneTimeAccountUserUidForEmptyUserUidReturnsNull(): void
     {
         $this->frontEndUserAuthenticationMock->method('getSessionData')->with('onetimeaccountUserUid')->willReturn('');
+        $this->userSessionMock->method('get')->with('onetimeaccountUserUid')->willReturn('');
 
         self::assertNull($this->subject->getOneTimeAccountUserUid());
     }
@@ -107,6 +134,7 @@ final class OneTimeAccountConnectorTest extends UnitTestCase
     public function getOneTimeAccountUserUidForZeroUserUidReturnsNull(): void
     {
         $this->frontEndUserAuthenticationMock->method('getSessionData')->with('onetimeaccountUserUid')->willReturn(0);
+        $this->userSessionMock->method('get')->with('onetimeaccountUserUid')->willReturn(0);
 
         self::assertNull($this->subject->getOneTimeAccountUserUid());
     }
@@ -119,6 +147,7 @@ final class OneTimeAccountConnectorTest extends UnitTestCase
         $userUid = 63;
         $this->frontEndUserAuthenticationMock->method('getSessionData')
             ->with('onetimeaccountUserUid')->willReturn($userUid);
+        $this->userSessionMock->method('get')->with('onetimeaccountUserUid')->willReturn($userUid);
 
         self::assertSame($userUid, $this->subject->getOneTimeAccountUserUid());
     }


### PR DESCRIPTION
Fixes #3324