### PR TITLE
[BUGFIX] Avoid the deprecated `ActionController::forward()` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- Avoid the deprecated `ActionController::forward()` method (#3637)
 - Drop tests for duplicated place associations (#3631)
 - Always return a response from controller actions (#3619)
 - Stop setting `TemplateHelper::cObj` (#3613)

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -211,6 +211,16 @@ parameters:
 			path: Classes/Controller/EventRegistrationController.php
 
 		-
+			message: "#^Unreachable statement \\- code above always terminates\\.$#"
+			count: 1
+			path: Classes/Controller/EventRegistrationController.php
+
+		-
+			message: "#^Unreachable statement \\- code above always terminates\\.$#"
+			count: 1
+			path: Classes/Controller/EventUnregistrationController.php
+
+		-
 			message: "#^Cannot cast mixed to int\\.$#"
 			count: 1
 			path: Classes/Controller/FrontEndEditorController.php


### PR DESCRIPTION
Fixes #3546