### PR TITLE
[BUGFIX] Avoid using the deprecated `TSFE->indexedDocTitle`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- Avoid using the deprecated `TSFE->indexedDocTitle` (#3740)
 - Fix setting `cObj` in the `TemplateHelper` in TYPO3 11LTS (#3736)
 - Add upgrade wizard to remove duplicate event-venue relations (#3717, #3732)
 - Avoid using the deprecated `GeneralUtility::_GET()` (#3690)

--- a/Classes/FrontEnd/DefaultController.php
+++ b/Classes/FrontEnd/DefaultController.php
@@ -504,8 +504,6 @@ class DefaultController extends TemplateHelper
     protected function createSingleViewForExistingEvent(): string
     {
         $title = $this->seminar->getTitle();
-        // This sets the title of the page for use in indexed search results:
-        $this->getFrontEndController()->indexedDocTitle = $title;
         GeneralUtility::makeInstance(SingleViewPageTitleProvider::class)->setTitle($title);
 
         $this->setEventTypeMarker();

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -371,11 +371,6 @@ parameters:
 			path: Classes/FrontEnd/DefaultController.php
 
 		-
-			message: "#^Cannot access property \\$indexedDocTitle on TYPO3\\\\CMS\\\\Frontend\\\\Controller\\\\TypoScriptFrontendController\\|null\\.$#"
-			count: 1
-			path: Classes/FrontEnd/DefaultController.php
-
-		-
 			message: "#^Cannot call method cObjGetSingle\\(\\) on TYPO3\\\\CMS\\\\Frontend\\\\ContentObject\\\\ContentObjectRenderer\\|null\\.$#"
 			count: 3
 			path: Classes/FrontEnd/DefaultController.php


### PR DESCRIPTION
Nowadays, we can use the page title provider API (which we already are offering).

Fixes #3738