### PR TITLE
[TASK] Optimize line breaks in the event lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Add `Venue.city` property (#3908, #3914)
 - Add a new plugin for the event archive, outlook and single view
   (#3895, #3909, #3910, #3911, #3913, #3915, #3986, #3969, #4024, #4025, #4026,
-  #4027, #4028, #4029, #4030, #4031, #4033, #4049, #4052)
+  #4027, #4028, #4029, #4030, #4031, #4033, #4049, #4052, #4054)
 - Re-add the FE editor (#3894, #3903, #3904)
 - Add `EventRepository::findUpcoming()` (#3892, #3904)
 - Add `EventRepository::findInPast()` (#3885, #3887, #3891, #3904)

--- a/Resources/Private/Partials/Event/ArchiveList.html
+++ b/Resources/Private/Partials/Event/ArchiveList.html
@@ -35,9 +35,7 @@
                 <tr>
                     <oelib:isFieldEnabled fieldName="date">
                         <td>
-                            <span class="text-nowrap">
-                                <f:render partial="EventDate" arguments="{event: event}"/>
-                            </span>
+                            <f:render partial="EventDate" arguments="{event: event}"/>
                         </td>
                     </oelib:isFieldEnabled>
                     <oelib:isFieldEnabled fieldName="eventType">

--- a/Resources/Private/Partials/Event/OutlookList.html
+++ b/Resources/Private/Partials/Event/OutlookList.html
@@ -40,9 +40,7 @@
                 <tr>
                     <oelib:isFieldEnabled fieldName="date">
                         <td>
-                            <span class="text-nowrap">
-                                <f:render partial="EventDate" arguments="{event: event}"/>
-                            </span>
+                            <f:render partial="EventDate" arguments="{event: event}"/>
                         </td>
                     </oelib:isFieldEnabled>
                     <oelib:isFieldEnabled fieldName="eventType">

--- a/Resources/Private/Partials/Event/Vacancies.html
+++ b/Resources/Private/Partials/Event/Vacancies.html
@@ -1,18 +1,21 @@
 <html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers" data-namespace-typo3-fluid="true">
     <f:variable name="statistics" value="{event.statistics}"/>
     <f:if condition="({event.registrationRequired} && {event.registrationPossibleByDate})">
-        <f:if condition="({event.unlimitedSeats} || ({statistics.vacancies} >= {settings.enoughVacanciesThreshold}))">
-            <f:then>
-                <f:translate key="plugin.eventOutlook.events.property.vacancies.enough"/>
-                🟢
-            </f:then>
-            <f:else if="{statistics.fullyBooked}">
-                <f:translate key="plugin.eventOutlook.events.property.vacancies.fullyBooked"/>
-                🔴
-            </f:else>
-            <f:else>
-                {statistics.vacancies} 🟡
-            </f:else>
-        </f:if>
+        <span class="text-nowrap">
+            <f:if
+                condition="({event.unlimitedSeats} || ({statistics.vacancies} >= {settings.enoughVacanciesThreshold}))">
+                <f:then>
+                    <f:translate key="plugin.eventOutlook.events.property.vacancies.enough"/>
+                    🟢
+                </f:then>
+                <f:else if="{statistics.fullyBooked}">
+                    <f:translate key="plugin.eventOutlook.events.property.vacancies.fullyBooked"/>
+                    🔴
+                </f:else>
+                <f:else>
+                    {statistics.vacancies} 🟡
+                </f:else>
+            </f:if>
+        </span>
     </f:if>
 </html>


### PR DESCRIPTION
- do not allow a line break for the vacancies before the traffic light icon
- allow breaking the (potentially long) dates