### PR TITLE
[BUGFIX] Ignore the webinar URL when duplicating an event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- Ignore the webinar URL when duplicating an event (#3806)
 - Fix incorrect translation references in the TCEforms (#3801)
 - Add upgrade wizard to remove duplicate event-venue relations (#3717)
 

--- a/Classes/Domain/Repository/Event/EventRepository.php
+++ b/Classes/Domain/Repository/Event/EventRepository.php
@@ -36,6 +36,7 @@ class EventRepository extends AbstractRawDataCapableRepository implements Direct
         // @deprecated #1324 will be removed in seminars 6.0
         'registrations',
         'slug',
+        'webinar_url',
     ];
 
     /**

--- a/Tests/Functional/Domain/Repository/Event/Fixtures/duplicateViaDataHandler/SingleEventAndDuplicateWithResetData.csv
+++ b/Tests/Functional/Domain/Repository/Event/Fixtures/duplicateViaDataHandler/SingleEventAndDuplicateWithResetData.csv
@@ -3,6 +3,6 @@
 ,1,0,254,"Record for pages"
 
 "tx_seminars_seminars"
-,"uid","pid","object_type","slug","cancelled","event_takes_place_reminder_sent","cancelation_deadline_reminder_sent","offline_attendees","organizers_notified_about_minimum_reached","date_of_last_registration_digest"
-,1,1,0,"some slug",1,1,1,5,1,1234567890
-,2,1,0,"",0,0,0,0,0,0
+,"uid","pid","object_type","slug","cancelled","event_takes_place_reminder_sent","cancelation_deadline_reminder_sent","offline_attendees","organizers_notified_about_minimum_reached","date_of_last_registration_digest","webinar_url"
+,1,1,0,"some slug",1,1,1,5,1,1234567890,"https://www.example.com/webinar"
+,2,1,0,"",0,0,0,0,0,0,""

--- a/Tests/Functional/Domain/Repository/Event/Fixtures/duplicateViaDataHandler/SingleEventWithDataToReset.csv
+++ b/Tests/Functional/Domain/Repository/Event/Fixtures/duplicateViaDataHandler/SingleEventWithDataToReset.csv
@@ -3,5 +3,5 @@
 ,1,0,254,"Record for pages"
 
 "tx_seminars_seminars"
-,"uid","pid","object_type","slug","cancelled","event_takes_place_reminder_sent","cancelation_deadline_reminder_sent","offline_attendees","organizers_notified_about_minimum_reached","date_of_last_registration_digest"
-,1,1,0,"some slug",1,1,1,5,1,1234567890
+,"uid","pid","object_type","slug","cancelled","event_takes_place_reminder_sent","cancelation_deadline_reminder_sent","offline_attendees","organizers_notified_about_minimum_reached","date_of_last_registration_digest","webinar_url"
+,1,1,0,"some slug",1,1,1,5,1,1234567890,"https://www.example.com/webinar"


### PR DESCRIPTION
This is the 5.x backport of #3805

Fixes #3757