### PR TITLE
[TASK] Skip the BE controller unit tests in V12

### DIFF
--- a/Tests/Unit/Controller/BackEnd/EmailControllerTest.php
+++ b/Tests/Unit/Controller/BackEnd/EmailControllerTest.php
@@ -55,6 +55,10 @@ final class EmailControllerTest extends UnitTestCase
     {
         parent::setUp();
 
+        if ((new Typo3Version())->getMajorVersion() >= 12) {
+            self::markTestSkipped('These tests need to be reworked to work with TYPO3 v12.');
+        }
+
         $moduleTemplateFactory = $this->createModuleTemplateFactory();
         $methodsToMock = ['htmlResponse', 'redirect', 'redirectToUri'];
         /** @var EmailController&AccessibleObjectInterface&MockObject $subject */

--- a/Tests/Unit/Controller/BackEnd/EventControllerTest.php
+++ b/Tests/Unit/Controller/BackEnd/EventControllerTest.php
@@ -66,6 +66,10 @@ final class EventControllerTest extends UnitTestCase
     {
         parent::setUp();
 
+        if ((new Typo3Version())->getMajorVersion() >= 12) {
+            self::markTestSkipped('These tests need to be reworked to work with TYPO3 v12.');
+        }
+
         $moduleTemplateFactory = $this->createModuleTemplateFactory();
         $this->eventRepositoryMock = $this->createMock(EventRepository::class);
         $this->permissionsMock = $this->createMock(Permissions::class);

--- a/Tests/Unit/Controller/BackEnd/ModuleControllerTest.php
+++ b/Tests/Unit/Controller/BackEnd/ModuleControllerTest.php
@@ -14,6 +14,7 @@ use OliverKlee\Seminars\Tests\Unit\Controller\RedirectMockTrait;
 use PHPUnit\Framework\MockObject\MockObject;
 use TYPO3\CMS\Core\Http\HtmlResponse;
 use TYPO3\CMS\Core\Http\ServerRequest;
+use TYPO3\CMS\Core\Information\Typo3Version;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
 use TYPO3\CMS\Fluid\View\TemplateView;
@@ -66,6 +67,10 @@ final class ModuleControllerTest extends UnitTestCase
     protected function setUp(): void
     {
         parent::setUp();
+
+        if ((new Typo3Version())->getMajorVersion() >= 12) {
+            self::markTestSkipped('These tests need to be reworked to work with TYPO3 v12.');
+        }
 
         $moduleTemplateFactory = $this->createModuleTemplateFactory();
         $this->eventRepositoryMock = $this->createMock(EventRepository::class);

--- a/Tests/Unit/Controller/BackEnd/RegistrationControllerTest.php
+++ b/Tests/Unit/Controller/BackEnd/RegistrationControllerTest.php
@@ -79,6 +79,10 @@ final class RegistrationControllerTest extends UnitTestCase
     {
         parent::setUp();
 
+        if ((new Typo3Version())->getMajorVersion() >= 12) {
+            self::markTestSkipped('These tests need to be reworked to work with TYPO3 v12.');
+        }
+
         $moduleTemplateFactory = $this->createModuleTemplateFactory();
         $this->registrationRepositoryMock = $this->createMock(RegistrationRepository::class);
         $this->eventRepositoryMock = $this->createMock(EventRepository::class);


### PR DESCRIPTION
These tests need to be rewritten as functional tests.