### PR TITLE
[BUGFIX] Return a response rendered controller actions

### DIFF
--- a/Classes/Controller/BackEnd/EmailController.php
+++ b/Classes/Controller/BackEnd/EmailController.php
@@ -6,6 +6,7 @@ namespace OliverKlee\Seminars\Controller\BackEnd;
 
 use OliverKlee\Seminars\BackEnd\GeneralEventMailForm;
 use OliverKlee\Seminars\Domain\Model\Event\Event;
+use Psr\Http\Message\ResponseInterface;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Annotation\IgnoreValidation;
 use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
@@ -24,14 +25,20 @@ class EmailController extends ActionController
      *
      * @IgnoreValidation("event")
      */
-    public function composeAction(Event $event, int $pageUid, string $subject = '', string $body = ''): void
-    {
+    public function composeAction(
+        Event $event,
+        int $pageUid,
+        string $subject = '',
+        string $body = ''
+    ): ResponseInterface {
         $this->checkPermissions();
 
         $this->view->assign('event', $event);
         $this->view->assign('pageUid', $pageUid);
         $this->view->assign('subject', $subject);
         $this->view->assign('body', $body);
+
+        return $this->htmlResponse();
     }
 
     /**

--- a/Classes/Controller/BackEnd/EventController.php
+++ b/Classes/Controller/BackEnd/EventController.php
@@ -7,6 +7,7 @@ namespace OliverKlee\Seminars\Controller\BackEnd;
 use OliverKlee\Seminars\BackEnd\Permissions;
 use OliverKlee\Seminars\Domain\Repository\Event\EventRepository;
 use OliverKlee\Seminars\Service\EventStatisticsCalculator;
+use Psr\Http\Message\ResponseInterface;
 use TYPO3\CMS\Core\Localization\LanguageService;
 use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
 
@@ -56,27 +57,31 @@ class EventController extends ActionController
     /**
      * @param positive-int $eventUid
      */
-    public function hideAction(int $eventUid): void
+    public function hideAction(int $eventUid): ResponseInterface
     {
         $this->eventRepository->hideViaDataHandler($eventUid);
 
         $this->redirectToOverviewAction();
+
+        return $this->htmlResponse();
     }
 
     /**
      * @param positive-int $eventUid
      */
-    public function unhideAction(int $eventUid): void
+    public function unhideAction(int $eventUid): ResponseInterface
     {
         $this->eventRepository->unhideViaDataHandler($eventUid);
 
         $this->redirectToOverviewAction();
+
+        return $this->htmlResponse();
     }
 
     /**
      * @param positive-int $eventUid
      */
-    public function deleteAction(int $eventUid): void
+    public function deleteAction(int $eventUid): ResponseInterface
     {
         $this->eventRepository->deleteViaDataHandler($eventUid);
 
@@ -85,13 +90,15 @@ class EventController extends ActionController
         $this->addFlashMessage($message);
 
         $this->redirectToOverviewAction();
+
+        return $this->htmlResponse();
     }
 
     /**
      * @param int<0, max> $pageUid
      * @param string $searchTerm
      */
-    public function searchAction(int $pageUid, string $searchTerm = ''): void
+    public function searchAction(int $pageUid, string $searchTerm = ''): ResponseInterface
     {
         $this->view->assign('permissions', $this->permissions);
         $this->view->assign('pageUid', $pageUid);
@@ -104,15 +111,19 @@ class EventController extends ActionController
         $this->view->assign('events', $events);
 
         $this->view->assign('searchTerm', \trim($searchTerm));
+
+        return $this->htmlResponse();
     }
 
     /**
      * @param positive-int $eventUid
      */
-    public function duplicateAction(int $eventUid): void
+    public function duplicateAction(int $eventUid): ResponseInterface
     {
         $this->eventRepository->duplicateViaDataHandler($eventUid);
 
         $this->redirectToOverviewAction();
+
+        return $this->htmlResponse();
     }
 }

