### PR TITLE
[BUGFIX] Use variadic parameters when calling `logicalAnd`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
-- Add `EventRepository::findInPast()` (#3885)
+- Add `EventRepository::findInPast()` (#3885, #3887)
 - Show a confirmation dialog when deleting a record in the BE module (#3849)
 - Add button in the BE module to create an event (#3845)
 - Add upgrade notes (#3710)

--- a/Classes/Domain/Repository/Event/EventRepository.php
+++ b/Classes/Domain/Repository/Event/EventRepository.php
@@ -321,7 +321,7 @@ class EventRepository extends AbstractRawDataCapableRepository implements Direct
         $now = (int)GeneralUtility::makeInstance(Context::class)->getPropertyFromAspect('date', 'timestamp');
         $endInPastMatcher = $query->lessThan('endDate', $now);
         $query->matching(
-            $query->logicalAnd([$objectTypeMatcher, $statusMatcher, $startMatcher, $endSetMatcher, $endInPastMatcher])
+            $query->logicalAnd($objectTypeMatcher, $statusMatcher, $startMatcher, $endSetMatcher, $endInPastMatcher)
         );
         $query->setOrderings(['begin_date' => QueryInterface::ORDER_DESCENDING]);
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -246,6 +246,11 @@ parameters:
 			path: Classes/Domain/Repository/Event/EventRepository.php
 
 		-
+			message: "#^Method TYPO3\\\\CMS\\\\Extbase\\\\Persistence\\\\QueryInterface\\<OliverKlee\\\\Seminars\\\\Domain\\\\Model\\\\Event\\\\Event\\>\\:\\:logicalAnd\\(\\) invoked with 5 parameters, 1 required\\.$#"
+			count: 1
+			path: Classes/Domain/Repository/Event/EventRepository.php
+
+		-
 			message: "#^Cannot cast mixed to int\\.$#"
 			count: 1
 			path: Classes/Domain/Repository/Registration/RegistrationRepository.php


### PR DESCRIPTION
Followup to #3885
Fixes #3886