### PR TITLE
[TASK] Remove left-over code from CSV export of events

### DIFF
--- a/Classes/Configuration/CsvExportConfigurationCheck.php
+++ b/Classes/Configuration/CsvExportConfigurationCheck.php
@@ -15,22 +15,12 @@ class CsvExportConfigurationCheck extends AbstractConfigurationCheck
 {
     protected function checkAllConfigurationValues(): void
     {
-        $this->checkFilenameForEventsCsv();
         $this->checkFilenameForRegistrationsCsv();
         $this->checkFieldsFromFeUserForCsv();
         $this->checkFieldsFromAttendanceForCsv();
         $this->checkFieldsFromFeUserForEmailCsv();
         $this->checkFieldsFromAttendanceForEmailCsv();
         $this->checkShowAttendancesOnRegistrationQueueInEmailCsv();
-    }
-
-    private function checkFilenameForEventsCsv(): void
-    {
-        $this->checkForNonEmptyString(
-            'filenameForEventsCsv',
-            'This value specifies the file name to suggest for the CSV export of event records.
-            If this value is not set, an empty filename will be used for saving the CSV file which will cause problems.'
-        );
     }
 
     private function checkFilenameForRegistrationsCsv(): void

--- a/Configuration/TypoScript/PluginShared.typoscript
+++ b/Configuration/TypoScript/PluginShared.typoscript
@@ -86,14 +86,8 @@ plugin.tx_seminars {
   # If there are at least this many vancancies, "enough" is displayed instead of the exact number.
   showVacanciesThreshold = 10
 
-  # the filename proposed for CSV export of event lists
-  filenameForEventsCsv = events.csv
-
   # the filename proposed for CSV export of registration lists
   filenameForRegistrationsCsv = registrations.csv
-
-  # comma-separated list of field names from tx_seminars_seminars that will be used for CSV export
-  fieldsFromEventsForCsv = uid,title,subtitle,description,event_type,date,time,place,room,speakers,price_regular,attendees,attendees_max,vacancies,is_full
 
   # comma-separated list of field names from fe_users that will be used for CSV export
   fieldsFromFeUserForCsv = name,company,address,zip,city,country,telephone,email


### PR DESCRIPTION
We don't have a CSV export for events anymore.

Fixes #4131