### PR TITLE
[TASK] Make `enrichWithStatistics` keep existing statistics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- Make `enrichWithStatistics` keep existing statistics (#4032)
 - Make `RegistrationDigest` a singleton (#4002)
 - Move the webinar URL further up in the TCEforms (#3975)
 - Move determining the email sender out of the models (#3965)

--- a/Classes/Service/EventStatisticsCalculator.php
+++ b/Classes/Service/EventStatisticsCalculator.php
@@ -25,10 +25,15 @@ class EventStatisticsCalculator implements SingletonInterface
 
     /**
      * Calculates and sets `$event.statistics` if the event allows registration in general.
+     *
+     * If the statistics already exist for the given event, the existing statistics will be kept and not overwritten.
      */
     public function enrichWithStatistics(Event $event): void
     {
-        if (!$event instanceof EventDateInterface) {
+        if (!($event instanceof EventDateInterface)) {
+            return;
+        }
+        if ($event->getStatistics() instanceof EventStatistics) {
             return;
         }
 

--- a/Tests/Unit/Service/EventStatisticsCalculatorTest.php
+++ b/Tests/Unit/Service/EventStatisticsCalculatorTest.php
@@ -57,7 +57,7 @@ final class EventStatisticsCalculatorTest extends UnitTestCase
     /**
      * @test
      */
-    public function enrichWithStatisticsForEventDateWithoutRegistrationStatistics(): void
+    public function enrichWithStatisticsForEventDateWithoutRegistrationSetsStatistics(): void
     {
         $event = new EventDate();
 
@@ -69,7 +69,7 @@ final class EventStatisticsCalculatorTest extends UnitTestCase
     /**
      * @test
      */
-    public function enrichWithStatisticsForSingleEventWithoutRegistrationStatistics(): void
+    public function enrichWithStatisticsForSingleEventWithoutRegistrationSetsStatistics(): void
     {
         $event = new SingleEvent();
 
@@ -89,6 +89,23 @@ final class EventStatisticsCalculatorTest extends UnitTestCase
         $this->subject->enrichWithStatistics($event);
 
         self::assertInstanceOf(EventStatistics::class, $event->getStatistics());
+    }
+
+    /**
+     * @test
+     */
+    public function enrichWithStatisticsCalledTwiceReturnsSameStatistics(): void
+    {
+        $event = new SingleEvent();
+        $event->setRegistrationRequired(true);
+
+        $this->subject->enrichWithStatistics($event);
+        $statisticsAfterFirstCall = $event->getStatistics();
+
+        $this->subject->enrichWithStatistics($event);
+        $statisticsAfterSecondCall = $event->getStatistics();
+
+        self::assertSame($statisticsAfterFirstCall, $statisticsAfterSecondCall);
     }
 
     /**


### PR DESCRIPTION
This helps improve performance in the list view.

Also add missing words to some test names.