### PR TITLE
[TASK] Drop `Event.hasVacancies` and `.hasUnlimitedVacancies`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,7 +54,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Removed
 
 - Drop some `Event` methods that are only called from tests
-  (#3932, #3933, #3934, #3935)
+  (#3932, #3933, #3934, #3935, #3936)
 - Drop the single view links from the emails (#3931)
 - Remove unneeded `resname` from the language files (#3871)
 - Drop unused old models and mappers

--- a/Classes/Model/Event.php
+++ b/Classes/Model/Event.php
@@ -287,16 +287,6 @@ class Event extends AbstractTimeSpan
         return $this->getAsInteger('attendees_max');
     }
 
-    public function hasMaximumAttendees(): bool
-    {
-        return $this->hasInteger('attendees_max');
-    }
-
-    public function hasUnlimitedVacancies(): bool
-    {
-        return !$this->hasMaximumAttendees();
-    }
-
     /**
      * @return EventInterface::STATUS_*
      */
@@ -524,23 +514,6 @@ class Event extends AbstractTimeSpan
             0,
             $this->getMaximumAttendees() - $this->getRegisteredSeats()
         );
-    }
-
-    /**
-     * Checks whether this event has at least one vacancy.
-     *
-     * If this event has an unlimited number of possible registrations, this
-     * function will always return TRUE.
-     *
-     * @deprecated will be removed in version 6.0 in #3422
-     */
-    public function hasVacancies(): bool
-    {
-        if ($this->hasUnlimitedVacancies()) {
-            return true;
-        }
-
-        return $this->getVacancies() > 0;
     }
 
     /**

--- a/Tests/Unit/Model/EventTest.php
+++ b/Tests/Unit/Model/EventTest.php
@@ -610,30 +610,6 @@ final class EventTest extends UnitTestCase
         );
     }
 
-    /**
-     * @test
-     */
-    public function hasMaximumAttendeesWithoutMaximumAttendeesReturnsFalse(): void
-    {
-        $this->subject->setData([]);
-
-        self::assertFalse(
-            $this->subject->hasMaximumAttendees()
-        );
-    }
-
-    /**
-     * @test
-     */
-    public function hasMaximumAttendeesWithMaximumAttendeesReturnsTrue(): void
-    {
-        $this->subject->setData(['attendees_max' => 42]);
-
-        self::assertTrue(
-            $this->subject->hasMaximumAttendees()
-        );
-    }
-
     // Tests regarding the status.
 
     /**
@@ -1006,34 +982,6 @@ final class EventTest extends UnitTestCase
         self::assertTrue($this->subject->getRegistrationsAfterLastDigest()->isEmpty());
     }
 
-    //////////////////////////////////////////////////////////////////////
-    // Tests concerning hasUnlimitedVacancies
-    //////////////////////////////////////////////////////////////////////
-
-    /**
-     * @test
-     */
-    public function hasUnlimitedVacanciesForMaxAttendeesZeroReturnsTrue(): void
-    {
-        $this->subject->setData(['attendees_max' => 0]);
-
-        self::assertTrue(
-            $this->subject->hasUnlimitedVacancies()
-        );
-    }
-
-    /**
-     * @test
-     */
-    public function hasUnlimitedVacanciesForMaxAttendeesOneReturnsFalse(): void
-    {
-        $this->subject->setData(['attendees_max' => 1]);
-
-        self::assertFalse(
-            $this->subject->hasUnlimitedVacancies()
-        );
-    }
-
     ////////////////////////////////////////
     // Tests concerning getRegisteredSeats
     ////////////////////////////////////////
@@ -1229,82 +1177,6 @@ final class EventTest extends UnitTestCase
         self::assertSame(
             0,
             $event->getVacancies()
-        );
-    }
-
-    //////////////////////////////////
-    // Tests concerning hasVacancies
-    //////////////////////////////////
-
-    /**
-     * @test
-     */
-    public function hasVacanciesForOneRegisteredAndTwoMaximumReturnsTrue(): void
-    {
-        $event = $this->createPartialMock(
-            Event::class,
-            ['getRegisteredSeats']
-        );
-        $event->setData(['attendees_max' => 2]);
-        $event->method('getRegisteredSeats')
-            ->willReturn(1);
-
-        self::assertTrue(
-            $event->hasVacancies()
-        );
-    }
-
-    /**
-     * @test
-     */
-    public function hasVacanciesForAsManySeatsRegisteredAsMaximumReturnsFalse(): void
-    {
-        $event = $this->createPartialMock(
-            Event::class,
-            ['getRegisteredSeats']
-        );
-        $event->setData(['attendees_max' => 2]);
-        $event->method('getRegisteredSeats')
-            ->willReturn(2);
-
-        self::assertFalse(
-            $event->hasVacancies()
-        );
-    }
-
-    /**
-     * @test
-     */
-    public function hasVacanciesForAsMoreSeatsRegisteredThanMaximumReturnsFalse(): void
-    {
-        $event = $this->createPartialMock(
-            Event::class,
-            ['getRegisteredSeats']
-        );
-        $event->setData(['attendees_max' => 1]);
-        $event->method('getRegisteredSeats')
-            ->willReturn(2);
-
-        self::assertFalse(
-            $event->hasVacancies()
-        );
-    }
-
-    /**
-     * @test
-     */
-    public function hasVacanciesForNonZeroSeatsRegisteredAndUnlimitedVacanciesReturnsTrue(): void
-    {
-        $event = $this->createPartialMock(
-            Event::class,
-            ['getRegisteredSeats']
-        );
-        $event->setData(['attendees_max' => 0]);
-        $event->method('getRegisteredSeats')
-            ->willReturn(1);
-
-        self::assertTrue(
-            $event->hasVacancies()
         );
     }
 


### PR DESCRIPTION
These methods are only called from tests.

Part of #3422