### PR TITLE
[TASK] Do not display "will be announced" for time slots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- Display "will be announced" in fewer places (#3817)
 - Hide registration-related field for events without registration (#3808)
 - Require higher TYPO3 bugfix versions (#3511)
 

--- a/Classes/OldModel/LegacyTimeSlot.php
+++ b/Classes/OldModel/LegacyTimeSlot.php
@@ -51,12 +51,12 @@ class LegacyTimeSlot extends AbstractTimeSpan
      * Gets our place as plain text (just the name).
      * Returns a localized string "will be announced" if the time slot has no place set.
      *
-     * @return string our places or a localized string "will be announced" if this times lot has no place assigned
+     * @return string our places or an empty string if this timeslot lot has no place assigned
      */
     public function getPlaceShort(): string
     {
         if (!$this->hasPlace()) {
-            return $this->translate('message_willBeAnnounced');
+            return '';
         }
 
         $table = 'tx_seminars_sites';
@@ -78,12 +78,12 @@ class LegacyTimeSlot extends AbstractTimeSpan
      * Gets the entry date and time as a formatted date. If the begin date of
      * this time slot is on the same day as the entry date, only the time will be returned.
      *
-     * @return string the entry date and time (or the localized string "will be announced" if no entry date is set)
+     * @return string the entry date and time (or an empty string if no entry date is set)
      */
     public function getEntryDate(): string
     {
         if (!$this->hasEntryDate()) {
-            return $this->translate('message_willBeAnnounced');
+            return '';
         }
 
         $beginDate = $this->getBeginDateAsTimestamp();

--- a/Tests/LegacyFunctional/OldModel/LegacyTimeSlotTest.php
+++ b/Tests/LegacyFunctional/OldModel/LegacyTimeSlotTest.php
@@ -149,12 +149,9 @@ final class LegacyTimeSlotTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function getPlaceShortReturnsWillBeAnnouncedForNoPlaces(): void
+    public function getPlaceShortReturnsEmptyStringForNoPlaces(): void
     {
-        self::assertSame(
-            $this->translate('message_willBeAnnounced'),
-            $this->subject->getPlaceShort()
-        );
+        self::assertSame('', $this->subject->getPlaceShort());
     }
 
     /**
@@ -223,6 +220,14 @@ final class LegacyTimeSlotTest extends FunctionalTestCase
         self::assertTrue(
             $this->subject->hasEntryDate()
         );
+    }
+
+    /**
+     * @test
+     */
+    public function getEntryDateForNoEntryDateReturnsEmptyString(): void
+    {
+        self::assertSame('', $this->subject->getEntryDate());
     }
 
     /**


### PR DESCRIPTION
This is the 5.x backport of #3816.

Part of #3463