### PR TITLE
[TASK] Always have `minitems` first before `maxitems`

### DIFF
--- a/Configuration/FlexForms/EventArchive.xml
+++ b/Configuration/FlexForms/EventArchive.xml
@@ -20,8 +20,8 @@
                                 <internal_type>db</internal_type>
                                 <allowed>pages</allowed>
                                 <size>1</size>
-                                <maxitems>1</maxitems>
                                 <minitems>1</minitems>
+                                <maxitems>1</maxitems>
                             </config>
                         </TCEforms>
                     </settings.singleViewPage>
@@ -35,8 +35,8 @@
                                 <internal_type>db</internal_type>
                                 <allowed>pages</allowed>
                                 <size>3</size>
-                                <maxitems>99</maxitems>
                                 <minitems>1</minitems>
+                                <maxitems>99</maxitems>
                             </config>
                         </TCEforms>
                     </persistence.storagePid>
@@ -70,8 +70,8 @@
                                         <numIndex index="1">4</numIndex>
                                     </numIndex>
                                 </items>
-                                <minitems>0</minitems>
                                 <maxitems>1</maxitems>
+                                <minitems>0</minitems>
                                 <size>1</size>
                             </config>
                         </TCEforms>

--- a/Configuration/FlexForms/EventOutlook.xml
+++ b/Configuration/FlexForms/EventOutlook.xml
@@ -20,8 +20,8 @@
                                 <internal_type>db</internal_type>
                                 <allowed>pages</allowed>
                                 <size>1</size>
-                                <maxitems>1</maxitems>
                                 <minitems>1</minitems>
+                                <maxitems>1</maxitems>
                             </config>
                         </TCEforms>
                     </settings.singleViewPage>
@@ -35,8 +35,8 @@
                                 <internal_type>db</internal_type>
                                 <allowed>pages</allowed>
                                 <size>3</size>
-                                <maxitems>99</maxitems>
                                 <minitems>1</minitems>
+                                <maxitems>99</maxitems>
                             </config>
                         </TCEforms>
                     </persistence.storagePid>

--- a/Configuration/FlexForms/flexforms_pi1.xml
+++ b/Configuration/FlexForms/flexforms_pi1.xml
@@ -64,8 +64,8 @@
 								<internal_type>db</internal_type>
 								<allowed>pages</allowed>
 								<size>1</size>
-								<maxitems>1</maxitems>
 								<minitems>0</minitems>
+								<maxitems>1</maxitems>
 							</config>
 						</TCEforms>
 					</listPID>
@@ -78,8 +78,8 @@
 								<internal_type>db</internal_type>
 								<allowed>pages</allowed>
 								<size>1</size>
-								<maxitems>1</maxitems>
 								<minitems>0</minitems>
+								<maxitems>1</maxitems>
 							</config>
 						</TCEforms>
 					</detailPID>
@@ -92,8 +92,8 @@
 								<internal_type>db</internal_type>
 								<allowed>pages</allowed>
 								<size>1</size>
-								<maxitems>1</maxitems>
 								<minitems>0</minitems>
+								<maxitems>1</maxitems>
 							</config>
 						</TCEforms>
 					</myEventsPID>
@@ -106,8 +106,8 @@
 								<internal_type>db</internal_type>
 								<allowed>pages</allowed>
 								<size>1</size>
-								<maxitems>1</maxitems>
 								<minitems>0</minitems>
+								<maxitems>1</maxitems>
 							</config>
 						</TCEforms>
 					</registerPID>
@@ -120,8 +120,8 @@
 								<internal_type>db</internal_type>
 								<allowed>pages</allowed>
 								<size>1</size>
-								<maxitems>1</maxitems>
 								<minitems>0</minitems>
+								<maxitems>1</maxitems>
 							</config>
 						</TCEforms>
 					</loginPID>
@@ -134,8 +134,8 @@
 								<internal_type>db</internal_type>
 								<allowed>pages</allowed>
 								<size>1</size>
-								<maxitems>1</maxitems>
 								<minitems>0</minitems>
+								<maxitems>1</maxitems>
 							</config>
 						</TCEforms>
 					</registrationsListPID>
@@ -148,8 +148,8 @@
 								<internal_type>db</internal_type>
 								<allowed>pages</allowed>
 								<size>1</size>
-								<maxitems>1</maxitems>
 								<minitems>0</minitems>
+								<maxitems>1</maxitems>
 							</config>
 						</TCEforms>
 					</registrationsVipListPID>
@@ -170,8 +170,8 @@
 								<internal_type>db</internal_type>
 								<allowed>pages</allowed>
 								<size>3</size>
-								<maxitems>99</maxitems>
 								<minitems>0</minitems>
+								<maxitems>99</maxitems>
 							</config>
 						</TCEforms>
 					</pages>
@@ -424,8 +424,8 @@
 								<internal_type>db</internal_type>
 								<allowed>tx_seminars_seminars</allowed>
 								<size>1</size>
-								<maxitems>1</maxitems>
 								<minitems>0</minitems>
+								<maxitems>1</maxitems>
 							</config>
 						</TCEforms>
 					</showSingleEvent>
@@ -487,8 +487,8 @@
 								<internal_type>db</internal_type>
 								<allowed>fe_groups</allowed>
 								<size>1</size>
-								<maxitems>1</maxitems>
 								<minitems>0</minitems>
+								<maxitems>1</maxitems>
 							</config>
 						</TCEforms>
 					</defaultEventVipsFeGroupID>


### PR DESCRIPTION
This avoids mistakes when a developer edits the flexforms or TCA.