### PR TITLE
[BUGFIX] Avoid using the deprecated `GeneralUtility::_GPmerged()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- Avoid using the deprecated `GeneralUtility::_GPmerged()` (#3595)
 - Drop unused dependency on `MarkerBasedTemplateService` (#3594)
 - Provide PSR-7 request when testing `RichTextViewHelper` (#3592)
 - Avoid using the deprecated `$GLOBALS['TSFE']->fe_user` (#3568)

--- a/Classes/Templating/TemplateHelper.php
+++ b/Classes/Templating/TemplateHelper.php
@@ -198,7 +198,7 @@ abstract class TemplateHelper
                 $this->frontendController = $realFrontEndController;
             }
         }
-        $this->piVars = GeneralUtility::_GPmerged($this->prefixId);
+        $this->extractPiVars();
         $this->LLkey = $this->frontendController->getLanguage()->getTypo3Language();
 
         $locales = GeneralUtility::makeInstance(Locales::class);
@@ -208,6 +208,21 @@ abstract class TemplateHelper
             }
             $this->altLLkey = \rtrim($this->altLLkey, ',');
         }
+    }
+
+    /**
+     * Sets `$this->piVars` from `$_POST` and `$_GET`.
+     */
+    private function extractPiVars(): void
+    {
+        $prefixId = $this->prefixId;
+
+        $postParameter = isset($_POST[$prefixId]) && \is_array($_POST[$prefixId]) ? $_POST[$prefixId] : [];
+        $getParameter = isset($_GET[$prefixId]) && \is_array($_GET[$prefixId]) ? $_GET[$prefixId] : [];
+        $mergedParameters = $getParameter;
+        ArrayUtility::mergeRecursiveWithOverrule($mergedParameters, $postParameter);
+
+        $this->piVars = $mergedParameters;
     }
 
     /**


### PR DESCRIPTION
Fixes #3593