### PR TITLE
[BUGFIX] Make the check for the begin date consistent

### DIFF
--- a/Classes/OldModel/LegacyEvent.php
+++ b/Classes/OldModel/LegacyEvent.php
@@ -3101,16 +3101,6 @@ class LegacyEvent extends AbstractTimeSpan
         return $this->getAttendancesOnRegistrationQueue() > 0;
     }
 
-    /**
-     * Checks whether there's a (begin) date set or any time slots exist.
-     * If there's an end date but no begin date, this function still will return
-     * FALSE.
-     */
-    public function hasDate(): bool
-    {
-        return $this->hasBeginDate() || $this->hasTimeslots();
-    }
-
     public function hasTimeslots(): bool
     {
         return $this->hasRecordPropertyInteger('timeslots');


### PR DESCRIPTION
Events with time slots, but without a begin date schould not be considered to have a date.

Fixes #3635