### PR TITLE
[TASK] Rename `Place::getAddress()` to `Place::getFullAddress()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- !!! Rename `Place::getAddress()` to `Place::getFullAddress()` (#4086)
 - !!! Assume that the venue address field contains the full address (#4085)
 - Make the flexforms more compact (#4071)
 - Rename and flip `EventStatistics.hasSeatsLimit` (#4047)

--- a/Classes/Model/Place.php
+++ b/Classes/Model/Place.php
@@ -23,10 +23,7 @@ class Place extends AbstractModel
         return $this->getAsString('title');
     }
 
-    /**
-     * @return string our address, might be empty
-     */
-    public function getAddress(): string
+    public function getFullAddress(): string
     {
         return $this->getAsString('address');
     }

--- a/Classes/Service/RegistrationManager.php
+++ b/Classes/Service/RegistrationManager.php
@@ -1019,7 +1019,7 @@ class RegistrationManager implements SingletonInterface
      */
     private function formatPlace(Place $place, string $newline): string
     {
-        $address = preg_replace('/[\\n|\\r]+/', ' ', str_replace('<br />', ' ', strip_tags($place->getAddress())));
+        $address = preg_replace('/[\\n|\\r]+/', ' ', str_replace('<br />', ' ', strip_tags($place->getFullAddress())));
 
         return $place->getTitle() . $newline . $address;
     }

--- a/Tests/LegacyFunctional/Model/PlaceTest.php
+++ b/Tests/LegacyFunctional/Model/PlaceTest.php
@@ -67,27 +67,22 @@ final class PlaceTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function getAddressWithoutAddressReturnsAnEmptyString(): void
+    public function getFullAddressWithoutFullAddressReturnsAnEmptyString(): void
     {
         $this->subject->setData([]);
 
-        self::assertEquals(
-            '',
-            $this->subject->getAddress()
-        );
+        self::assertSame('', $this->subject->getFullAddress());
     }
 
     /**
      * @test
      */
-    public function getAddressWithNonEmptyAddressReturnsAddress(): void
+    public function getFullAddressWithNonEmptyFullAddressReturnsAddress(): void
     {
-        $this->subject->setData(['address' => 'Backstreet 42']);
+        $address = "Backstreet 42\n13373 Hicksville";
+        $this->subject->setData(['address' => $address]);
 
-        self::assertEquals(
-            'Backstreet 42',
-            $this->subject->getAddress()
-        );
+        self::assertSame($address, $this->subject->getFullAddress());
     }
 
     /**


### PR DESCRIPTION
This only affects the old model, not the legacy model or the new domain model for venues.

Fixes #3922