### PR TITLE
[BUGFIX] Switch from the `be:moduleLayout` VH to `ModuleTemplate`

### DIFF
--- a/Classes/BackEnd/AbstractEventMailForm.php
+++ b/Classes/BackEnd/AbstractEventMailForm.php
@@ -156,7 +156,7 @@ abstract class AbstractEventMailForm
     protected function addFlashMessage(FlashMessage $flashMessage): void
     {
         $defaultFlashMessageQueue = GeneralUtility::makeInstance(FlashMessageService::class)
-            ->getMessageQueueByIdentifier();
+            ->getMessageQueueByIdentifier('extbase.flashmessages.tx_seminars_web_seminarsevents');
         $defaultFlashMessageQueue->enqueue($flashMessage);
     }
 

--- a/Classes/Controller/BackEnd/EmailController.php
+++ b/Classes/Controller/BackEnd/EmailController.php
@@ -7,6 +7,7 @@ namespace OliverKlee\Seminars\Controller\BackEnd;
 use OliverKlee\Seminars\BackEnd\GeneralEventMailForm;
 use OliverKlee\Seminars\Domain\Model\Event\Event;
 use Psr\Http\Message\ResponseInterface;
+use TYPO3\CMS\Backend\Template\ModuleTemplateFactory;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Annotation\IgnoreValidation;
 use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
