### PR TITLE
[TASK] Rename `Event.allowsUnlimitedRegistrations`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- Rename `Event.allowsUnlimitedRegistrations` (#4046)
 - Allow `typo3fluid/fluid:^4.0` (#4041)
 - Make `enrichWithStatistics` keep existing statistics (#4032)
 - Make `RegistrationDigest` a singleton (#4002)

--- a/Classes/Domain/Model/Event/EventDateInterface.php
+++ b/Classes/Domain/Model/Event/EventDateInterface.php
@@ -129,7 +129,7 @@ interface EventDateInterface
      */
     public function getAllPrices(): array;
 
-    public function allowsUnlimitedRegistrations(): bool;
+    public function hasUnlimitedSeats(): bool;
 
     public function setStatistics(EventStatistics $statistics): void;
 

--- a/Classes/Domain/Model/Event/EventDateTrait.php
+++ b/Classes/Domain/Model/Event/EventDateTrait.php
@@ -441,7 +441,7 @@ trait EventDateTrait
         $this->registrationCheckboxes = $registrationCheckboxes;
     }
 
-    public function allowsUnlimitedRegistrations(): bool
+    public function hasUnlimitedSeats(): bool
     {
         return $this->isRegistrationRequired() && $this->getMaximumNumberOfRegistrations() === 0;
     }

--- a/Classes/Service/RegistrationGuard.php
+++ b/Classes/Service/RegistrationGuard.php
@@ -169,7 +169,7 @@ class RegistrationGuard implements SingletonInterface
             return $this->vacanciesCache[$eventUid];
         }
 
-        if ($event->allowsUnlimitedRegistrations()) {
+        if ($event->hasUnlimitedSeats()) {
             $this->vacanciesCache[$eventUid] = null;
             return null;
         }

--- a/Tests/Unit/Domain/Model/Event/EventDateTest.php
+++ b/Tests/Unit/Domain/Model/Event/EventDateTest.php
@@ -1016,34 +1016,34 @@ final class EventDateTest extends UnitTestCase
     /**
      * @test
      */
-    public function allowsUnlimitedRegistrationsForZeroMaxRegistrationsAndRegistrationRequiredReturnsTrue(): void
+    public function hasUnlimitedSeatsForZeroMaxRegistrationsAndRegistrationRequiredReturnsTrue(): void
     {
         $this->subject->setMaximumNumberOfRegistrations(0);
         $this->subject->setRegistrationRequired(true);
 
-        self::assertTrue($this->subject->allowsUnlimitedRegistrations());
+        self::assertTrue($this->subject->hasUnlimitedSeats());
     }
 
     /**
      * @test
      */
-    public function allowsUnlimitedRegistrationsForNonZeroMaxRegistrationsAndRegistrationRequiredReturnsFalse(): void
+    public function hasUnlimitedSeatsForNonZeroMaxRegistrationsAndRegistrationRequiredReturnsFalse(): void
     {
         $this->subject->setMaximumNumberOfRegistrations(10);
         $this->subject->setRegistrationRequired(true);
 
-        self::assertFalse($this->subject->allowsUnlimitedRegistrations());
+        self::assertFalse($this->subject->hasUnlimitedSeats());
     }
 
     /**
      * @test
      */
-    public function allowsUnlimitedRegistrationsForZeroMaxRegistrationsAndRegistrationNotRequiredReturnsFalse(): void
+    public function hasUnlimitedSeatsForZeroMaxRegistrationsAndRegistrationNotRequiredReturnsFalse(): void
     {
         $this->subject->setMaximumNumberOfRegistrations(0);
         $this->subject->setRegistrationRequired(false);
 
-        self::assertFalse($this->subject->allowsUnlimitedRegistrations());
+        self::assertFalse($this->subject->hasUnlimitedSeats());
     }
 
     /**

--- a/Tests/Unit/Domain/Model/Event/SingleEventTest.php
+++ b/Tests/Unit/Domain/Model/Event/SingleEventTest.php
@@ -1137,34 +1137,34 @@ final class SingleEventTest extends UnitTestCase
     /**
      * @test
      */
-    public function allowsUnlimitedRegistrationsForZeroMaxRegistrationsAndRegistrationRequiredReturnsTrue(): void
+    public function hasUnlimitedSeatsForZeroMaxRegistrationsAndRegistrationRequiredReturnsTrue(): void
     {
         $this->subject->setMaximumNumberOfRegistrations(0);
         $this->subject->setRegistrationRequired(true);
 
-        self::assertTrue($this->subject->allowsUnlimitedRegistrations());
+        self::assertTrue($this->subject->hasUnlimitedSeats());
     }
 
     /**
      * @test
      */
-    public function allowsUnlimitedRegistrationsForNonZeroMaxRegistrationsAndRegistrationRequiredReturnsFalse(): void
+    public function hasUnlimitedSeatsForNonZeroMaxRegistrationsAndRegistrationRequiredReturnsFalse(): void
     {
         $this->subject->setMaximumNumberOfRegistrations(10);
         $this->subject->setRegistrationRequired(true);
 
-        self::assertFalse($this->subject->allowsUnlimitedRegistrations());
+        self::assertFalse($this->subject->hasUnlimitedSeats());
     }
 
     /**
      * @test
      */
-    public function allowsUnlimitedRegistrationsForZeroMaxRegistrationsAndRegistrationNotRequiredReturnsFalse(): void
+    public function hasUnlimitedSeatsForZeroMaxRegistrationsAndRegistrationNotRequiredReturnsFalse(): void
     {
         $this->subject->setMaximumNumberOfRegistrations(0);
         $this->subject->setRegistrationRequired(false);
 
-        self::assertFalse($this->subject->allowsUnlimitedRegistrations());
+        self::assertFalse($this->subject->hasUnlimitedSeats());
     }
 
     /**


### PR DESCRIPTION
The naming now is Fluid-friendly and more intuitive.