--- a/Classes/Controller/BackEnd/ModuleController.php
+++ b/Classes/Controller/BackEnd/ModuleController.php
@@ -6,6 +6,7 @@ namespace OliverKlee\Seminars\Controller\BackEnd;
 
 use OliverKlee\Seminars\Domain\Repository\Event\EventRepository;
 use OliverKlee\Seminars\Domain\Repository\Registration\RegistrationRepository;
+use Psr\Http\Message\ResponseInterface;
 use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
 
 /**
@@ -33,7 +34,7 @@ class ModuleController extends ActionController
         $this->registrationRepository = $registrationRepository;
     }
 
-    public function overviewAction(): void
+    public function overviewAction(): ResponseInterface
     {
         $pageUid = $this->getPageUid();
 
@@ -50,5 +51,7 @@ class ModuleController extends ActionController
             'numberOfRegistrations',
             $this->registrationRepository->countRegularRegistrationsByPageUid($pageUid)
         );
+
+        return $this->htmlResponse();
     }
 }

--- a/Classes/Controller/BackEnd/RegistrationController.php
+++ b/Classes/Controller/BackEnd/RegistrationController.php
@@ -58,7 +58,7 @@ class RegistrationController extends ActionController
      *
      * @throws \RuntimeException
      */
-    public function showForEventAction(int $eventUid): void
+    public function showForEventAction(int $eventUid): ResponseInterface
     {
         $event = $this->eventRepository->findOneByUidForBackend($eventUid);
         if (!($event instanceof Event)) {
@@ -80,6 +80,8 @@ class RegistrationController extends ActionController
             $this->registrationRepository->enrichWithRawData($waitingListRegistrations);
             $this->view->assign('waitingListRegistrations', $waitingListRegistrations);
         }
+
+        return $this->htmlResponse();
     }
 
     /**

--- a/Classes/Controller/EventRegistrationController.php
+++ b/Classes/Controller/EventRegistrationController.php
@@ -115,11 +115,11 @@ class EventRegistrationController extends ActionController
         return (new ForwardResponse('deny'))->withArguments(['warningMessageKey' => $warningMessageKey]);
     }
 
-    public function denyAction(string $warningMessageKey): ?ResponseInterface
+    public function denyAction(string $warningMessageKey): ResponseInterface
     {
         $this->view->assign('warningMessageKey', $warningMessageKey);
 
-        return null;
+        return $this->htmlResponse();
     }
 
     /**
@@ -146,7 +146,7 @@ class EventRegistrationController extends ActionController
      * @IgnoreValidation("event")
      * @IgnoreValidation("registration")
      */
-    public function newAction(Event $event, ?Registration $registration = null): ?ResponseInterface
+    public function newAction(Event $event, ?Registration $registration = null): ResponseInterface
     {
         $this->registrationGuard->assertBookableEventType($event);
         \assert($event instanceof EventDateInterface);
@@ -178,7 +178,7 @@ class EventRegistrationController extends ActionController
         $this->view->assign('maximumBookableSeats', $maximumBookableSeats);
         $this->view->assign('applicablePrices', $applicablePrices);
 
-        return null;
+        return $this->htmlResponse();
     }
 
     /**
@@ -186,7 +186,7 @@ class EventRegistrationController extends ActionController
      *
      * @IgnoreValidation("event")
      */
-    public function confirmAction(Event $event, Registration $registration): ?ResponseInterface
+    public function confirmAction(Event $event, Registration $registration): ResponseInterface
     {
         $this->registrationGuard->assertBookableEventType($event);
         \assert($event instanceof EventDateInterface);
@@ -198,7 +198,7 @@ class EventRegistrationController extends ActionController
         $this->view->assign('registration', $registration);
         $this->view->assign('applicablePrices', $this->priceFinder->findApplicablePrices($event));
 
-        return null;
+        return $this->htmlResponse();
     }
 
     /**
@@ -206,7 +206,7 @@ class EventRegistrationController extends ActionController
      *
      * @IgnoreValidation("event")
      */
