### PR TITLE
[BUGFIX] Only display the event times if there are no time slots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- Only display the event times if there are no time slots (#3839)
 - Fix translation for flash message in BE module (#3811)
 - Ignore the webinar URL when duplicating an event (#3806)
 - Fix incorrect translation references in the TCEforms (#3801)

--- a/Classes/OldModel/LegacyEvent.php
+++ b/Classes/OldModel/LegacyEvent.php
@@ -3647,4 +3647,11 @@ class LegacyEvent extends AbstractTimeSpan
             ->execute()
             ->fetchAll();
     }
+
+    public function hasTime(): bool
+    {
+        // Events with time slots should only display their time with the time slots,
+        // but not as general times in order to avoid confusion.
+        return !$this->hasTimeslots() && parent::hasTime();
+    }
 }

--- a/Tests/Functional/OldModel/Fixtures/Events/hasTime/SingleEventWithBeginAndWithEndDate.csv
+++ b/Tests/Functional/OldModel/Fixtures/Events/hasTime/SingleEventWithBeginAndWithEndDate.csv
@@ -1,0 +1,3 @@
+"tx_seminars_seminars"
+,"uid","begin_date","end_date","timeslots"
+,1,1729929600,1729958400,0

--- a/Tests/Functional/OldModel/Fixtures/Events/hasTime/SingleEventWithBeginAndWithoutEndDate.csv
+++ b/Tests/Functional/OldModel/Fixtures/Events/hasTime/SingleEventWithBeginAndWithoutEndDate.csv
@@ -1,0 +1,3 @@
+"tx_seminars_seminars"
+,"uid","begin_date","end_date","timeslots"
+,1,1729929600,0,0

--- a/Tests/Functional/OldModel/Fixtures/Events/hasTime/SingleEventWithOneTimeSlot.csv
+++ b/Tests/Functional/OldModel/Fixtures/Events/hasTime/SingleEventWithOneTimeSlot.csv
@@ -1,0 +1,7 @@
+"tx_seminars_seminars"
+,"uid","begin_date","end_date","timeslots"
+,1,1729929600,1729958400,1
+
+"tx_seminars_timeslots"
+,"uid","seminar","begin_date","end_date"
+,1,1,1729929600,1729958400

--- a/Tests/Functional/OldModel/Fixtures/Events/hasTime/SingleEventWithTwoTimeSlots.csv
+++ b/Tests/Functional/OldModel/Fixtures/Events/hasTime/SingleEventWithTwoTimeSlots.csv
@@ -1,0 +1,8 @@
+"tx_seminars_seminars"
+,"uid","begin_date","end_date","timeslots"
+,1,1729929600,1730048400,2
+
+"tx_seminars_timeslots"
+,"uid","seminar","begin_date","end_date"
+,1,1,1729929600,1729958400
+,2,1,1730019600,1730048400

--- a/Tests/Functional/OldModel/Fixtures/Events/hasTime/SingleEventWithoutBeginAndWithEndDate.csv
+++ b/Tests/Functional/OldModel/Fixtures/Events/hasTime/SingleEventWithoutBeginAndWithEndDate.csv
@@ -1,0 +1,3 @@
+"tx_seminars_seminars"
+,"uid","begin_date","end_date","timeslots"
+,1,0,1729958400,0

--- a/Tests/Functional/OldModel/Fixtures/Events/hasTime/SingleEventWithoutDate.csv
+++ b/Tests/Functional/OldModel/Fixtures/Events/hasTime/SingleEventWithoutDate.csv
@@ -1,0 +1,3 @@
+"tx_seminars_seminars"
+,"uid","begin_date","end_date","timeslots"
+,1,0,0,0

--- a/Tests/Functional/OldModel/LegacyEventTest.php
+++ b/Tests/Functional/OldModel/LegacyEventTest.php
@@ -1244,4 +1244,70 @@ final class LegacyEventTest extends FunctionalTestCase
 
         self::assertInstanceOf(FileReference::class, $subject->getImage());
     }
+
+    /**
+     * @test
+     */
+    public function hasTimeForEventWithoutDateReturnsFalse(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/Events/hasTime/SingleEventWithoutDate.csv');
+        $subject = new LegacyEvent(1);
+
+        self::assertFalse($subject->hasTime());
+    }
+
+    /**
+     * @test
+     */
+    public function hasTimeForEventWithBeginAndEndDateReturnsTrue(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/Events/hasTime/SingleEventWithBeginAndWithEndDate.csv');
+        $subject = new LegacyEvent(1);
+
+        self::assertTrue($subject->hasTime());
+    }
+
+    /**
+     * @test
+     */
+    public function hasTimeForEventWithBeginDateAndWithoutEndDateReturnsTrue(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/Events/hasTime/SingleEventWithBeginAndWithoutEndDate.csv');
+        $subject = new LegacyEvent(1);
+
+        self::assertTrue($subject->hasTime());
+    }
+
+    /**
+     * @test
+     */
+    public function hasTimeForEventWithoutBeginDateAndWithEndDateReturnsFalse(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/Events/hasTime/SingleEventWithoutBeginAndWithEndDate.csv');
+        $subject = new LegacyEvent(1);
+
+        self::assertFalse($subject->hasTime());
+    }
+
+    /**
+     * @test
+     */
+    public function hasTimeForEventWithOneTimeSlotReturnsFalse(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/Events/hasTime/SingleEventWithOneTimeSlot.csv');
+        $subject = new LegacyEvent(1);
+
+        self::assertFalse($subject->hasTime());
+    }
+
+    /**
+     * @test
+     */
+    public function hasTimeForEventWithTwoTimeSlotsReturnsFalse(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/Events/hasTime/SingleEventWithTwoTimeSlots.csv');
+        $subject = new LegacyEvent(1);
+
+        self::assertFalse($subject->hasTime());
+    }
 }


### PR DESCRIPTION
This is the 5.x backport of #3838.

Fixes #3646