### PR TITLE
[TASK] Drop `Event.hasQueueRegistrations`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,7 +53,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Removed
 
-- Drop some `Event` methods that are only used for tests (#3932, #3933)
+- Drop some `Event` methods that are only used for tests (#3932, #3933, #3934)
 - Drop the single view links from the emails (#3931)
 - Remove unneeded `resname` from the language files (#3871)
 - Drop unused old models and mappers

--- a/Classes/Model/Event.php
+++ b/Classes/Model/Event.php
@@ -452,17 +452,6 @@ class Event extends AbstractTimeSpan
     }
 
     /**
-     * Checks whether this event has any registrations on its registration
-     * queue (i.e., on the waiting list).
-     *
-     * @deprecated #1324 will be removed in seminars 6.0
-     */
-    public function hasQueueRegistrations(): bool
-    {
-        return !$this->getQueueRegistrations()->isEmpty();
-    }
-
-    /**
      * @return Collection<Registration>
      *
      * @deprecated will be removed in version 6.0 in #3422

--- a/Tests/LegacyFunctional/Model/EventTest.php
+++ b/Tests/LegacyFunctional/Model/EventTest.php
@@ -167,27 +167,6 @@ final class EventTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function hasQueueRegistrationsForOneQueueRegistrationReturnsTrue(): void
-    {
-        $registrations = new Collection();
-        $registration = MapperRegistry::get(RegistrationMapper::class)
-            ->getLoadedTestingModel(['registration_queue' => 1]);
-        $registrations->add($registration);
-        $event = $this->createPartialMock(
-            Event::class,
-            ['getQueueRegistrations']
-        );
-        $event->method('getQueueRegistrations')
-            ->willReturn($registrations);
-
-        self::assertTrue(
-            $event->hasQueueRegistrations()
-        );
-    }
-
-    /**
-     * @test
-     */
     public function getRegisteredSeatsCountsSingleSeatRegularRegistrations(): void
     {
         $registrations = new Collection();

--- a/Tests/Unit/Model/EventTest.php
+++ b/Tests/Unit/Model/EventTest.php
@@ -1006,23 +1006,6 @@ final class EventTest extends UnitTestCase
         self::assertTrue($this->subject->getRegistrationsAfterLastDigest()->isEmpty());
     }
 
-    /**
-     * @test
-     */
-    public function hasQueueRegistrationsForNoQueueRegistrationReturnsFalse(): void
-    {
-        $event = $this->createPartialMock(
-            Event::class,
-            ['getQueueRegistrations']
-        );
-        $event->method('getQueueRegistrations')
-            ->willReturn(new Collection());
-
-        self::assertFalse(
-            $event->hasQueueRegistrations()
-        );
-    }
-
     //////////////////////////////////////////////////////////////////////
     // Tests concerning hasUnlimitedVacancies
     //////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
This method is only called from tests.

Part of #3422