### PR TITLE
[TASK] Drop the cached seminars from `LegacyRegistration`

### DIFF
--- a/Classes/OldModel/LegacyRegistration.php
+++ b/Classes/OldModel/LegacyRegistration.php
@@ -69,24 +69,7 @@ class LegacyRegistration extends AbstractModel
      */
     protected array $checkboxes = [];
 
-    /**
-     * cached seminar objects with the seminar UIDs as keys and the objects as values
-     *
-     * @var array<positive-int, LegacyEvent>
-     */
-    private static array $cachedSeminars = [];
-
     protected ?FrontEndUser $user = null;
-
-    /**
-     * Purges our cached seminars array.
-     *
-     * This function is intended for testing purposes only.
-     */
-    public static function purgeCachedSeminars(): void
-    {
-        self::$cachedSeminars = [];
-    }
 
     /**
      * Gets the number of seats that are registered with this registration.
@@ -381,13 +364,7 @@ class LegacyRegistration extends AbstractModel
         if (!($this->seminar instanceof LegacyEvent) && $this->isOk()) {
             $seminarUid = $this->getRecordPropertyInteger('seminar');
             \assert($seminarUid > 0);
-            if (isset(self::$cachedSeminars[$seminarUid])) {
-                $this->seminar = self::$cachedSeminars[$seminarUid];
-            } else {
-                $seminar = GeneralUtility::makeInstance(LegacyEvent::class, $seminarUid);
-                $this->seminar = $seminar;
-                self::$cachedSeminars[$seminarUid] = $seminar;
-            }
+            $this->seminar = GeneralUtility::makeInstance(LegacyEvent::class, $seminarUid);
         }
 
         return $this->seminar;

--- a/Tests/Functional/Service/RegistrationManagerTest.php
+++ b/Tests/Functional/Service/RegistrationManagerTest.php
@@ -92,7 +92,6 @@ final class RegistrationManagerTest extends FunctionalTestCase
 
         $this->initializeBackEndLanguage();
 
-        LegacyRegistration::purgeCachedSeminars();
         $configurationRegistry = ConfigurationRegistry::getInstance();
         $this->configuration = new DummyConfiguration(
             [

--- a/Tests/LegacyFunctional/OldModel/LegacyRegistrationTest.php
+++ b/Tests/LegacyFunctional/OldModel/LegacyRegistrationTest.php
@@ -49,8 +49,6 @@ final class LegacyRegistrationTest extends FunctionalTestCase
         GeneralUtility::makeInstance(Context::class)
             ->setAspect('date', new DateTimeAspect(new \DateTimeImmutable('2018-04-26 12:42:23')));
 
-        LegacyRegistration::purgeCachedSeminars();
-
         $this->testingFramework = new TestingFramework('tx_seminars');
         $rootPageUid = $this->testingFramework->createFrontEndPage();
         $this->testingFramework->changeRecord('pages', $rootPageUid, ['slug' => '/home']);
@@ -511,38 +509,6 @@ final class LegacyRegistrationTest extends FunctionalTestCase
             1,
             $connection->count('*', 'tx_seminars_attendances', ['uid' => $registration->getUid()]),
             'The registration record cannot be found in the DB.'
-        );
-    }
-
-    // Tests regarding the cached seminars.
-
-    /**
-     * @test
-     */
-    public function purgeCachedSeminarsResultsInDifferentDataForSameSeminarUid(): void
-    {
-        $seminarUid = $this->testingFramework->createRecord(
-            'tx_seminars_seminars',
-            ['title' => 'test title 1']
-        );
-
-        $registrationUid = $this->testingFramework->createRecord(
-            'tx_seminars_attendances',
-            ['seminar' => $seminarUid]
-        );
-
-        $this->testingFramework->changeRecord(
-            'tx_seminars_seminars',
-            $seminarUid,
-            ['title' => 'test title 2']
-        );
-
-        LegacyRegistration::purgeCachedSeminars();
-        $subject = new LegacyRegistration($registrationUid);
-
-        self::assertSame(
-            'test title 2',
-            $subject->getSeminarObject()->getTitle()
         );
     }
 

--- a/Tests/LegacyFunctional/Service/RegistrationManagerTest.php
+++ b/Tests/LegacyFunctional/Service/RegistrationManagerTest.php
@@ -109,7 +109,6 @@ final class RegistrationManagerTest extends FunctionalTestCase
         $this->addMockedInstance(MailMessage::class, $this->email);
         $this->addMockedInstance(MailMessage::class, $secondEmail);
 
-        LegacyRegistration::purgeCachedSeminars();
         $configurationRegistry = ConfigurationRegistry::getInstance();
         $this->configuration = new DummyConfiguration(
             [


### PR DESCRIPTION
Models should not cache anything, particularly not for other models.

Fixes #3649