### PR TITLE
[BUGFIX] Make the `redirectToUri` tests compatible with 11LTS/12LTS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 - Avoid the deprecated `ActionController::forward()` method (#3637)
 - Drop tests for duplicated place associations (#3631)
-- Always return a response from controller actions (#3619, #3638, #3668)
+- Always return a response from controller actions (#3619, #3638, #3668, #3669)
 - Stop setting `TemplateHelper::cObj` (#3613)
 - Avoid using the deprecated `GeneralUtility::_GPmerged()` (#3595)
 - Drop unused dependency on `MarkerBasedTemplateService` (#3594)

--- a/Tests/Unit/Controller/EventRegistrationControllerTest.php
+++ b/Tests/Unit/Controller/EventRegistrationControllerTest.php
@@ -18,7 +18,6 @@ use TYPO3\CMS\Core\Http\HtmlResponse;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Http\ForwardResponse;
 use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
-use TYPO3\CMS\Extbase\Mvc\Exception\StopActionException;
 use TYPO3\CMS\Extbase\Mvc\Web\Routing\UriBuilder;
 use TYPO3\CMS\Fluid\View\TemplateView;
 use TYPO3\TestingFramework\Core\AccessibleObjectInterface;
@@ -316,10 +315,7 @@ final class EventRegistrationControllerTest extends UnitTestCase
         $this->uriBuilderMock->expects(self::exactly(2))->method('buildFrontendUri')
             ->willReturnOnConsecutiveCalls($redirectUrl, $loginPageUrl);
 
-        $this->subject->expects(self::once())->method('redirectToUri')
-            ->with($loginPageUrl)
-            ->willThrowException(new StopActionException('redirectToUri', 1476045828));
-        $this->expectException(StopActionException::class);
+        $this->mockRedirectToUri($loginPageUrl);
 
         $this->subject->checkPrerequisitesAction($event);
     }

--- a/Tests/Unit/Controller/RedirectMockTrait.php
+++ b/Tests/Unit/Controller/RedirectMockTrait.php
@@ -42,4 +42,21 @@ trait RedirectMockTrait
             $this->subject->method('redirect')->willReturn($redirectResponse);
         }
     }
+
+    /**
+     * @param non-empty-string $uri
+     */
+    private function mockRedirectToUri(string $uri): void
+    {
+        if ((new Typo3Version())->getMajorVersion() < 12) {
+            $this->subject->expects(self::once())->method('redirectToUri')
+                ->with($uri)
+                ->willThrowException(new StopActionException('redirectToUri', 1476045828));
+            $this->expectException(StopActionException::class);
+        } else {
+            $redirectResponse = $this->createStub(RedirectResponse::class);
+            $this->subject->expects(self::once())->method('redirectToUri')->with($uri)
+                ->willReturn($redirectResponse);
+        }
+    }
 }


### PR DESCRIPTION
Part of #1482