### PR TITLE
[TASK] Rename the setter for the status of legacy registrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
-- Make the registration status (regular/waiting list) a drop-down (#4091)
+- Make the registration status (regular/waiting list) a drop-down (#4091, #4092)
 - !!! Rename `Place::getAddress()` to `Place::getFullAddress()` (#4086)
 - !!! Assume that the venue address field contains the full address (#4085)
 - Make the flexforms more compact (#4071)

--- a/Classes/OldModel/LegacyRegistration.php
+++ b/Classes/OldModel/LegacyRegistration.php
@@ -6,6 +6,7 @@ namespace OliverKlee\Seminars\OldModel;
 
 use OliverKlee\Oelib\Exception\NotFoundException;
 use OliverKlee\Oelib\Mapper\MapperRegistry;
+use OliverKlee\Seminars\Domain\Model\Registration\Registration;
 use OliverKlee\Seminars\Mapper\FrontEndUserMapper;
 use OliverKlee\Seminars\Model\FrontEndUser;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -758,9 +759,14 @@ class LegacyRegistration extends AbstractModel
         return $this->getRecordPropertyBoolean('registration_queue');
     }
 
-    public function setIsOnRegistrationQueue(bool $isOnRegistrationQueue): void
+    /**
+     * @internal only used for testing
+     *
+     * @param Registration::STATUS_* $status
+     */
+    public function setStatus(int $status): void
     {
-        $this->setRecordPropertyInteger('registration_queue', (int)$isOnRegistrationQueue);
+        $this->setRecordPropertyInteger('registration_queue', $status);
     }
 
     /**

--- a/Tests/LegacyFunctional/OldModel/LegacyRegistrationTest.php
+++ b/Tests/LegacyFunctional/OldModel/LegacyRegistrationTest.php
@@ -8,6 +8,7 @@ use OliverKlee\Oelib\Configuration\ConfigurationRegistry;
 use OliverKlee\Oelib\Configuration\DummyConfiguration;
 use OliverKlee\Oelib\Mapper\MapperRegistry;
 use OliverKlee\Oelib\Testing\TestingFramework;
+use OliverKlee\Seminars\Domain\Model\Registration\Registration;
 use OliverKlee\Seminars\Mapper\FrontEndUserMapper;
 use OliverKlee\Seminars\OldModel\LegacyRegistration;
 use OliverKlee\Seminars\Tests\Support\LanguageHelper;
@@ -177,43 +178,38 @@ final class LegacyRegistrationTest extends FunctionalTestCase
         self::assertTrue($this->subject->isOk());
     }
 
-    // Tests regarding the registration queue.
+    // Tests regarding the status.
 
     /**
      * @test
      */
-    public function statusIsInitiallyRegular(): void
+    public function getStatusInitiallyReturnsRegular(): void
     {
-        self::assertSame(
-            'regular',
-            $this->subject->getStatus()
-        );
+        self::assertSame('regular', $this->subject->getStatus());
+    }
+
+    /**
+     * @return array<string, array{0: Registration::STATUS_*, 1: non-empty-string}>
+     */
+    public static function statusDataProvider(): array
+    {
+        return [
+            'regular' => [Registration::STATUS_REGULAR, 'regular'],
+            'waiting list' => [Registration::STATUS_WAITING_LIST, 'waiting list'],
+        ];
     }
 
     /**
      * @test
+     *
+     * @param Registration::STATUS_* $status
+     * @dataProvider statusDataProvider
      */
-    public function statusIsRegularIfNotOnQueue(): void
+    public function getStatusReturnsLabelForStatus(int $status, string $label): void
     {
-        $this->subject->setIsOnRegistrationQueue(false);
+        $this->subject->setStatus($status);
 
-        self::assertSame(
-            'regular',
-            $this->subject->getStatus()
-        );
-    }
-
-    /**
-     * @test
-     */
-    public function statusIsWaitingListIfOnQueue(): void
-    {
-        $this->subject->setIsOnRegistrationQueue(true);
-
-        self::assertSame(
-            'waiting list',
-            $this->subject->getStatus()
-        );
+        self::assertSame($label, $this->subject->getStatus());
     }
 
     // Tests regarding getting the registration data.

--- a/Tests/Unit/OldModel/LegacyRegistrationTest.php
+++ b/Tests/Unit/OldModel/LegacyRegistrationTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace OliverKlee\Seminars\Tests\Unit\OldModel;
 
+use OliverKlee\Seminars\Domain\Model\Registration\Registration;
 use OliverKlee\Seminars\Model\FrontEndUser;
 use OliverKlee\Seminars\OldModel\AbstractModel;
 use OliverKlee\Seminars\OldModel\LegacyRegistration;
@@ -66,49 +67,29 @@ final class LegacyRegistrationTest extends UnitTestCase
     /**
      * @test
      */
-    public function isOnRegistrationByDefaultReturnsFalse(): void
+    public function isOnRegistrationQueueByDefaultReturnsFalse(): void
     {
         self::assertFalse($this->subject->isOnRegistrationQueue());
-
-        $this->subject->setIsOnRegistrationQueue(true);
-        self::assertTrue(
-            $this->subject->isOnRegistrationQueue()
-        );
     }
 
     /**
      * @test
      */
-    public function isOnRegistrationReturnsRegistrationQueue(): void
+    public function isOnRegistrationQueueForRegularRegistrationReturnsFalse(): void
     {
-        $subject = LegacyRegistration::fromData(['registration_queue' => 1]);
+        $this->subject->setStatus(Registration::STATUS_REGULAR);
 
-        self::assertTrue($subject->isOnRegistrationQueue());
-    }
-
-    /**
-     * @return bool[][]
-     */
-    public function booleanDataProvider(): array
-    {
-        return [
-            'false' => [false],
-            'true' => [true],
-        ];
+        self::assertFalse($this->subject->isOnRegistrationQueue());
     }
 
     /**
      * @test
-     *
-     * @param bool $value
-     *
-     * @dataProvider booleanDataProvider
      */
-    public function setIsOnRegistrationQueueSetsOnRegistrationQueue(bool $value): void
+    public function isOnRegistrationQueueForWaitingListRegistrationReturnsTrue(): void
     {
-        $this->subject->setIsOnRegistrationQueue($value);
+        $this->subject->setStatus(Registration::STATUS_WAITING_LIST);
 
-        self::assertSame($value, $this->subject->isOnRegistrationQueue());
+        self::assertTrue($this->subject->isOnRegistrationQueue());
     }
 
     /**
@@ -259,9 +240,18 @@ final class LegacyRegistrationTest extends UnitTestCase
     }
 
     /**
+     * @return array<string, array{0: bool}>
+     */
+    public function booleanDataProvider(): array
+    {
+        return [
+            'false' => [false],
+            'true' => [true],
+        ];
+    }
+
+    /**
      * @test
-     *
-     * @param bool $value
      *
      * @dataProvider booleanDataProvider
      */


### PR DESCRIPTION
The setter is only used internally. So this change is not breaking.

Also mark the setter as `@internal` to make this explicit.