### PR TITLE
[TASK] Rename and flip `EventStatistics.hasSeatsLimit`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- Rename and flip `EventStatistics.hasSeatsLimit` (#4047)
 - Rename `Event.allowsUnlimitedRegistrations` (#4046)
 - Allow `typo3fluid/fluid:^4.0` (#4041)
 - Make `enrichWithStatistics` keep existing statistics (#4032)

--- a/Classes/Domain/Model/Event/EventStatistics.php
+++ b/Classes/Domain/Model/Event/EventStatistics.php
@@ -96,9 +96,9 @@ class EventStatistics
         return $this->seatsLimit;
     }
 
-    public function hasSeatsLimit(): bool
+    public function hasUnlimitedSeats(): bool
     {
-        return $this->seatsLimit > 0;
+        return $this->getSeatsLimit() === 0;
     }
 
     /**
@@ -114,7 +114,7 @@ class EventStatistics
      */
     public function getVacancies(): ?int
     {
-        if (!$this->hasSeatsLimit()) {
+        if ($this->hasUnlimitedSeats()) {
             return null;
         }
 

--- a/Tests/Unit/Domain/Model/Event/EventStatisticsTest.php
+++ b/Tests/Unit/Domain/Model/Event/EventStatisticsTest.php
@@ -60,21 +60,21 @@ final class EventStatisticsTest extends UnitTestCase
     /**
      * @test
      */
-    public function hasSeatsLimitForPositiveSeatsLimitReturnsTrue(): void
+    public function hasUnlimitedSeatsForPositiveSeatsLimitReturnsFalse(): void
     {
         $subject = new EventStatistics(0, 0, 0, 0, 1);
 
-        self::assertTrue($subject->hasSeatsLimit());
+        self::assertFalse($subject->hasUnlimitedSeats());
     }
 
     /**
      * @test
      */
-    public function hasSeatsLimitForZeroSeatsLimitReturnsFalse(): void
+    public function hasUnlimitedSeatsForZeroSeatsLimitReturnsTrue(): void
     {
         $subject = new EventStatistics(0, 0, 0, 0, 0);
 
-        self::assertFalse($subject->hasSeatsLimit());
+        self::assertTrue($subject->hasUnlimitedSeats());
     }
 
     /**


### PR DESCRIPTION
This makes the naming consistent with the corresponding method in `EventDateInterface`.

It also makes the method name Fluid-friendly (as Fluid does not support differentiating between `getFoo`, `hasFoo` and `isFoo`).