### PR TITLE
[TASK] Hide registration-related field for events without registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- - Hide registration-related field for events without registration (#3808)
 - Require higher TYPO3 bugfix versions (#3511)
 
 ### Deprecated

--- a/Configuration/TCA/tx_seminars_seminars.php
+++ b/Configuration/TCA/tx_seminars_seminars.php
@@ -790,6 +790,7 @@ $tca = [
         'additional_email_text' => [
             'exclude' => true,
             'label' => 'LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_seminars.additional_email_text',
+            'displayCond' => 'FIELD:needs_registration:REQ:true',
             'config' => [
                 'type' => 'text',
                 'cols' => 30,


### PR DESCRIPTION
The field for the additional email text in the registration email only makes sense for events that offer/require a registration.

Conditionally hiding this field improves usability.

This is the 5.x backport of #3807.

Fixes #3756