@@ -17,6 +18,13 @@ use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
 class EmailController extends ActionController
 {
     use PermissionsTrait;
+
+    private ModuleTemplateFactory $moduleTemplateFactory;
+
+    public function __construct(ModuleTemplateFactory $moduleTemplateFactory)
+    {
+        $this->moduleTemplateFactory = $moduleTemplateFactory;
+    }
 
     /**
      * Action for the displaying the email form.
@@ -38,7 +46,10 @@ class EmailController extends ActionController
         $this->view->assign('subject', $subject);
         $this->view->assign('body', $body);
 
-        return $this->htmlResponse();
+        $moduleTemplate = $this->moduleTemplateFactory->create($this->request);
+        $moduleTemplate->setContent($this->view->render());
+
+        return $this->htmlResponse($moduleTemplate->renderContent());
     }
 
     /**

--- a/Classes/Controller/BackEnd/EventController.php
+++ b/Classes/Controller/BackEnd/EventController.php
@@ -8,6 +8,7 @@ use OliverKlee\Seminars\BackEnd\Permissions;
 use OliverKlee\Seminars\Domain\Repository\Event\EventRepository;
 use OliverKlee\Seminars\Service\EventStatisticsCalculator;
 use Psr\Http\Message\ResponseInterface;
+use TYPO3\CMS\Backend\Template\ModuleTemplateFactory;
 use TYPO3\CMS\Core\Localization\LanguageService;
 use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
 
@@ -16,6 +17,8 @@ use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
  */
 class EventController extends ActionController
 {
+    private ModuleTemplateFactory $moduleTemplateFactory;
+
     private EventRepository $eventRepository;
 
     private Permissions $permissions;
@@ -25,10 +28,12 @@ class EventController extends ActionController
     private LanguageService $languageService;
 
     public function __construct(
+        ModuleTemplateFactory $moduleTemplateFactory,
         EventRepository $eventRepository,
         Permissions $permissions,
         EventStatisticsCalculator $eventStatisticsCalculator
     ) {
+        $this->moduleTemplateFactory = $moduleTemplateFactory;
         $this->eventRepository = $eventRepository;
         $this->permissions = $permissions;
         $this->eventStatisticsCalculator = $eventStatisticsCalculator;
@@ -94,7 +99,10 @@ class EventController extends ActionController
 
         $this->view->assign('searchTerm', \trim($searchTerm));
 
-        return $this->htmlResponse();
+        $moduleTemplate = $this->moduleTemplateFactory->create($this->request);
+        $moduleTemplate->setContent($this->view->render());
+
+        return $this->htmlResponse($moduleTemplate->renderContent());
     }
 
     /**

--- a/Classes/Controller/BackEnd/ModuleController.php
+++ b/Classes/Controller/BackEnd/ModuleController.php
@@ -7,6 +7,7 @@ namespace OliverKlee\Seminars\Controller\BackEnd;
 use OliverKlee\Seminars\Domain\Repository\Event\EventRepository;
 use OliverKlee\Seminars\Domain\Repository\Registration\RegistrationRepository;
 use Psr\Http\Message\ResponseInterface;
+use TYPO3\CMS\Backend\Template\ModuleTemplateFactory;
 use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
 
 /**
@@ -18,12 +19,18 @@ class ModuleController extends ActionController
     use PageUidTrait;
     use PermissionsTrait;
 
+    private ModuleTemplateFactory $moduleTemplateFactory;
+
     private EventRepository $eventRepository;
 
     private RegistrationRepository $registrationRepository;
 
-    public function __construct(EventRepository $eventRepository, RegistrationRepository $registrationRepository)
-    {
+    public function __construct(
+        ModuleTemplateFactory $moduleTemplateFactory,
+        EventRepository $eventRepository,
+        RegistrationRepository $registrationRepository
+    ) {
+        $this->moduleTemplateFactory = $moduleTemplateFactory;
         $this->eventRepository = $eventRepository;
         $this->registrationRepository = $registrationRepository;
     }
@@ -46,6 +53,9 @@ class ModuleController extends ActionController
             $this->registrationRepository->countRegularRegistrationsByPageUid($pageUid)
         );
 
-        return $this->htmlResponse();
+        $moduleTemplate = $this->moduleTemplateFactory->create($this->request);
+        $moduleTemplate->setContent($this->view->render());
+
+        return $this->htmlResponse($moduleTemplate->renderContent());
     }
 }

--- a/Classes/Controller/BackEnd/RegistrationController.php
+++ b/Classes/Controller/BackEnd/RegistrationController.php
@@ -11,6 +11,7 @@ use OliverKlee\Seminars\Domain\Model\Event\EventDateInterface;
 use OliverKlee\Seminars\Domain\Repository\Event\EventRepository;
 use OliverKlee\Seminars\Domain\Repository\Registration\RegistrationRepository;
 use Psr\Http\Message\ResponseInterface;
+use TYPO3\CMS\Backend\Template\ModuleTemplateFactory;
 use TYPO3\CMS\Core\Localization\LanguageService;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
@@ -29,14 +30,20 @@ class RegistrationController extends ActionController
      */
     private const CSV_FILENAME = 'registrations.csv';
 
+    private ModuleTemplateFactory $moduleTemplateFactory;
+
     private RegistrationRepository $registrationRepository;
 
     private EventRepository $eventRepository;
 
     private LanguageService $languageService;
 
-    public function __construct(RegistrationRepository $registrationRepository, EventRepository $eventRepository)
-    {
+    public function __construct(
+        ModuleTemplateFactory $moduleTemplateFactory,
+        RegistrationRepository $registrationRepository,
+        EventRepository $eventRepository
+    ) {
+        $this->moduleTemplateFactory = $moduleTemplateFactory;
         $this->registrationRepository = $registrationRepository;
         $this->eventRepository = $eventRepository;
         $languageService = $GLOBALS['LANG'] ?? null;
@@ -72,7 +79,10 @@ class RegistrationController extends ActionController
             $this->view->assign('waitingListRegistrations', $waitingListRegistrations);
         }
 
-        return $this->htmlResponse();
+        $moduleTemplate = $this->moduleTemplateFactory->create($this->request);
+        $moduleTemplate->setContent($this->view->render());
+
+        return $this->htmlResponse($moduleTemplate->renderContent());
     }
 
     /**

--- a/Resources/Private/Layouts/BackEndModule.html
+++ b/Resources/Private/Layouts/BackEndModule.html
@@ -1,12 +1,9 @@
 <html
     xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
-    xmlns:be="http://typo3.org/ns/TYPO3/CMS/Backend/ViewHelpers"
     data-namespace-typo3-fluid="true">
-    <be:moduleLayout>
-        <f:render section="Header"/>
+    <f:render section="Header"/>
 
-        <f:flashMessages queueIdentifier="core.template.flashMessages"/>
+    <f:flashMessages queueIdentifier="extbase.flashmessages.tx_seminars_web_seminarsevents"/>
 
-        <f:render section="Content"/>
-    </be:moduleLayout>
+    <f:render section="Content"/>
 </html>


### PR DESCRIPTION
The `be:moduleLayout` view helper was deprecated in TYPO3 11LTS and removed in TYPO3 12LTS.

Fixes #3743