### PR TITLE
[BUGFIX] Avoid crashes for deleted lazy-loaded associations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- Avoid crashes for deleted lazy-loaded associations (#4110)
 - Avoid empty localized email subjects in some cases (#3867)
 
 ## 5.8.0: Usability features for the BE module

--- a/Classes/Domain/Model/Event/EventTopicTrait.php
+++ b/Classes/Domain/Model/Event/EventTopicTrait.php
@@ -141,8 +141,9 @@ trait EventTopicTrait
         $eventType = $this->eventType;
         if ($eventType instanceof LazyLoadingProxy) {
             $eventType = $eventType->_loadRealInstance();
-            \assert($eventType instanceof EventType);
-            $this->eventType = $eventType;
+            if ($eventType instanceof EventType) {
+                $this->eventType = $eventType;
+            }
         }
 
         return $eventType;

--- a/Classes/Domain/Model/Registration/AttendeesTrait.php
+++ b/Classes/Domain/Model/Registration/AttendeesTrait.php
@@ -58,8 +58,9 @@ trait AttendeesTrait
         $user = $this->user;
         if ($user instanceof LazyLoadingProxy) {
             $user = $user->_loadRealInstance();
-            \assert($user instanceof FrontendUser);
-            $this->user = $user;
+            if ($user instanceof FrontendUser) {
+                $this->user = $user;
+            }
         }
 
         return $user;

--- a/Classes/Domain/Model/Registration/PaymentTrait.php
+++ b/Classes/Domain/Model/Registration/PaymentTrait.php
@@ -87,8 +87,9 @@ trait PaymentTrait
         $paymentMethod = $this->paymentMethod;
         if ($paymentMethod instanceof LazyLoadingProxy) {
             $paymentMethod = $paymentMethod->_loadRealInstance();
-            \assert($paymentMethod instanceof PaymentMethod);
-            $this->paymentMethod = $paymentMethod;
+            if ($paymentMethod instanceof PaymentMethod) {
+                $this->paymentMethod = $paymentMethod;
+            }
         }
 
         return $paymentMethod;

--- a/Classes/Domain/Model/Registration/Registration.php
+++ b/Classes/Domain/Model/Registration/Registration.php
@@ -131,8 +131,9 @@ class Registration extends AbstractEntity implements RawDataInterface
         $event = $this->event;
         if ($event instanceof LazyLoadingProxy) {
             $event = $event->_loadRealInstance();
-            \assert($event instanceof Event);
-            $this->event = $event;
+            if ($event instanceof Event) {
+                $this->event = $event;
+            }
         }
 
         return $event;

--- a/Tests/Functional/Domain/Repository/Event/EventRepositoryTest.php
+++ b/Tests/Functional/Domain/Repository/Event/EventRepositoryTest.php
@@ -326,6 +326,19 @@ final class EventRepositoryTest extends FunctionalTestCase
     /**
      * @test
      */
+    public function mapsDeletedEventTypeAssociationForSingleEventAsNull(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/propertyMapping/SingleEventWithDeletedEventType.csv');
+
+        $result = $this->subject->findByUid(1);
+        self::assertInstanceOf(SingleEvent::class, $result);
+
+        self::assertNull($result->getEventType());
+    }
+
+    /**
+     * @test
+     */
     public function mapsEmptyEventTypeAssociationForEventTopicAsNull(): void
     {
         $this->importDataSet(__DIR__ . '/Fixtures/EventTopicWithAllFields.xml');

--- a/Tests/Functional/Domain/Repository/Event/Fixtures/propertyMapping/SingleEventWithDeletedEventType.csv
+++ b/Tests/Functional/Domain/Repository/Event/Fixtures/propertyMapping/SingleEventWithDeletedEventType.csv
@@ -1,0 +1,3 @@
+"tx_seminars_seminars"
+,"uid","object_type","title","description","event_type"
+,1,0,"Jousting","There is no glory in prevention.",99

--- a/Tests/Functional/Domain/Repository/Registration/Fixtures/propertyMapping/RegistrationWithDeletedEvent.csv
+++ b/Tests/Functional/Domain/Repository/Registration/Fixtures/propertyMapping/RegistrationWithDeletedEvent.csv
@@ -1,0 +1,3 @@
+"tx_seminars_attendances"
+,"uid","seminar"
+,1,99

--- a/Tests/Functional/Domain/Repository/Registration/Fixtures/propertyMapping/RegistrationWithDeletedPaymentMethod.csv
+++ b/Tests/Functional/Domain/Repository/Registration/Fixtures/propertyMapping/RegistrationWithDeletedPaymentMethod.csv
@@ -1,0 +1,3 @@
+"tx_seminars_attendances"
+,"uid","method_of_payment"
+,1,99

--- a/Tests/Functional/Domain/Repository/Registration/Fixtures/propertyMapping/RegistrationWithDeletedUser.csv
+++ b/Tests/Functional/Domain/Repository/Registration/Fixtures/propertyMapping/RegistrationWithDeletedUser.csv
@@ -1,0 +1,3 @@
+"tx_seminars_attendances"
+,"uid","user"
+,1,99

--- a/Tests/Functional/Domain/Repository/Registration/RegistrationRepositoryTest.php
+++ b/Tests/Functional/Domain/Repository/Registration/RegistrationRepositoryTest.php
@@ -217,6 +217,19 @@ final class RegistrationRepositoryTest extends FunctionalTestCase
     /**
      * @test
      */
+    public function mapsDeletedEventAssociationAsNull(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/propertyMapping/RegistrationWithDeletedEvent.csv');
+
+        $result = $this->subject->findByUid(1);
+        self::assertInstanceOf(Registration::class, $result);
+
+        self::assertNull($result->getEvent());
+    }
+
+    /**
+     * @test
+     */
     public function mapsEventAssociationWithEventDate(): void
     {
         $this->importDataSet(__DIR__ . '/Fixtures/RegistrationWithEventDate.xml');
@@ -254,6 +267,19 @@ final class RegistrationRepositoryTest extends FunctionalTestCase
         self::assertInstanceOf(Registration::class, $result);
 
         self::assertInstanceOf(FrontendUser::class, $result->getUser());
+    }
+
+    /**
+     * @test
+     */
+    public function mapsDeletedUserAssociationAsNull(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/propertyMapping/RegistrationWithDeletedUser.csv');
+
+        $result = $this->subject->findByUid(1);
+        self::assertInstanceOf(Registration::class, $result);
+
+        self::assertNull($result->getUser());
     }
 
     /**
@@ -331,6 +357,19 @@ final class RegistrationRepositoryTest extends FunctionalTestCase
         self::assertInstanceOf(Registration::class, $result);
 
         self::assertInstanceOf(PaymentMethod::class, $result->getPaymentMethod());
+    }
+
+    /**
+     * @test
+     */
+    public function mapsDeletedPaymentMethodAssociationAsNull(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/propertyMapping/RegistrationWithDeletedPaymentMethod.csv');
+
+        $result = $this->subject->findByUid(1);
+        self::assertInstanceOf(Registration::class, $result);
+
+        self::assertNull($result->getPaymentMethod());
     }
 
     /**

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -271,6 +271,31 @@ parameters:
 			path: Classes/Domain/Model/Event/EventDate.php
 
 		-
+			message: "#^Method OliverKlee\\\\Seminars\\\\Domain\\\\Model\\\\Event\\\\EventTopic\\:\\:getEventType\\(\\) should return OliverKlee\\\\Seminars\\\\Domain\\\\Model\\\\EventType\\|null but returns object\\|null\\.$#"
+			count: 1
+			path: Classes/Domain/Model/Event/EventTopic.php
+
+		-
+			message: "#^Method OliverKlee\\\\Seminars\\\\Domain\\\\Model\\\\Event\\\\SingleEvent\\:\\:getEventType\\(\\) should return OliverKlee\\\\Seminars\\\\Domain\\\\Model\\\\EventType\\|null but returns object\\|null\\.$#"
+			count: 1
+			path: Classes/Domain/Model/Event/SingleEvent.php
+
+		-
+			message: "#^Method OliverKlee\\\\Seminars\\\\Domain\\\\Model\\\\Registration\\\\Registration\\:\\:getEvent\\(\\) should return OliverKlee\\\\Seminars\\\\Domain\\\\Model\\\\Event\\\\Event\\|null but returns object\\|null\\.$#"
+			count: 1
+			path: Classes/Domain/Model/Registration/Registration.php
+
+		-
+			message: "#^Method OliverKlee\\\\Seminars\\\\Domain\\\\Model\\\\Registration\\\\Registration\\:\\:getPaymentMethod\\(\\) should return OliverKlee\\\\Seminars\\\\Domain\\\\Model\\\\PaymentMethod\\|null but returns object\\|null\\.$#"
+			count: 1
+			path: Classes/Domain/Model/Registration/Registration.php
+
+		-
+			message: "#^Method OliverKlee\\\\Seminars\\\\Domain\\\\Model\\\\Registration\\\\Registration\\:\\:getUser\\(\\) should return OliverKlee\\\\FeUserExtraFields\\\\Domain\\\\Model\\\\FrontendUser\\|null but returns object\\|null\\.$#"
+			count: 1
+			path: Classes/Domain/Model/Registration/Registration.php
+
+		-
 			message: "#^Cannot call method fetchAll\\(\\) on Doctrine\\\\DBAL\\\\Result\\|int\\.$#"
 			count: 1
 			path: Classes/Domain/Repository/AbstractRawDataCapableRepository.php


### PR DESCRIPTION
This is the 5.x backport of #4109.