### PR TITLE
[TASK] Move the PHPUnit configuration files to `Build/`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,8 +8,6 @@
 /.php_cs.dist export-ignore
 /Build/ export-ignore
 /CODE_OF_CONDUCT.md export-ignore
-/Configuration/FunctionalTests.xml export-ignore
-/Configuration/UnitTests.xml export-ignore
 /Resources/Private/Patches/ export-ignore
 /Tests/ export-ignore
 /composer-unused.php export-ignore

--- a/Build/phpunit/FunctionalTests.xml
+++ b/Build/phpunit/FunctionalTests.xml
@@ -4,7 +4,7 @@
          backupGlobals="true"
          backupStaticAttributes="false"
          beStrictAboutTestsThatDoNotTestAnything="false"
-         bootstrap="../.Build/vendor/typo3/testing-framework/Resources/Core/Build/FunctionalTestsBootstrap.php"
+         bootstrap="../../.Build/vendor/typo3/testing-framework/Resources/Core/Build/FunctionalTestsBootstrap.php"
          cacheResult="false"
          colors="true"
          convertDeprecationsToExceptions="false"

--- a/Build/phpunit/UnitTests.xml
+++ b/Build/phpunit/UnitTests.xml
@@ -4,7 +4,7 @@
          backupGlobals="true"
          backupStaticAttributes="false"
          beStrictAboutTestsThatDoNotTestAnything="false"
-         bootstrap="../.Build/vendor/typo3/testing-framework/Resources/Core/Build/UnitTestsBootstrap.php"
+         bootstrap="../../.Build/vendor/typo3/testing-framework/Resources/Core/Build/UnitTestsBootstrap.php"
          cacheResult="false"
          colors="true"
          convertDeprecationsToExceptions="true"

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ To run all unit tests in a directory or file (using the directory
 `Tests/Unit/Model/` as an example):
 
 ```bash
-.Build/vendor/bin/phpunit -c Configuration/UnitTests.xml Tests/Unit/Model/
+.Build/vendor/bin/phpunit -c Build/phpunit/UnitTests.xml Tests/Unit/Model/
 ```
 
 #### In PhpStorm
@@ -64,7 +64,7 @@ the script path `.Build/vendor/autoload.php` within your project.
 In the Run/Debug configurations for PHPUnit, use an alternative configuration
 file:
 
-`Configuration/UnitTests.xml`
+`Build/phpunit/UnitTests.xml`
 
 ### Running the functional tests
 
@@ -97,7 +97,7 @@ To run all functional tests in a directory or file (using the directory
 `Tests/Functional/Authentication/` as an example):
 
 ```bash
-typo3DatabaseUsername=typo3 typo3DatabasePassword=typo3pass typo3DatabaseName=typo3_test .Build/vendor/bin/phpunit -c Configuration/FunctionalTests.xml Tests/Functional/Authentication/
+typo3DatabaseUsername=typo3 typo3DatabasePassword=typo3pass typo3DatabaseName=typo3_test .Build/vendor/bin/phpunit -c Build/phpunit/FunctionalTests.xml Tests/Functional/Authentication/
 ```
 
 #### In PhpStorm
@@ -112,7 +112,7 @@ the script path `.Build/vendor/autoload.php` within your project.
 In the Run/Debug configurations for PHPUnit, use an alternative configuration
 file:
 
-`Configuration/FunctionalTests.xml`
+`Build/phpunit/FunctionalTests.xml`
 
 Also set the following environment variables in your runner configuration:
 
@@ -125,4 +125,4 @@ Also set the following environment variables in your runner configuration:
 Running the legacy tests works exactly the same as running the functional tests,
 except that you run the tests in `Tests/LegacyFunctional/` instead
 of `Tests/Functional/`. You'll still need to use the configuration file
-`Configuration/FunctionalTests.xml`, though.
+`Build/phpunit/FunctionalTests.xml`, though.

