### PR TITLE
[TASK] Hide registration-related field for events without registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- Hide registration-related field for events without registration (#3807)
 - Ignore the webinar URL when duplicating an event (#3805)
 - Fix incorrect translation references in the TCEforms (#3800)
 - Avoid mocking the final `ModuleTemplateFactory` class (#3765)

--- a/Configuration/TCA/tx_seminars_seminars.php
+++ b/Configuration/TCA/tx_seminars_seminars.php
@@ -796,6 +796,7 @@ $tca = [
         'additional_email_text' => [
             'exclude' => true,
             'label' => 'LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_seminars.additional_email_text',
+            'displayCond' => 'FIELD:needs_registration:REQ:true',
             'config' => [
                 'type' => 'text',
                 'cols' => 30,


### PR DESCRIPTION
The field for the additional email text in the registration email only makes sense for events that offer/require a registration.

Conditionally hiding this field improves usability.

Fixes #3756