-    public function createAction(Event $event, Registration $registration): void
+    public function createAction(Event $event, Registration $registration): ResponseInterface
     {
         $this->registrationGuard->assertBookableEventType($event);
         \assert($event instanceof EventDateInterface);
@@ -230,11 +230,11 @@ class EventRegistrationController extends ActionController
      * @IgnoreValidation("event")
      * @IgnoreValidation("registration")
      */
-    public function thankYouAction(Event $event, Registration $registration): ?ResponseInterface
+    public function thankYouAction(Event $event, Registration $registration): ResponseInterface
     {
         $this->view->assign('event', $event);
         $this->view->assign('registration', $registration);
 
-        return null;
+        return $this->htmlResponse();
     }
 }

--- a/Classes/Controller/EventUnregistrationController.php
+++ b/Classes/Controller/EventUnregistrationController.php
@@ -88,11 +88,11 @@ class EventUnregistrationController extends ActionController
         return (new ForwardResponse('deny'))->withArguments(['warningMessageKey' => $warningMessageKey]);
     }
 
-    public function denyAction(string $warningMessageKey): ?ResponseInterface
+    public function denyAction(string $warningMessageKey): ResponseInterface
     {
         $this->view->assign('warningMessageKey', $warningMessageKey);
 
-        return null;
+        return $this->htmlResponse();
     }
 
     /**
@@ -100,11 +100,11 @@ class EventUnregistrationController extends ActionController
      *
      * @IgnoreValidation("registration")
      */
-    public function confirmAction(Registration $registration): ?ResponseInterface
+    public function confirmAction(Registration $registration): ResponseInterface
     {
         $this->view->assign('registration', $registration);
 
-        return null;
+        return $this->htmlResponse();
     }
 
     /**
@@ -123,10 +123,10 @@ class EventUnregistrationController extends ActionController
     /**
      * @IgnoreValidation("event")
      */
-    public function thankYouAction(Event $event): ?ResponseInterface
+    public function thankYouAction(Event $event): ResponseInterface
     {
         $this->view->assign('event', $event);
 
-        return null;
+        return $this->htmlResponse();
     }
 }

--- a/Classes/Controller/FrontEndEditorController.php
+++ b/Classes/Controller/FrontEndEditorController.php
@@ -10,6 +10,7 @@ use OliverKlee\Seminars\Domain\Repository\EventTypeRepository;
 use OliverKlee\Seminars\Domain\Repository\OrganizerRepository;
 use OliverKlee\Seminars\Domain\Repository\SpeakerRepository;
 use OliverKlee\Seminars\Domain\Repository\VenueRepository;
+use Psr\Http\Message\ResponseInterface;
 use TYPO3\CMS\Core\Context\Context;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Annotation\IgnoreValidation;
@@ -64,10 +65,12 @@ class FrontEndEditorController extends ActionController
         return (int)GeneralUtility::makeInstance(Context::class)->getPropertyFromAspect('frontend.user', 'id');
     }
 
-    public function indexAction(): void
+    public function indexAction(): ResponseInterface
     {
         $events = $this->eventRepository->findSingleEventsByOwnerUid($this->getLoggedInUserUid());
         $this->view->assign('events', $events);
+
+        return $this->htmlResponse();
     }
 
     /**
@@ -89,12 +92,14 @@ class FrontEndEditorController extends ActionController
     /**
      * @IgnoreValidation("event")
      */
-    public function editAction(SingleEvent $event): void
+    public function editAction(SingleEvent $event): ResponseInterface
     {
         $this->checkEventOwner($event);
 
         $this->view->assign('event', $event);
         $this->assignAuxiliaryRecordsToView();
+
+        return $this->htmlResponse();
     }
 
     private function assignAuxiliaryRecordsToView(): void
