### PR TITLE
[TASK] Use the term "event" instead of "seminars" in the TCEforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- Use the term "event" instead of "seminars" in the TCEforms (#3928)
 - Shorten the link label for the waiting list registration (#3926)
 - Make some TCEforms labels more specific (#3924, #3925, #3927)
 - Shorten the registation link label (#3921)

--- a/Resources/Private/Language/locallang_db.xlf
+++ b/Resources/Private/Language/locallang_db.xlf
@@ -23,7 +23,7 @@
 				<source>Gender</source>
 			</trans-unit>
 			<trans-unit id="tx_seminars_seminars">
-				<source>Seminars</source>
+				<source>Event</source>
 			</trans-unit>
 			<trans-unit id="tx_seminars_seminars.divLabelGeneral">
 				<source>General</source>
@@ -359,7 +359,7 @@
 				<source>Front-end User</source>
 			</trans-unit>
 			<trans-unit id="tx_seminars_attendances.seminar">
-				<source>Seminar</source>
+				<source>Event</source>
 			</trans-unit>
 			<trans-unit id="tx_seminars_attendances.registration_queue">
 				<source>Is on the registration queue</source>


### PR DESCRIPTION
This record type represents all types of events, not only seminars.

Fixes #3466