### PR TITLE
[BUGFIX] Drop tests for duplicated place associations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- Drop tests for duplicated place associations (#3631)
 - Always return a response from controller actions (#3619)
 - Stop setting `TemplateHelper::cObj` (#3613)
 - Avoid using the deprecated `GeneralUtility::_GPmerged()` (#3595)

--- a/Tests/Functional/OldModel/Fixtures/Events/EventsWithPlaces.xml
+++ b/Tests/Functional/OldModel/Fixtures/Events/EventsWithPlaces.xml
@@ -16,20 +16,6 @@
     </tx_seminars_seminars_place_mm>
 
     <tx_seminars_seminars>
-        <uid>3</uid>
-        <title>event with duplicate place</title>
-        <place>2</place>
-    </tx_seminars_seminars>
-    <tx_seminars_seminars_place_mm>
-        <uid_local>3</uid_local>
-        <uid_foreign>1</uid_foreign>
-    </tx_seminars_seminars_place_mm>
-    <tx_seminars_seminars_place_mm>
-        <uid_local>3</uid_local>
-        <uid_foreign>1</uid_foreign>
-    </tx_seminars_seminars_place_mm>
-
-    <tx_seminars_seminars>
         <uid>4</uid>
         <title>event with one place with valid country</title>
         <place>1</place>

--- a/Tests/Functional/OldModel/LegacyEventTest.php
+++ b/Tests/Functional/OldModel/LegacyEventTest.php
@@ -649,20 +649,6 @@ final class LegacyEventTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function getPlaceWithDetailsListsDuplicateAssociationsOnlyOnce(): void
-    {
-        $this->importDataSet(__DIR__ . '/Fixtures/Events/EventsWithPlaces.xml');
-        $plugin = $this->buildFrontEndAndPlugin();
-        $subject = TestingLegacyEvent::fromUid(3);
-
-        $result = $subject->getPlaceWithDetails($plugin);
-
-        self::assertSame(1, \substr_count($result, 'The Castle (without country)'));
-    }
-
-    /**
-     * @test
-     */
     public function getPlaceWithDetailsContainsAddressOfOnePlace(): void
     {
         $this->importDataSet(__DIR__ . '/Fixtures/Events/EventsWithPlaces.xml');
@@ -772,19 +758,6 @@ final class LegacyEventTest extends FunctionalTestCase
         $result = $subject->getPlaceWithDetailsRaw();
 
         self::assertStringContainsString("3 turns left, then always right\nThe garden (without country)", $result);
-    }
-
-    /**
-     * @test
-     */
-    public function getPlaceWithDetailsRawListsDuplicateAssociationsOnlyOnce(): void
-    {
-        $this->importDataSet(__DIR__ . '/Fixtures/Events/EventsWithPlaces.xml');
-        $subject = TestingLegacyEvent::fromUid(3);
-
-        $result = $subject->getPlaceWithDetailsRaw();
-
-        self::assertSame(1, \substr_count($result, 'The Castle (without country)'));
     }
 
     /**
@@ -975,19 +948,6 @@ final class LegacyEventTest extends FunctionalTestCase
         $result = $subject->getPlaceShort();
 
         self::assertStringContainsString('The Castle (without country), The garden (without country)', $result);
-    }
-
-    /**
-     * @test
-     */
-    public function getPlaceShortListsDuplicateAssociationsOnlyOnce(): void
-    {
-        $this->importDataSet(__DIR__ . '/Fixtures/Events/EventsWithPlaces.xml');
-        $subject = TestingLegacyEvent::fromUid(3);
-
-        $result = $subject->getPlaceShort();
-
-        self::assertSame(1, \substr_count($result, 'The Castle (without country)'));
     }
 
     // Tests concerning getPlaces

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -2227,17 +2227,17 @@ parameters:
 
 		-
 			message: "#^Cannot call method getPlaceShort\\(\\) on OliverKlee\\\\Seminars\\\\Tests\\\\Unit\\\\OldModel\\\\Fixtures\\\\TestingLegacyEvent\\|null\\.$#"
-			count: 4
+			count: 3
 			path: Tests/Functional/OldModel/LegacyEventTest.php
 
 		-
 			message: "#^Cannot call method getPlaceWithDetails\\(\\) on OliverKlee\\\\Seminars\\\\Tests\\\\Unit\\\\OldModel\\\\Fixtures\\\\TestingLegacyEvent\\|null\\.$#"
-			count: 9
+			count: 8
 			path: Tests/Functional/OldModel/LegacyEventTest.php
 
 		-
 			message: "#^Cannot call method getPlaceWithDetailsRaw\\(\\) on OliverKlee\\\\Seminars\\\\Tests\\\\Unit\\\\OldModel\\\\Fixtures\\\\TestingLegacyEvent\\|null\\.$#"
-			count: 9
+			count: 8
 			path: Tests/Functional/OldModel/LegacyEventTest.php
 
 		-


### PR DESCRIPTION
This is not possible in TYPO3 12LTS anymore as the DB then prohibits duplicate keys.

Fixes #3544