@@ -118,11 +123,13 @@ class FrontEndEditorController extends ActionController
     /**
      * @IgnoreValidation("event")
      */
-    public function newAction(?SingleEvent $event = null): void
+    public function newAction(?SingleEvent $event = null): ResponseInterface
     {
         $eventToCreate = $event instanceof SingleEvent ? $event : GeneralUtility::makeInstance(SingleEvent::class);
         $this->view->assign('event', $eventToCreate);
         $this->assignAuxiliaryRecordsToView();
+
+        return $this->htmlResponse();
     }
 
     public function createAction(SingleEvent $event): void

--- a/Tests/Unit/Controller/BackEnd/EmailControllerTest.php
+++ b/Tests/Unit/Controller/BackEnd/EmailControllerTest.php
@@ -9,6 +9,7 @@ use OliverKlee\Seminars\BackEnd\Permissions;
 use OliverKlee\Seminars\Controller\BackEnd\EmailController;
 use OliverKlee\Seminars\Domain\Model\Event\SingleEvent;
 use PHPUnit\Framework\MockObject\MockObject;
+use TYPO3\CMS\Core\Http\HtmlResponse;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
 use TYPO3\CMS\Fluid\View\TemplateView;
@@ -49,6 +50,9 @@ final class EmailControllerTest extends UnitTestCase
         /** @var EmailController&AccessibleObjectInterface&MockObject $subject */
         $subject = $this->getAccessibleMock(EmailController::class, $methodsToMock);
         $this->subject = $subject;
+
+        $responseStub = $this->createStub(HtmlResponse::class);
+        $this->subject->method('htmlResponse')->willReturn($responseStub);
 
         $this->viewMock = $this->createMock(TemplateView::class);
         $this->subject->_set('view', $this->viewMock);
@@ -120,7 +124,21 @@ final class EmailControllerTest extends UnitTestCase
     /**
      * @test
      */
