### PR TITLE
[TASK] Do not display "will be announced" for date or time of not set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
-- Display "will be announced" in fewer places (#3817)
+- Display "will be announced" in fewer places (#3817, #3837)
 - Hide registration-related field for events without registration (#3808)
 - Require higher TYPO3 bugfix versions (#3511)
 

--- a/Classes/OldModel/AbstractTimeSpan.php
+++ b/Classes/OldModel/AbstractTimeSpan.php
@@ -57,7 +57,7 @@ abstract class AbstractTimeSpan extends AbstractModel
     /**
      * Gets the date.
      *
-     * Returns a localized string "will be announced" if there's no date set.
+     * Returns an empty string if there's no date set.
      *
      * Returns just one day if the timespan takes place on only one day.
      * Returns a date range if the timespan takes several days.
@@ -66,28 +66,28 @@ abstract class AbstractTimeSpan extends AbstractModel
      */
     public function getDate(string $dash = '&#8211;'): string
     {
-        if ($this->hasDate()) {
-            $beginDate = $this->getBeginDateAsTimestamp();
-            $endDate = $this->getEndDateAsTimestamp();
+        if (!$this->hasDate()) {
+            return '';
+        }
 
-            $dateFormat = $this->getDateFormat();
-            $beginDateDay = \date($dateFormat, $beginDate);
-            $endDateDay = \date($dateFormat, $endDate);
+        $beginDate = $this->getBeginDateAsTimestamp();
+        $endDate = $this->getEndDateAsTimestamp();
 
-            // Does the workshop span only one day (or is open-ended)?
-            if ($beginDateDay === $endDateDay || !$this->hasEndDate()) {
-                $result = $beginDateDay;
-            } else {
-                $resultBeforeHook = $beginDateDay . $dash . $endDateDay;
-                $result = $this->getDateTimeSpanHookProvider()->executeHookReturningModifiedValue(
-                    'modifyDateSpan',
-                    $resultBeforeHook,
-                    $this,
-                    $dash
-                );
-            }
+        $dateFormat = $this->getDateFormat();
+        $beginDateDay = \date($dateFormat, $beginDate);
+        $endDateDay = \date($dateFormat, $endDate);
+
+        // Does the workshop span only one day (or is open-ended)?
+        if ($beginDateDay === $endDateDay || !$this->hasEndDate()) {
+            $result = $beginDateDay;
         } else {
-            $result = $this->translate('message_willBeAnnounced');
+            $resultBeforeHook = $beginDateDay . $dash . $endDateDay;
+            $result = $this->getDateTimeSpanHookProvider()->executeHookReturningModifiedValue(
+                'modifyDateSpan',
+                $resultBeforeHook,
+                $this,
+                $dash
+            );
         }
 
         return (string)$result;
@@ -106,8 +106,8 @@ abstract class AbstractTimeSpan extends AbstractModel
     /**
      * Gets the time.
      *
-     * Returns a localized string "will be announced" if there's no time set
-     * (i.e. both begin time and end time are 00:00).
+     * Returns an empty string if there's no time set (i.e., both begin time and end time are 00:00).
+     *
      * Returns only the begin time if begin time and end time are the same.
      *
      * @param string $dash the character or HTML entity used to separate begin time and end time
@@ -115,7 +115,7 @@ abstract class AbstractTimeSpan extends AbstractModel
     public function getTime(string $dash = '&#8211;'): string
     {
         if (!$this->hasTime()) {
-            return $this->translate('message_willBeAnnounced');
+            return '';
         }
 
         $timeFormat = $this->getTimeFormat();

--- a/Tests/Functional/OldModel/AbstractTimeSpanTest.php
+++ b/Tests/Functional/OldModel/AbstractTimeSpanTest.php
@@ -72,12 +72,9 @@ final class AbstractTimeSpanTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function getTimeForNoTimeReturnsWillBeAnnouncesMessage(): void
+    public function getTimeForNoTimeReturnsEmptyString(): void
     {
-        self::assertSame(
-            $this->translate('message_willBeAnnounced'),
-            $this->subject->getTime()
-        );
+        self::assertSame('', $this->subject->getTime());
     }
 
     /**
@@ -237,12 +234,9 @@ final class AbstractTimeSpanTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function getDateForNoDateReturnsWillBeAnnouncedMessage(): void
+    public function getDateForNoDateReturnsEmptyString(): void
     {
-        self::assertSame(
-            $this->translate('message_willBeAnnounced'),
-            $this->subject->getDate()
-        );
+        self::assertSame('', $this->subject->getDate());
     }
 
     /**
@@ -261,14 +255,11 @@ final class AbstractTimeSpanTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function getDateForEndDateReturnsWillBeAnnouncedMessage(): void
+    public function getDateForEndDateOnlyWithoutBeginDateReturnsEmptyString(): void
     {
         $this->subject->setEndDateAndTime(\mktime(0, 0, 0, 1, 1, 2010));
 
-        self::assertSame(
-            $this->translate('message_willBeAnnounced'),
-            $this->subject->getDate()
-        );
+        self::assertSame('', $this->subject->getDate());
     }
 
     /**


### PR DESCRIPTION
This makes the display a bit more compact.

This is the 5.x backport of #3836.

Fixes #3814