### PR TITLE
[BUGFIX] Mock redirects both for 11LTS and 12LTS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 - Avoid the deprecated `ActionController::forward()` method (#3637)
 - Drop tests for duplicated place associations (#3631)
-- Always return a response from controller actions (#3619, #3638)
+- Always return a response from controller actions (#3619, #3638, #3668)
 - Stop setting `TemplateHelper::cObj` (#3613)
 - Avoid using the deprecated `GeneralUtility::_GPmerged()` (#3595)
 - Drop unused dependency on `MarkerBasedTemplateService` (#3594)

--- a/Tests/Unit/Controller/BackEnd/EmailControllerTest.php
+++ b/Tests/Unit/Controller/BackEnd/EmailControllerTest.php
@@ -8,6 +8,7 @@ use OliverKlee\Seminars\BackEnd\GeneralEventMailForm;
 use OliverKlee\Seminars\BackEnd\Permissions;
 use OliverKlee\Seminars\Controller\BackEnd\EmailController;
 use OliverKlee\Seminars\Domain\Model\Event\SingleEvent;
+use OliverKlee\Seminars\Tests\Unit\Controller\RedirectMockTrait;
 use PHPUnit\Framework\MockObject\MockObject;
 use TYPO3\CMS\Core\Http\HtmlResponse;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -22,6 +23,8 @@ use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
  */
 final class EmailControllerTest extends UnitTestCase
 {
+    use RedirectMockTrait;
+
     /**
      * @var EmailController&MockObject&AccessibleObjectInterface
      */
@@ -322,8 +325,7 @@ final class EmailControllerTest extends UnitTestCase
         $eventUid = 9;
         $event = $this->buildSingleEventMockWithUid($eventUid);
 
-        $this->subject->expects(self::once())
-            ->method('redirect')->with('overview', 'BackEnd\\Module');
+        $this->mockRedirect('overview', 'BackEnd\\Module');
 
         $this->subject->sendAction($event, '', '');
     }

--- a/Tests/Unit/Controller/BackEnd/EventControllerTest.php
+++ b/Tests/Unit/Controller/BackEnd/EventControllerTest.php
@@ -10,6 +10,7 @@ use OliverKlee\Seminars\Csv\CsvDownloader;
 use OliverKlee\Seminars\Domain\Model\Event\SingleEvent;
 use OliverKlee\Seminars\Domain\Repository\Event\EventRepository;
 use OliverKlee\Seminars\Service\EventStatisticsCalculator;
+use OliverKlee\Seminars\Tests\Unit\Controller\RedirectMockTrait;
 use PHPUnit\Framework\MockObject\MockObject;
 use TYPO3\CMS\Core\Http\HtmlResponse;
 use TYPO3\CMS\Core\Localization\LanguageService;
@@ -24,6 +25,8 @@ use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
  */
 final class EventControllerTest extends UnitTestCase
 {
+    use RedirectMockTrait;
+
     /**
      * @var EventController&MockObject&AccessibleObjectInterface
      */
@@ -120,8 +123,7 @@ final class EventControllerTest extends UnitTestCase
      */
     public function hideActionRedirectsToModuleOverviewAction(): void
     {
-        $this->subject->expects(self::once())->method('redirect')
-            ->with('overview', 'BackEnd\\Module');
+        $this->mockRedirect('overview', 'BackEnd\\Module');
 
         $this->subject->hideAction(15);
     }
@@ -142,8 +144,7 @@ final class EventControllerTest extends UnitTestCase
      */
     public function unhideActionRedirectsToModuleOverviewAction(): void
     {
-        $this->subject->expects(self::once())->method('redirect')
-            ->with('overview', 'BackEnd\\Module');
+        $this->mockRedirect('overview', 'BackEnd\\Module');
 
         $this->subject->unhideAction(15);
     }
@@ -178,8 +179,7 @@ final class EventControllerTest extends UnitTestCase
      */
     public function deleteActionRedirectsToModuleOverviewAction(): void
     {
-        $this->subject->expects(self::once())->method('redirect')
-            ->with('overview', 'BackEnd\\Module');
+        $this->mockRedirect('overview', 'BackEnd\\Module');
 
         $this->subject->deleteAction(15);
     }
@@ -334,8 +334,7 @@ final class EventControllerTest extends UnitTestCase
      */
     public function duplicateActionRedirectsToModuleOverviewAction(): void
     {
-        $this->subject->expects(self::once())->method('redirect')
-            ->with('overview', 'BackEnd\\Module');
+        $this->mockRedirect('overview', 'BackEnd\\Module');
 
         $this->subject->duplicateAction(15);
     }

--- a/Tests/Unit/Controller/BackEnd/ModuleControllerTest.php
+++ b/Tests/Unit/Controller/BackEnd/ModuleControllerTest.php
@@ -10,6 +10,7 @@ use OliverKlee\Seminars\Domain\Model\Event\SingleEvent;
 use OliverKlee\Seminars\Domain\Repository\Event\EventRepository;
 use OliverKlee\Seminars\Domain\Repository\Registration\RegistrationRepository;
 use OliverKlee\Seminars\Service\EventStatisticsCalculator;
+use OliverKlee\Seminars\Tests\Unit\Controller\RedirectMockTrait;
 use PHPUnit\Framework\MockObject\MockObject;
 use TYPO3\CMS\Core\Http\HtmlResponse;
 use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
@@ -25,6 +26,8 @@ use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
  */
 final class ModuleControllerTest extends UnitTestCase
 {
+    use RedirectMockTrait;
+
     /**
      * @var ModuleController&MockObject&AccessibleObjectInterface
      */

--- a/Tests/Unit/Controller/BackEnd/RegistrationControllerTest.php
+++ b/Tests/Unit/Controller/BackEnd/RegistrationControllerTest.php
@@ -13,6 +13,7 @@ use OliverKlee\Seminars\Domain\Repository\Event\EventRepository;
 use OliverKlee\Seminars\Domain\Repository\Registration\RegistrationRepository;
 use OliverKlee\Seminars\Model\Registration;
 use OliverKlee\Seminars\Service\EventStatisticsCalculator;
+use OliverKlee\Seminars\Tests\Unit\Controller\RedirectMockTrait;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Http\Message\ResponseInterface;
 use TYPO3\CMS\Core\Http\HtmlResponse;
@@ -31,6 +32,8 @@ use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
  */
 final class RegistrationControllerTest extends UnitTestCase
 {
+    use RedirectMockTrait;
+
     /**
      * @var RegistrationController&MockObject&AccessibleObjectInterface
      */
@@ -577,8 +580,8 @@ final class RegistrationControllerTest extends UnitTestCase
     public function deleteActionRedirectsToShowRegistrationsForEventAction(): void
     {
         $eventUid = 2;
-        $this->subject->expects(self::once())->method('redirect')
-            ->with('showForEvent', 'BackEnd\\Registration', null, ['eventUid' => $eventUid]);
+
+        $this->mockRedirect('showForEvent', 'BackEnd\\Registration', null, ['eventUid' => $eventUid]);
 
         $this->subject->deleteAction(15, $eventUid);
     }

--- a/Tests/Unit/Controller/EventRegistrationControllerTest.php
+++ b/Tests/Unit/Controller/EventRegistrationControllerTest.php
@@ -29,6 +29,8 @@ use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
  */
 final class EventRegistrationControllerTest extends UnitTestCase
 {
+    use RedirectMockTrait;
+
     /**
      * @var EventRegistrationController&MockObject&AccessibleObjectInterface
      */
@@ -118,10 +120,7 @@ final class EventRegistrationControllerTest extends UnitTestCase
         $pageUid = 42;
         $this->subject->_set('settings', ['pageForMissingEvent' => (string)$pageUid]);
 
-        $this->subject->expects(self::once())->method('redirect')
-            ->with(null, null, null, [], $pageUid)
-            ->willThrowException(new StopActionException('redirectToUri', 1476045828));
-        $this->expectException(StopActionException::class);
+        $this->mockRedirect(null, null, null, [], $pageUid);
 
         $this->subject->checkPrerequisitesAction();
     }
@@ -134,10 +133,7 @@ final class EventRegistrationControllerTest extends UnitTestCase
         $pageUid = 42;
         $this->subject->_set('settings', ['pageForMissingEvent' => (string)$pageUid]);
 
-        $this->subject->expects(self::once())->method('redirect')
-            ->with(null, null, null, [], $pageUid)
-            ->willThrowException(new StopActionException('redirectToUri', 1476045828));
-        $this->expectException(StopActionException::class);
+        $this->mockRedirect(null, null, null, [], $pageUid);
 
         $this->subject->checkPrerequisitesAction(null);
     }
@@ -240,10 +236,7 @@ final class EventRegistrationControllerTest extends UnitTestCase
         $this->registrationGuardMock->expects(self::once())
             ->method('getVacancies')->with($event)->willReturn(0);
 
-        $this->subject->expects(self::once())->method('redirect')
-            ->with('new', null, null, ['event' => $event])
-            ->willThrowException(new StopActionException('redirectToUri', 1476045828));
-        $this->expectException(StopActionException::class);
+        $this->mockRedirect('new', null, null, ['event' => $event]);
 
         $this->subject->checkPrerequisitesAction($event);
     }
@@ -267,10 +260,7 @@ final class EventRegistrationControllerTest extends UnitTestCase
         $this->registrationGuardMock->expects(self::once())
             ->method('getVacancies')->with($event)->willReturn(null);
 
-        $this->subject->expects(self::once())->method('redirect')
-            ->with('new', null, null, ['event' => $event])
-            ->willThrowException(new StopActionException('redirectToUri', 1476045828));
-        $this->expectException(StopActionException::class);
+        $this->mockRedirect('new', null, null, ['event' => $event]);
 
         $this->subject->checkPrerequisitesAction($event);
     }
@@ -294,10 +284,7 @@ final class EventRegistrationControllerTest extends UnitTestCase
         $this->registrationGuardMock->expects(self::once())
             ->method('getVacancies')->with($event)->willReturn(1);
 
-        $this->subject->expects(self::once())->method('redirect')
-            ->with('new', null, null, ['event' => $event])
-            ->willThrowException(new StopActionException('redirectToUri', 1476045828));
-        $this->expectException(StopActionException::class);
+        $this->mockRedirect('new', null, null, ['event' => $event]);
 
         $this->subject->checkPrerequisitesAction($event);
     }
@@ -909,8 +896,7 @@ final class EventRegistrationControllerTest extends UnitTestCase
     public function createActionAssertsBookableEventType(): void
     {
         $event = new SingleEvent();
-        $this->subject->method('redirect')->willThrowException(new StopActionException('redirectToUri', 1476045828));
-        $this->expectException(StopActionException::class);
+        $this->stubRedirect();
 
         $this->registrationGuardMock->expects(self::once())->method('assertBookableEventType')->with($event);
 
@@ -926,8 +912,7 @@ final class EventRegistrationControllerTest extends UnitTestCase
         $event = new SingleEvent();
         $settings = ['registration' => ['registrationRecordsStorageFolder' => '5']];
         $this->subject->_set('settings', $settings);
-        $this->subject->method('redirect')->willThrowException(new StopActionException('redirectToUri', 1476045828));
-        $this->expectException(StopActionException::class);
+        $this->stubRedirect();
 
         $this->registrationProcesserMock->expects(self::once())->method('enrichWithMetadata')
             ->with($registration, $event, $settings);
@@ -941,8 +926,7 @@ final class EventRegistrationControllerTest extends UnitTestCase
     public function createActionCalculatesTotalPrice(): void
     {
         $registration = new Registration();
-        $this->subject->method('redirect')->willThrowException(new StopActionException('redirectToUri', 1476045828));
-        $this->expectException(StopActionException::class);
+        $this->stubRedirect();
 
         $this->registrationProcesserMock->expects(self::once())->method('calculateTotalPrice')
             ->with($registration);
@@ -956,8 +940,7 @@ final class EventRegistrationControllerTest extends UnitTestCase
     public function createActionCreatesRegistrationTitle(): void
     {
         $registration = new Registration();
-        $this->subject->method('redirect')->willThrowException(new StopActionException('redirectToUri', 1476045828));
-        $this->expectException(StopActionException::class);
+        $this->stubRedirect();
 
         $this->registrationProcesserMock->expects(self::once())->method('createTitle')->with($registration);
 
@@ -970,8 +953,7 @@ final class EventRegistrationControllerTest extends UnitTestCase
     public function createActionWithoutUserStorageSettingCreatesAdditionalPersonsWithZeroStorageFolderUid(): void
     {
         $registration = new Registration();
-        $this->subject->method('redirect')->willThrowException(new StopActionException('redirectToUri', 1476045828));
-        $this->expectException(StopActionException::class);
+        $this->stubRedirect();
 
         $this->registrationProcesserMock->expects(self::once())->method('createAdditionalPersons')
             ->with($registration, 0);
@@ -987,8 +969,7 @@ final class EventRegistrationControllerTest extends UnitTestCase
         $folderUid = 15;
         $this->subject->_set('settings', ['additionalPersonsStorageFolder' => (string)$folderUid]);
         $registration = new Registration();
-        $this->subject->method('redirect')->willThrowException(new StopActionException('redirectToUri', 1476045828));
-        $this->expectException(StopActionException::class);
+        $this->stubRedirect();
 
         $this->registrationProcesserMock->expects(self::once())->method('createAdditionalPersons')
             ->with($registration, $folderUid);
@@ -1002,8 +983,7 @@ final class EventRegistrationControllerTest extends UnitTestCase
     public function createActionPersistsRegistration(): void
     {
         $registration = new Registration();
-        $this->subject->method('redirect')->willThrowException(new StopActionException('redirectToUri', 1476045828));
-        $this->expectException(StopActionException::class);
+        $this->stubRedirect();
 
         $this->registrationProcesserMock->expects(self::once())->method('persist')->with($registration);
 
@@ -1016,8 +996,7 @@ final class EventRegistrationControllerTest extends UnitTestCase
     public function createActionSendsEmail(): void
     {
         $registration = new Registration();
-        $this->subject->method('redirect')->willThrowException(new StopActionException('redirectToUri', 1476045828));
-        $this->expectException(StopActionException::class);
+        $this->stubRedirect();
 
         $this->registrationProcesserMock->expects(self::once())->method('sendEmails')->with($registration);
 
@@ -1030,8 +1009,7 @@ final class EventRegistrationControllerTest extends UnitTestCase
     public function createDestroysOneTimeAccountSession(): void
     {
         $registration = new Registration();
-        $this->subject->method('redirect')->willThrowException(new StopActionException('redirectToUri', 1476045828));
-        $this->expectException(StopActionException::class);
+        $this->stubRedirect();
 
         $this->oneTimeAccountConnectorMock->expects(self::once())->method('destroyOneTimeSession');
 
@@ -1046,10 +1024,7 @@ final class EventRegistrationControllerTest extends UnitTestCase
         $event = new SingleEvent();
         $registration = new Registration();
 
-        $this->subject->expects(self::once())->method('redirect')
-            ->with('thankYou', null, null, ['event' => $event, 'registration' => $registration])
-            ->willThrowException(new StopActionException('redirectToUri', 1476045828));
-        $this->expectException(StopActionException::class);
+        $this->mockRedirect('thankYou', null, null, ['event' => $event, 'registration' => $registration]);
 
         $this->subject->createAction($event, $registration);
     }

--- a/Tests/Unit/Controller/EventUnregistrationControllerTest.php
+++ b/Tests/Unit/Controller/EventUnregistrationControllerTest.php
@@ -18,7 +18,6 @@ use TYPO3\CMS\Core\Http\HtmlResponse;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Http\ForwardResponse;
 use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
-use TYPO3\CMS\Extbase\Mvc\Exception\StopActionException;
 use TYPO3\CMS\Fluid\View\TemplateView;
 use TYPO3\TestingFramework\Core\AccessibleObjectInterface;
 use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
@@ -28,6 +27,8 @@ use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
  */
 final class EventUnregistrationControllerTest extends UnitTestCase
 {
+    use RedirectMockTrait;
+
     /**
      * @var EventUnregistrationController&MockObject&AccessibleObjectInterface
      */
@@ -214,10 +215,7 @@ final class EventUnregistrationControllerTest extends UnitTestCase
         $this->legacyRegistrationMock->expects(self::once())->method('getSeminarObject')->willReturn($legacyEvent);
         $legacyEvent->expects(self::once())->method('isUnregistrationPossible')->willReturn(true);
 
-        $this->subject->expects(self::once())->method('redirect')
-            ->with('confirm', null, null, ['registration' => $registration])
-            ->willThrowException(new StopActionException('redirectToUri', 1476045828));
-        $this->expectException(StopActionException::class);
+        $this->mockRedirect('confirm', null, null, ['registration' => $registration]);
 
         $this->subject->checkPrerequisitesAction($registration);
     }
@@ -289,10 +287,7 @@ final class EventUnregistrationControllerTest extends UnitTestCase
         $event = new SingleEvent();
         $registration->setEvent($event);
 
-        $this->subject->expects(self::once())->method('redirect')
-            ->with('thankYou', null, null, ['event' => $event])
-            ->willThrowException(new StopActionException('redirectToUri', 1476045828));
-        $this->expectException(StopActionException::class);
+        $this->mockRedirect('thankYou', null, null, ['event' => $event]);
 
         $this->subject->unregisterAction($registration);
     }

--- a/Tests/Unit/Controller/FrontEndEditorControllerTest.php
+++ b/Tests/Unit/Controller/FrontEndEditorControllerTest.php
@@ -28,6 +28,8 @@ use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
  */
 final class FrontEndEditorControllerTest extends UnitTestCase
 {
+    use RedirectMockTrait;
+
     /**
      * @var FrontEndEditorController&MockObject&AccessibleObjectInterface
      */
@@ -233,8 +235,8 @@ final class FrontEndEditorControllerTest extends UnitTestCase
     public function updateActionRedirectsToIndexAction(): void
     {
         $event = new SingleEvent();
-        $this->subject->expects(self::once())->method('redirect')
-            ->with('index');
+
+        $this->mockRedirect('index');
 
         $this->subject->updateAction($event);
     }
@@ -420,8 +422,7 @@ final class FrontEndEditorControllerTest extends UnitTestCase
     {
         $event = new SingleEvent();
 
-        $this->subject->expects(self::once())->method('redirect')
-            ->with('index');
+        $this->mockRedirect('index');
 
         $this->subject->createAction($event);
     }

--- a/Tests/Unit/Controller/RedirectMockTrait.php
+++ b/Tests/Unit/Controller/RedirectMockTrait.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OliverKlee\Seminars\Tests\Unit\Controller;
+
+use TYPO3\CMS\Core\Http\RedirectResponse;
+use TYPO3\CMS\Core\Information\Typo3Version;
+use TYPO3\CMS\Extbase\Mvc\Exception\StopActionException;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+/**
+ * @phpstan-require-extends UnitTestCase
+ */
+trait RedirectMockTrait
+{
+    /**
+     * @param string|array<string, mixed>|int|null ...$arguments
+     */
+    private function mockRedirect(...$arguments): void
+    {
+        if ((new Typo3Version())->getMajorVersion() < 12) {
+            $this->subject->expects(self::once())->method('redirect')
+                ->with(...$arguments)
+                ->willThrowException(new StopActionException('redirectToUri', 1476045828));
+            $this->expectException(StopActionException::class);
+        } else {
+            $redirectResponse = $this->createStub(RedirectResponse::class);
+            $this->subject->expects(self::once())->method('redirect')->with(...$arguments)
+                ->willReturn($redirectResponse);
+        }
+    }
+
+    private function stubRedirect(): void
+    {
+        if ((new Typo3Version())->getMajorVersion() < 12) {
+            $this->subject->method('redirect')
+                ->willThrowException(new StopActionException('redirectToUri', 1476045828));
+            $this->expectException(StopActionException::class);
+        } else {
+            $redirectResponse = $this->createStub(RedirectResponse::class);
+            $this->subject->method('redirect')->willReturn($redirectResponse);
+        }
+    }
+}


### PR DESCRIPTION
Also reduce code duplication.

This is for calls to `redirect`, not for `redirectToUri`, which will come in a later change.

Part of #1482