-    public function composeActioPassesProvidedEventToView(): void
+    public function composeActionReturnsHtmlResponse(): void
+    {
+        $this->permissionsMock->method('hasReadAccessToEvents')->willReturn(true);
+        $this->permissionsMock->method('hasReadAccessToRegistrations')->willReturn(true);
+
+        $event = new SingleEvent();
+        $result = $this->subject->composeAction($event, 1);
+
+        self::assertInstanceOf(HtmlResponse::class, $result);
+    }
+
+    /**
+     * @test
+     */
+    public function composeActionPassesProvidedEventToView(): void
     {
         $this->permissionsMock->method('hasReadAccessToEvents')->willReturn(true);
         $this->permissionsMock->method('hasReadAccessToRegistrations')->willReturn(true);
@@ -139,7 +157,7 @@ final class EmailControllerTest extends UnitTestCase
     /**
      * @test
      */
-    public function composeActioPassesProvidedPageUidToView(): void
+    public function composeActionPassesProvidedPageUidToView(): void
     {
         $this->permissionsMock->method('hasReadAccessToEvents')->willReturn(true);
         $this->permissionsMock->method('hasReadAccessToRegistrations')->willReturn(true);

--- a/Tests/Unit/Controller/BackEnd/EventControllerTest.php
+++ b/Tests/Unit/Controller/BackEnd/EventControllerTest.php
@@ -11,6 +11,7 @@ use OliverKlee\Seminars\Domain\Model\Event\SingleEvent;
 use OliverKlee\Seminars\Domain\Repository\Event\EventRepository;
 use OliverKlee\Seminars\Service\EventStatisticsCalculator;
 use PHPUnit\Framework\MockObject\MockObject;
+use TYPO3\CMS\Core\Http\HtmlResponse;
 use TYPO3\CMS\Core\Localization\LanguageService;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
@@ -76,6 +77,9 @@ final class EventControllerTest extends UnitTestCase
             [$this->eventRepositoryMock, $this->permissionsMock, $this->eventStatisticsCalculatorMock]
         );
         $this->subject = $subject;
+
+        $responseStub = $this->createStub(HtmlResponse::class);
+        $this->subject->method('htmlResponse')->willReturn($responseStub);
 
         $this->viewMock = $this->createMock(TemplateView::class);
         $this->subject->_set('view', $this->viewMock);
@@ -175,6 +179,16 @@ final class EventControllerTest extends UnitTestCase
         $this->subject->expects(self::once())->method('redirect')->with('overview', 'BackEnd\\Module');
 
         $this->subject->deleteAction(15);
+    }
+
+    /**
+     * @test
+     */
+    public function searchActionReturnsHtmlResponse(): void
+    {
+        $result = $this->subject->searchAction(1, '');
+
+        self::assertInstanceOf(HtmlResponse::class, $result);
     }
 
     /**

--- a/Tests/Unit/Controller/BackEnd/ModuleControllerTest.php
+++ b/Tests/Unit/Controller/BackEnd/ModuleControllerTest.php
@@ -11,6 +11,7 @@ use OliverKlee\Seminars\Domain\Repository\Event\EventRepository;
 use OliverKlee\Seminars\Domain\Repository\Registration\RegistrationRepository;
 use OliverKlee\Seminars\Service\EventStatisticsCalculator;
 use PHPUnit\Framework\MockObject\MockObject;
+use TYPO3\CMS\Core\Http\HtmlResponse;
 use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
 use TYPO3\CMS\Fluid\View\TemplateView;
 use TYPO3\TestingFramework\Core\AccessibleObjectInterface;
@@ -70,6 +71,9 @@ final class ModuleControllerTest extends UnitTestCase
         );
         $this->subject = $subject;
 
+        $responseStub = $this->createStub(HtmlResponse::class);
+        $this->subject->method('htmlResponse')->willReturn($responseStub);
+
         $this->viewMock = $this->createMock(TemplateView::class);
         $this->subject->_set('view', $this->viewMock);
         $this->permissionsMock = $this->createMock(Permissions::class);
@@ -121,6 +125,16 @@ final class ModuleControllerTest extends UnitTestCase
     public function pageUidForNoIdInRequestIsZero(): void
     {
         self::assertSame(0, $this->subject->getPageUid());
+    }
+
+    /**
+     * @test
+     */
+    public function overviewActionReturnsHtmlResponse(): void
+    {
+        $result = $this->subject->overviewAction();
+
+        self::assertInstanceOf(HtmlResponse::class, $result);
     }
 
     /**

--- a/Tests/Unit/Controller/BackEnd/RegistrationControllerTest.php
+++ b/Tests/Unit/Controller/BackEnd/RegistrationControllerTest.php
@@ -15,6 +15,7 @@ use OliverKlee\Seminars\Model\Registration;
 use OliverKlee\Seminars\Service\EventStatisticsCalculator;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Http\Message\ResponseInterface;
+use TYPO3\CMS\Core\Http\HtmlResponse;
 use TYPO3\CMS\Core\Localization\LanguageService;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
@@ -88,6 +89,9 @@ final class RegistrationControllerTest extends UnitTestCase
         );
         $this->subject = $subject;
 
+        $responseStub = $this->createStub(HtmlResponse::class);
+        $this->subject->method('htmlResponse')->willReturn($responseStub);
+
         $this->viewMock = $this->createMock(TemplateView::class);
         $this->subject->_set('view', $this->viewMock);
         $this->permissionsMock = $this->createMock(Permissions::class);
@@ -156,6 +160,22 @@ final class RegistrationControllerTest extends UnitTestCase
     public function pageUidForNoIdInRequestIsZero(): void
     {
         self::assertSame(0, $this->subject->getPageUid());
+    }
+
+    /**
+     * @test
+     */
+    public function showForEventActionReturnsHtmlResponse(): void
+    {
+        $eventUid = 5;
+        $event = $this->createMock(EventTopic::class);
+        $event->method('getUid')->willReturn($eventUid);
+        $this->eventRepositoryMock->expects(self::once())
+            ->method('findOneByUidForBackend')->with($eventUid)->willReturn($event);
+
+        $result = $this->subject->showForEventAction($eventUid);
+
+        self::assertInstanceOf(HtmlResponse::class, $result);
     }
 
     /**

--- a/Tests/Unit/Controller/EventRegistrationControllerTest.php
+++ b/Tests/Unit/Controller/EventRegistrationControllerTest.php
@@ -14,6 +14,7 @@ use OliverKlee\Seminars\Service\PriceFinder;
 use OliverKlee\Seminars\Service\RegistrationGuard;
 use OliverKlee\Seminars\Service\RegistrationProcessor;
 use PHPUnit\Framework\MockObject\MockObject;
+use TYPO3\CMS\Core\Http\HtmlResponse;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Http\ForwardResponse;
 use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
@@ -84,6 +85,9 @@ final class EventRegistrationControllerTest extends UnitTestCase
             ]
         );
         $this->subject = $subject;
+
+        $responseStub = $this->createStub(HtmlResponse::class);
+        $this->subject->method('htmlResponse')->willReturn($responseStub);
 
         $this->viewMock = $this->createMock(TemplateView::class);
         $this->subject->_set('view', $this->viewMock);
@@ -352,12 +356,32 @@ final class EventRegistrationControllerTest extends UnitTestCase
     /**
      * @test
      */
