### PR TITLE
[TASK] Drop `Event.getRegistrationsAfterLastDigest`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,7 +54,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Removed
 
 - Drop some `Event` methods that are only called from tests
-  (#3932, #3933, #3934, #3935, #3936, #3937, #3938)
+  (#3932, #3933, #3934, #3935, #3936, #3937, #3938, #3941)
 - Drop the single view links from the emails (#3931)
 - Remove unneeded `resname` from the language files (#3871)
 - Drop unused old models and mappers

--- a/Classes/Model/Event.php
+++ b/Classes/Model/Event.php
@@ -418,27 +418,6 @@ class Event extends AbstractTimeSpan
     }
 
     /**
-     * @return Collection<Registration>
-     *
-     * @deprecated will be removed in version 6.0 in #3422
-     */
-    public function getRegistrationsAfterLastDigest(): Collection
-    {
-        /** @var Collection<Registration> $newerRegistrations */
-        $newerRegistrations = new Collection();
-        $dateOfLastDigest = $this->getDateOfLastRegistrationDigestEmailAsUnixTimeStamp();
-
-        /** @var Registration $registration */
-        foreach ($this->getRegistrations() as $registration) {
-            if ($registration->getCreationDateAsUnixTimeStamp() > $dateOfLastDigest) {
-                $newerRegistrations->add($registration);
-            }
-        }
-
-        return $newerRegistrations;
-    }
-
-    /**
      * Returns the number of regularly registered seats for this event.
      *
      * This functions counts the number of registered seats from regular

--- a/Tests/Unit/Model/EventTest.php
+++ b/Tests/Unit/Model/EventTest.php
@@ -930,57 +930,6 @@ final class EventTest extends UnitTestCase
         );
     }
 
-    /**
-     * @test
-     */
-    public function getRegistrationsAfterLastDigestReturnsNewerRegistrations(): void
-    {
-        $this->subject->setDateOfLastRegistrationDigestEmailAsUnixTimeStamp(1);
-
-        /** @var Collection<Registration> $registrations */
-        $registrations = new Collection();
-        $registration = new Registration();
-        $registration->setData(['crdate' => 2]);
-        $registrations->add($registration);
-        $this->subject->setRegistrations($registrations);
-
-        self::assertContains($registration, $this->subject->getRegistrationsAfterLastDigest());
-    }
-
-    /**
-     * @test
-     */
-    public function getRegistrationsAfterLastDigestNotReturnsOlderRegistrations(): void
-    {
-        $this->subject->setDateOfLastRegistrationDigestEmailAsUnixTimeStamp(2);
-
-        /** @var Collection<Registration> $registrations */
-        $registrations = new Collection();
-        $registration = new Registration();
-        $registration->setData(['crdate' => 1]);
-        $registrations->add($registration);
-        $this->subject->setRegistrations($registrations);
-
-        self::assertTrue($this->subject->getRegistrationsAfterLastDigest()->isEmpty());
-    }
-
-    /**
-     * @test
-     */
-    public function getRegistrationsAfterLastDigestNotReturnsRegistrationsExactlyAtDigestDate(): void
-    {
-        $this->subject->setDateOfLastRegistrationDigestEmailAsUnixTimeStamp(1);
-
-        /** @var Collection<Registration> $registrations */
-        $registrations = new Collection();
-        $registration = new Registration();
-        $registration->setData(['crdate' => 1]);
-        $registrations->add($registration);
-        $this->subject->setRegistrations($registrations);
-
-        self::assertTrue($this->subject->getRegistrationsAfterLastDigest()->isEmpty());
-    }
-
     ////////////////////////////////////////
     // Tests concerning getRegisteredSeats
     ////////////////////////////////////////


### PR DESCRIPTION
This method is only called from tests.

Part of #3422