### PR TITLE
[TASK] Make the event statistics internal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- Make the event statistics internal (#4075)
 - Move the webinar URL further up in the TCEforms (#3976)
 
 ### Deprecated

--- a/Classes/Domain/Model/Event/EventDateInterface.php
+++ b/Classes/Domain/Model/Event/EventDateInterface.php
@@ -120,6 +120,9 @@ interface EventDateInterface
 
     public function allowsUnlimitedRegistrations(): bool;
 
+    /**
+     * @internal
+     */
     public function setStatistics(EventStatistics $statistics): void;
 
     /**

--- a/Classes/Domain/Model/Event/EventDateTrait.php
+++ b/Classes/Domain/Model/Event/EventDateTrait.php
@@ -118,6 +118,7 @@ trait EventDateTrait
     /**
      * @var EventStatistics|null
      * @TYPO3\CMS\Extbase\Annotation\ORM\Transient
+     * @internal
      */
     protected $statistics;
 
@@ -432,11 +433,17 @@ trait EventDateTrait
         return $this->isRegistrationRequired() && $this->getMaximumNumberOfRegistrations() === 0;
     }
 
+    /**
+     * @internal
+     */
     public function getStatistics(): ?EventStatistics
     {
         return $this->statistics;
     }
 
+    /**
+     * @internal
+     */
     public function setStatistics(EventStatistics $statistics): void
     {
         $this->statistics = $statistics;

--- a/Classes/Domain/Model/Event/EventInterface.php
+++ b/Classes/Domain/Model/Event/EventInterface.php
@@ -106,5 +106,8 @@ interface EventInterface
      */
     public function getRawData(): ?array;
 
+    /**
+     * @internal
+     */
     public function getStatistics(): ?EventStatistics;
 }

--- a/Classes/Domain/Model/Event/EventStatistics.php
+++ b/Classes/Domain/Model/Event/EventStatistics.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace OliverKlee\Seminars\Domain\Model\Event;
 
 /**
- * The registration statistics for a single event.
+ * The registration statistics for an event.
+ *
+ * @internal
  */
 class EventStatistics
 {

--- a/Classes/Domain/Model/Event/EventTopic.php
+++ b/Classes/Domain/Model/Event/EventTopic.php
@@ -17,6 +17,9 @@ class EventTopic extends Event implements EventTopicInterface
         $this->initializeEventTopic();
     }
 
+    /**
+     * @internal
+     */
     public function getStatistics(): ?EventStatistics
     {
         return null;

--- a/Classes/Service/EventStatisticsCalculator.php
+++ b/Classes/Service/EventStatisticsCalculator.php
@@ -13,6 +13,8 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
  * Calculates the statistics for events.
+ *
+ * @internal
  */
 class EventStatisticsCalculator implements SingletonInterface
 {


### PR DESCRIPTION
They will be refactored quite soon and hence will change drastically.

Hence they must not be public interface.

This is the 5.x backport of #4074.

Fixes #4073