+    public function denyActionReturnsHtmlResponse(): void
+    {
+        $result = $this->subject->denyAction('noRegistrationPossibleAtAll');
+
+        self::assertInstanceOf(HtmlResponse::class, $result);
+    }
+
+    /**
+     * @test
+     */
     public function denyActionPassesProvidedWarningMessageKeyToView(): void
     {
         $warningMessageKey = 'noRegistrationPossibleAtAll';
         $this->viewMock->expects(self::once())->method('assign')->with('warningMessageKey', $warningMessageKey);
 
         $this->subject->denyAction($warningMessageKey);
+    }
+
+    /**
+     * @test
+     */
+    public function newActionReturnsHtml(): void
+    {
+        $result = $this->subject->newAction(new SingleEvent(), new Registration());
+
+        self::assertInstanceOf(HtmlResponse::class, $result);
     }
 
     /**
@@ -782,6 +806,16 @@ final class EventRegistrationControllerTest extends UnitTestCase
     /**
      * @test
      */
+    public function confirmActionReturnsHtmlResponse(): void
+    {
+        $result = $this->subject->confirmAction(new SingleEvent(), new Registration());
+
+        self::assertInstanceOf(HtmlResponse::class, $result);
+    }
+
+    /**
+     * @test
+     */
     public function confirmActionAssertsBookableEventType(): void
     {
         $event = new SingleEvent();
@@ -891,6 +925,10 @@ final class EventRegistrationControllerTest extends UnitTestCase
     public function createActionAssertsBookableEventType(): void
     {
         $event = new SingleEvent();
+        $this->subject->expects(self::once())->method('redirect')
+            ->willThrowException(new StopActionException('redirectToUri', 1476045828));
+        $this->expectException(StopActionException::class);
+
         $this->registrationGuardMock->expects(self::once())->method('assertBookableEventType')->with($event);
 
         $this->subject->createAction($event, new Registration());
@@ -905,6 +943,9 @@ final class EventRegistrationControllerTest extends UnitTestCase
         $event = new SingleEvent();
         $settings = ['registration' => ['registrationRecordsStorageFolder' => '5']];
         $this->subject->_set('settings', $settings);
+        $this->subject->expects(self::once())->method('redirect')
+            ->willThrowException(new StopActionException('redirectToUri', 1476045828));
+        $this->expectException(StopActionException::class);
 
         $this->registrationProcesserMock->expects(self::once())->method('enrichWithMetadata')
             ->with($registration, $event, $settings);
@@ -918,6 +959,10 @@ final class EventRegistrationControllerTest extends UnitTestCase
     public function createActionCalculatesTotalPrice(): void
     {
         $registration = new Registration();
+        $this->subject->expects(self::once())->method('redirect')
+            ->willThrowException(new StopActionException('redirectToUri', 1476045828));
+        $this->expectException(StopActionException::class);
+
         $this->registrationProcesserMock->expects(self::once())->method('calculateTotalPrice')
             ->with($registration);
 
@@ -930,6 +975,9 @@ final class EventRegistrationControllerTest extends UnitTestCase
     public function createActionCreatesRegistrationTitle(): void
     {
         $registration = new Registration();
+        $this->subject->expects(self::once())->method('redirect')
+            ->willThrowException(new StopActionException('redirectToUri', 1476045828));
+        $this->expectException(StopActionException::class);
 
         $this->registrationProcesserMock->expects(self::once())->method('createTitle')->with($registration);
 
@@ -942,6 +990,9 @@ final class EventRegistrationControllerTest extends UnitTestCase
     public function createActionWithoutUserStorageSettingCreatesAdditionalPersonsWithZeroStorageFolderUid(): void
     {
         $registration = new Registration();
+        $this->subject->expects(self::once())->method('redirect')
+            ->willThrowException(new StopActionException('redirectToUri', 1476045828));
+        $this->expectException(StopActionException::class);
 
         $this->registrationProcesserMock->expects(self::once())->method('createAdditionalPersons')
             ->with($registration, 0);
@@ -957,6 +1008,9 @@ final class EventRegistrationControllerTest extends UnitTestCase
         $folderUid = 15;
         $this->subject->_set('settings', ['additionalPersonsStorageFolder' => (string)$folderUid]);
         $registration = new Registration();
+        $this->subject->expects(self::once())->method('redirect')
+            ->willThrowException(new StopActionException('redirectToUri', 1476045828));
+        $this->expectException(StopActionException::class);
 
         $this->registrationProcesserMock->expects(self::once())->method('createAdditionalPersons')
             ->with($registration, $folderUid);
@@ -970,6 +1024,9 @@ final class EventRegistrationControllerTest extends UnitTestCase
     public function createActionPersistsRegistration(): void
     {
         $registration = new Registration();
+        $this->subject->expects(self::once())->method('redirect')
+            ->willThrowException(new StopActionException('redirectToUri', 1476045828));
+        $this->expectException(StopActionException::class);
 
         $this->registrationProcesserMock->expects(self::once())->method('persist')->with($registration);
 
@@ -982,6 +1039,9 @@ final class EventRegistrationControllerTest extends UnitTestCase
     public function createActionSendsEmail(): void
     {
         $registration = new Registration();
+        $this->subject->expects(self::once())->method('redirect')
+            ->willThrowException(new StopActionException('redirectToUri', 1476045828));
+        $this->expectException(StopActionException::class);
 
         $this->registrationProcesserMock->expects(self::once())->method('sendEmails')->with($registration);
 
@@ -994,6 +1054,9 @@ final class EventRegistrationControllerTest extends UnitTestCase
     public function createDestroysOneTimeAccountSession(): void
     {
         $registration = new Registration();
+        $this->subject->expects(self::once())->method('redirect')
+            ->willThrowException(new StopActionException('redirectToUri', 1476045828));
+        $this->expectException(StopActionException::class);
 
         $this->oneTimeAccountConnectorMock->expects(self::once())->method('destroyOneTimeSession');
 
@@ -1015,6 +1078,16 @@ final class EventRegistrationControllerTest extends UnitTestCase
         $this->expectException(StopActionException::class);
 
         $this->subject->createAction($event, $registration);
+    }
+
+    /**
+     * @test
+     */
+    public function thankYouActionReturnsHtmlResponse(): void
+    {
+        $result = $this->subject->thankYouAction(new SingleEvent(), new Registration());
+
+        self::assertInstanceOf(HtmlResponse::class, $result);
     }
 
     /**

--- a/Tests/Unit/Controller/EventUnregistrationControllerTest.php
+++ b/Tests/Unit/Controller/EventUnregistrationControllerTest.php
@@ -14,6 +14,7 @@ use OliverKlee\Seminars\OldModel\LegacyRegistration;
 use OliverKlee\Seminars\Service\RegistrationManager;
 use PHPUnit\Framework\MockObject\MockObject;
 use TYPO3\CMS\Core\Context\Context;
+use TYPO3\CMS\Core\Http\HtmlResponse;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Http\ForwardResponse;
 use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
@@ -70,6 +71,9 @@ final class EventUnregistrationControllerTest extends UnitTestCase
             [$this->registrationManagerMock]
         );
         $this->subject = $subject;
+
+        $responseStub = $this->createStub(HtmlResponse::class);
+        $this->subject->method('htmlResponse')->willReturn($responseStub);
 
         $this->viewMock = $this->createMock(TemplateView::class);
         $this->subject->_set('view', $this->viewMock);
@@ -221,12 +225,32 @@ final class EventUnregistrationControllerTest extends UnitTestCase
     /**
      * @test
      */
+    public function denyActionReturnsHtmlResponse(): void
+    {
+        $result = $this->subject->denyAction('registrationMissing');
+
+        self::assertInstanceOf(HtmlResponse::class, $result);
+    }
+
+    /**
+     * @test
+     */
     public function denyActionPassesProvidedWarningMessageKeyToView(): void
     {
         $warningMessageKey = 'registrationMissing';
         $this->viewMock->expects(self::once())->method('assign')->with('warningMessageKey', $warningMessageKey);
 
         $this->subject->denyAction($warningMessageKey);
+    }
+
+    /**
+     * @test
+     */
+    public function confirmActionReturnsHtmlResponse(): void
+    {
+        $result = $this->subject->confirmAction(new Registration());
+
+        self::assertInstanceOf(HtmlResponse::class, $result);
     }
 
     /**
@@ -270,6 +294,16 @@ final class EventUnregistrationControllerTest extends UnitTestCase
         $this->expectException(StopActionException::class);
 
         $this->subject->unregisterAction($registration);
+    }
+
+    /**
+     * @test
+     */
+    public function thankYouActionReturnsHtmlResponse(): void
+    {
+        $result = $this->subject->thankYouAction(new SingleEvent());
+
+        self::assertInstanceOf(HtmlResponse::class, $result);
     }
 
     /**

--- a/Tests/Unit/Controller/FrontEndEditorControllerTest.php
+++ b/Tests/Unit/Controller/FrontEndEditorControllerTest.php
@@ -15,6 +15,7 @@ use OliverKlee\Seminars\Domain\Repository\SpeakerRepository;
 use OliverKlee\Seminars\Domain\Repository\VenueRepository;
 use PHPUnit\Framework\MockObject\MockObject;
 use TYPO3\CMS\Core\Context\Context;
+use TYPO3\CMS\Core\Http\HtmlResponse;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
 use TYPO3\CMS\Extbase\Persistence\QueryResultInterface;
@@ -91,6 +92,9 @@ final class FrontEndEditorControllerTest extends UnitTestCase
             ]
         );
         $this->subject = $subject;
+
+        $responseStub = $this->createStub(HtmlResponse::class);
+        $this->subject->method('htmlResponse')->willReturn($responseStub);
 
         $this->viewMock = $this->createMock(TemplateView::class);
         $this->subject->_set('view', $this->viewMock);


### PR DESCRIPTION
Not returning anything in controller actions was deprecated in TYPO3 11LTS and removed in TYPO3 12LTS.

This commit takes care of `htmlResponse()`.

Part of #1482