### PR TITLE
[TASK] Shorten the link label for the waiting list registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- Shorten the link label for the waiting list registration (#3926)
 - Make some TCEforms labels more specific (#3924, #3925)
 - Shorten the registation link label (#3921)
 - Use responsive Bootstrap tables in the FE and BE (#3897, #3901, #3916)

--- a/Classes/Service/RegistrationManager.php
+++ b/Classes/Service/RegistrationManager.php
@@ -196,10 +196,7 @@ class RegistrationManager implements SingletonInterface
                 $label = $this->translate('label_onlinePrebooking');
             }
         } elseif ($event->hasRegistrationQueue()) {
-            $label = \sprintf(
-                $this->translate('label_onlineRegistrationOnQueue'),
-                $event->getAttendancesOnRegistrationQueue()
-            );
+            $label = \sprintf($this->translate('label_onlineRegistrationOnQueue'), '');
         } else {
             $label = $this->translate('label_onlineRegistration');
         }

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -823,10 +823,10 @@ This event now has been confirmed.</source>
 				<source>Register</source>
 			</trans-unit>
 			<trans-unit id="label_onlineRegistrationOnQueue">
-				<source>Register for the waiting list&lt;br /&gt;(%d registrations on the waiting list)</source>
+				<source>Waiting list</source>
 			</trans-unit>
 			<trans-unit id="label_onlinePrebooking">
-				<source>Prebook now</source>
+				<source>Prebook</source>
 			</trans-unit>
 			<trans-unit id="label_onlineUnregistration">
 				<source>Unregister</source>

--- a/Tests/Functional/Service/RegistrationManagerTest.php
+++ b/Tests/Functional/Service/RegistrationManagerTest.php
@@ -422,7 +422,7 @@ final class RegistrationManagerTest extends FunctionalTestCase
 
         $result = $this->subject->getLinkToRegistrationPage($plugin, $event);
 
-        $expected = \sprintf($this->translate('label_onlineRegistrationOnQueue'), 0);
+        $expected = $this->translate('label_onlineRegistrationOnQueue');
         self::assertStringContainsString($expected, $result);
     }
 

--- a/Tests/LegacyFunctional/FrontEnd/DefaultControllerTest.php
+++ b/Tests/LegacyFunctional/FrontEnd/DefaultControllerTest.php
@@ -4240,10 +4240,7 @@ final class DefaultControllerTest extends FunctionalTestCase
         );
 
         self::assertStringContainsString(
-            sprintf(
-                $this->translate('label_onlineRegistrationOnQueue'),
-                0
-            ),
+            $this->translate('label_onlineRegistrationOnQueue'),
             $this->subject->main('', [])
         );
     }
@@ -4276,10 +4273,7 @@ final class DefaultControllerTest extends FunctionalTestCase
         );
 
         self::assertStringNotContainsString(
-            sprintf(
-                $this->translate('label_onlineRegistrationOnQueue'),
-                0
-            ),
+            $this->translate('label_onlineRegistrationOnQueue'),
             $this->subject->main('', [])
         );
     }
@@ -5016,10 +5010,7 @@ final class DefaultControllerTest extends FunctionalTestCase
         $this->subject->piVars['showUid'] = $this->seminarUid;
 
         self::assertStringContainsString(
-            sprintf(
-                $this->translate('label_onlineRegistrationOnQueue'),
-                0
-            ),
+            $this->translate('label_onlineRegistrationOnQueue'),
             $this->subject->main('', [])
         );
     }
@@ -5055,10 +5046,7 @@ final class DefaultControllerTest extends FunctionalTestCase
         $this->subject->piVars['showUid'] = $this->seminarUid;
 
         self::assertStringNotContainsString(
-            sprintf(
-                $this->translate('label_onlineRegistrationOnQueue'),
-                0
-            ),
+            $this->translate('label_onlineRegistrationOnQueue'),
             $this->subject->main('', [])
         );
     }


### PR DESCRIPTION
This helps reduce the width and height of the event list view, particularly on mobile devices.

Also shorten the label for prebooking.

Fixes #3925