### PR TITLE
[TASK] Shorten the registation/unregistration link label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- Shorten the registation link label (#3921)
 - Use responsive Bootstrap tables in the FE and BE (#3897, #3901, #3916)
 - Display "will be announced" in fewer places (#3816, #3836)
 - Make the `RegistrationManager` a proper TYPO3 singleton (#3782)

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -820,7 +820,7 @@ This event now has been confirmed.</source>
 				<source>Attached files</source>
 			</trans-unit>
 			<trans-unit id="label_onlineRegistration">
-				<source>Register now</source>
+				<source>Register</source>
 			</trans-unit>
 			<trans-unit id="label_onlineRegistrationOnQueue">
 				<source>Register for the waiting list&lt;br /&gt;(%d registrations on the waiting list)</source>
@@ -829,7 +829,7 @@ This event now has been confirmed.</source>
 				<source>Prebook now</source>
 			</trans-unit>
 			<trans-unit id="label_onlineUnregistration">
-				<source>Unregister now</source>
+				<source>Unregister</source>
 			</trans-unit>
 			<trans-unit id="label_list_registrations">
 				<source>List of registrations</source>


### PR DESCRIPTION
This reduces the width of the FE events list, which is particularly helpful on mobile devices.

Fixes #3919