### PR TITLE
[TASK] Improve the label for "register myself (as well)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- Improve the label for "register myself (as well)" (#3929)
 - Use the term "event" instead of "seminars" in the TCEforms (#3928)
 - Shorten the link label for the waiting list registration (#3926)
 - Make some TCEforms labels more specific (#3924, #3925, #3927)

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -874,7 +874,7 @@ This event now has been confirmed.</source>
 				<source>Persons to register:</source>
 			</trans-unit>
 			<trans-unit id="label_registered_themselves">
-				<source>myself</source>
+				<source>myself (too)</source>
 			</trans-unit>
 			<trans-unit id="label_firstname">
 				<source>First name:</source>
@@ -1124,7 +1124,7 @@ This event now has been confirmed.</source>
 				<source>Maximum bookable seats per registration</source>
 			</trans-unit>
 			<trans-unit id="plugin.eventRegistration.settings.registerThemselvesDefault">
-				<source>People register themselves by default</source>
+				<source>People register themselves (too) by default</source>
 			</trans-unit>
 			<trans-unit id="plugin.eventRegistration.settings.showEmailFieldForAdditionalAttendees">
 				<source>Show an email field for additional attendees</source>
@@ -1142,7 +1142,7 @@ This event now has been confirmed.</source>
 				<source>Seats</source>
 			</trans-unit>
 			<trans-unit id="plugin.eventRegistration.settings.fieldsToShow.registeredThemselves">
-				<source>Is registering themselves</source>
+				<source>Is registering themselves (too)</source>
 			</trans-unit>
 			<trans-unit id="plugin.eventRegistration.settings.fieldsToShow.attendeesNames">
 				<source>Persons to register</source>
@@ -1340,7 +1340,7 @@ This event now has been confirmed.</source>
 				<source>Seats to book</source>
 			</trans-unit>
 			<trans-unit id="plugin.eventRegistration.property.registeredThemselves">
-				<source>I am registering myself.</source>
+				<source>I am registering myself (too).</source>
 			</trans-unit>
 			<trans-unit id="plugin.eventRegistration.property.registeredThemselves.not">
 				<source>I am not registering myself.</source>

--- a/Resources/Private/Language/locallang_db.xlf
+++ b/Resources/Private/Language/locallang_db.xlf
@@ -464,7 +464,7 @@
 				<source>Additional notes</source>
 			</trans-unit>
 			<trans-unit id="tx_seminars_attendances.registered_themselves">
-				<source>Has signed up themselves</source>
+				<source>Has signed up themselves (too)</source>
 			</trans-unit>
 			<trans-unit id="tx_seminars_attendances.seats">
 				<source>Number of seats</source>


### PR DESCRIPTION
The label now communicates better that there can be additional attendees, too.

Fixes #3662