### PR TITLE
[BUGFIX] Avoid using the deprecated `GeneralUtility::_GET()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- Avoid using the deprecated `GeneralUtility::_GET()` (#3690)
 - Increase type safety in the `RegistrationManager` (#3678)
 - Avoid the deprecated `ActionController::forward()` method (#3637)
 - Drop tests for duplicated place associations (#3631)

--- a/Classes/Csv/CsvDownloader.php
+++ b/Classes/Csv/CsvDownloader.php
@@ -34,8 +34,8 @@ class CsvDownloader
      */
     public function main(): string
     {
-        $pageUid = \max(0, (int)GeneralUtility::_GET('pid'));
-        $eventUid = \max(0, (int)GeneralUtility::_GET('eventUid'));
+        $pageUid = \max(0, (int)($_GET['pid'] ?? 0));
+        $eventUid = \max(0, (int)($_GET['eventUid'] ?? 0));
         return $this->createAndOutputListOfRegistrations($eventUid, $pageUid);
     }
 


### PR DESCRIPTION
Fixes #3642