### PR TITLE
[TASK] Drop `Event.getQueueRegistrations`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,7 +54,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Removed
 
 - Drop some `Event` methods that are only called from tests
-  (#3932, #3933, #3934, #3935, #3936, #3937)
+  (#3932, #3933, #3934, #3935, #3936, #3937, #3938)
 - Drop the single view links from the emails (#3931)
 - Remove unneeded `resname` from the language files (#3871)
 - Drop unused old models and mappers

--- a/Classes/Model/Event.php
+++ b/Classes/Model/Event.php
@@ -418,30 +418,6 @@ class Event extends AbstractTimeSpan
     }
 
     /**
-     * Gets the queue registrations for this event, i.e., the registrations
-     * that are no regular registrations (yet).
-     *
-     * @return Collection<Registration> the queue registrations for this event, will be
-     *                       will be empty if this event no queue registrations
-     *
-     * @deprecated #1324 will be removed in seminars 6.0
-     */
-    public function getQueueRegistrations(): Collection
-    {
-        /** @var Collection<Registration> $queueRegistrations */
-        $queueRegistrations = new Collection();
-
-        /** @var Registration $registration */
-        foreach ($this->getRegistrations() as $registration) {
-            if ($registration->isOnRegistrationQueue()) {
-                $queueRegistrations->add($registration);
-            }
-        }
-
-        return $queueRegistrations;
-    }
-
-    /**
      * @return Collection<Registration>
      *
      * @deprecated will be removed in version 6.0 in #3422

--- a/Tests/LegacyFunctional/Model/EventTest.php
+++ b/Tests/LegacyFunctional/Model/EventTest.php
@@ -135,38 +135,6 @@ final class EventTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function getQueueRegistrationsReturnsQueueRegistrations(): void
-    {
-        /** @var Collection<Registration> $registrations */
-        $registrations = new Collection();
-        $registration = MapperRegistry::get(RegistrationMapper::class)
-            ->getLoadedTestingModel(['registration_queue' => 1]);
-        $registrations->add($registration);
-        $this->subject->setRegistrations($registrations);
-
-        self::assertEquals(
-            $registration->getUid(),
-            $this->subject->getQueueRegistrations()->getUids()
-        );
-    }
-
-    public function getQueueRegistrationsNotReturnsRegularRegistrations(): void
-    {
-        /** @var Collection<Registration> $registrations */
-        $registrations = new Collection();
-        $registration = MapperRegistry::get(RegistrationMapper::class)
-            ->getLoadedTestingModel(['registration_queue' => 0]);
-        $registrations->add($registration);
-        $this->subject->setRegistrations($registrations);
-
-        self::assertTrue(
-            $this->subject->getQueueRegistrations()->isEmpty()
-        );
-    }
-
-    /**
-     * @test
-     */
     public function getRegisteredSeatsCountsSingleSeatRegularRegistrations(): void
     {
         $registrations = new Collection();
@@ -216,22 +184,12 @@ final class EventTest extends FunctionalTestCase
     public function getRegisteredSeatsNotCountsQueueRegistrations(): void
     {
         $queueRegistrations = new Collection();
-        $registration = MapperRegistry::get(RegistrationMapper::class)
-            ->getLoadedTestingModel(['seats' => 1]);
+        $registration = MapperRegistry::get(RegistrationMapper::class)->getLoadedTestingModel(['seats' => 1]);
         $queueRegistrations->add($registration);
-        $event = $this->createPartialMock(
-            Event::class,
-            ['getRegularRegistrations', 'getQueueRegistrations']
-        );
+        $event = $this->createPartialMock(Event::class, ['getRegularRegistrations']);
         $event->setData([]);
-        $event->method('getQueueRegistrations')
-            ->willReturn($queueRegistrations);
-        $event->method('getRegularRegistrations')
-            ->willReturn(new Collection());
+        $event->method('getRegularRegistrations')->willReturn(new Collection());
 
-        self::assertEquals(
-            0,
-            $event->getRegisteredSeats()
-        );
+        self::assertSame(0, $event->getRegisteredSeats());
     }
 }


### PR DESCRIPTION
This method is only called from tests.

Part of #3422