--- a/composer.json
+++ b/composer.json
@@ -121,11 +121,11 @@
 		],
 		"ci:coverage:functional": [
 			"@coverage:create-directories",
-			"find 'Tests/Functional' -wholename '*Test.php' | parallel --gnu 'echo; echo \"Running functional test suite {}\"; .Build/vendor/bin/phpunit -c Configuration/FunctionalTests.xml --whitelist Classes --coverage-php=\".Build/coverage/{}.cov\" {}';"
+			"find 'Tests/Functional' -wholename '*Test.php' | parallel --gnu 'echo; echo \"Running functional test suite {}\"; .Build/vendor/bin/phpunit -c Build/phpunit/FunctionalTests.xml --whitelist Classes --coverage-php=\".Build/coverage/{}.cov\" {}';"
 		],
 		"ci:coverage:legacy-functional": [
 			"@coverage:create-directories",
-			"find 'Tests/LegacyFunctional' -wholename '*Test.php' | parallel --gnu 'echo; echo \"Running legacy functional test suite {}\"; .Build/vendor/bin/phpunit -c Configuration/FunctionalTests.xml --whitelist Classes --coverage-php=\".Build/coverage/{}.cov\" {}';"
+			"find 'Tests/LegacyFunctional' -wholename '*Test.php' | parallel --gnu 'echo; echo \"Running legacy functional test suite {}\"; .Build/vendor/bin/phpunit -c Build/phpunit/FunctionalTests.xml --whitelist Classes --coverage-php=\".Build/coverage/{}.cov\" {}';"
 		],
 		"ci:coverage:merge": [
 			"@coverage:create-directories",
@@ -133,7 +133,7 @@
 		],
 		"ci:coverage:unit": [
 			"@coverage:create-directories",
-			".Build/vendor/bin/phpunit -c Configuration/UnitTests.xml --whitelist Classes --coverage-php=.Build/coverage/unit.cov Tests/Unit"
+			".Build/vendor/bin/phpunit -c Build/phpunit/UnitTests.xml --whitelist Classes --coverage-php=.Build/coverage/unit.cov Tests/Unit"
 		],
 		"ci:php": [
 			"@ci:php:cs-fixer",
@@ -157,9 +157,9 @@
 			"@ci:ts:lint",
 			"@ci:xliff:lint"
 		],
-		"ci:tests:functional": "find 'Tests/Functional' -wholename '*Test.php' | parallel --gnu 'echo; echo \"Running functional test suite {}\"; .Build/vendor/bin/phpunit -c Configuration/FunctionalTests.xml {}';",
-		"ci:tests:legacy-functional": "find 'Tests/LegacyFunctional' -wholename '*Test.php' | parallel --gnu 'echo; echo \"Running legacy functional test suite {}\"; .Build/vendor/bin/phpunit -c Configuration/FunctionalTests.xml {}';",
-		"ci:tests:unit": ".Build/vendor/bin/phpunit -c Configuration/UnitTests.xml Tests/Unit",
+		"ci:tests:functional": "find 'Tests/Functional' -wholename '*Test.php' | parallel --gnu 'echo; echo \"Running functional test suite {}\"; .Build/vendor/bin/phpunit -c Build/phpunit/FunctionalTests.xml {}';",
+		"ci:tests:legacy-functional": "find 'Tests/LegacyFunctional' -wholename '*Test.php' | parallel --gnu 'echo; echo \"Running legacy functional test suite {}\"; .Build/vendor/bin/phpunit -c Build/phpunit/FunctionalTests.xml {}';",
+		"ci:tests:unit": ".Build/vendor/bin/phpunit -c Build/phpunit/UnitTests.xml Tests/Unit",
 		"ci:ts:lint": ".Build/vendor/bin/typoscript-lint -c Configuration/TypoScriptLint.yaml --ansi -n --fail-on-warnings -vvv Configuration/TypoScript",
 		"ci:xliff:lint": "php Build/xliff/xliff-lint lint:xliff Resources/Private/Language",
 		"coverage:create-directories": "mkdir -p build/logs .Build/coverage",
@@ -183,6 +183,7 @@
 			"rm -rf .github",
 			"rm -rf .idea",
 			"rm -rf .phive",
+			"rm -rf Build",
 			"rm -rf Tests",
 			"rm -rf var",
 			"rm .editorconfig",
@@ -190,9 +191,7 @@
 			"rm .gitignore",
 			"rm .php-cs-fixer.cache",
 			"rm .php-cs-fixer.php",
-			"rm Configuration/FunctionalTests.xml",
 			"rm Configuration/TypoScriptLint.yaml",
-			"rm Configuration/UnitTests.xml",
 			"rm composer-unused.php",
 			"rm composer.lock",
 			"rm crowdin.yml",


### PR DESCRIPTION
This follows current best practices.