### PR TITLE
[TASK] Do not localize the CSV headings anymore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- !!! Do not localize the CSV headings anymore (#4133)
 - Stop including the ticket ID in the thank-you email by default (#4117)
 - Shorten the heading when registering for the waiting list (#4114)
 - Do not display the event UID in the (un)registration process (#4113, #4118)

--- a/Classes/Csv/CsvDownloader.php
+++ b/Classes/Csv/CsvDownloader.php
@@ -6,7 +6,6 @@ namespace OliverKlee\Seminars\Csv;
 
 use OliverKlee\Oelib\Configuration\ConfigurationRegistry;
 use OliverKlee\Oelib\Interfaces\Configuration;
-use OliverKlee\Seminars\Localization\TranslateTrait;
 use OliverKlee\Seminars\Middleware\ResponseHeadersModifier;
 use OliverKlee\Seminars\OldModel\LegacyEvent;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -18,8 +17,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  */
 class CsvDownloader
 {
-    use TranslateTrait;
-
     protected Configuration $configuration;
 
     public function __construct()

--- a/Resources/Private/Language/locallang_db.xlf
+++ b/Resources/Private/Language/locallang_db.xlf
@@ -16,12 +16,6 @@
 			<trans-unit id="LGL.endtime">
 				<source>Stop</source>
 			</trans-unit>
-			<trans-unit id="LGL.telephone">
-				<source>Phone</source>
-			</trans-unit>
-			<trans-unit id="LGL.gender">
-				<source>Gender</source>
-			</trans-unit>
 			<trans-unit id="tx_seminars_seminars">
 				<source>Event</source>
 			</trans-unit>

--- a/Tests/Functional/Csv/CsvDownloaderTest.php
+++ b/Tests/Functional/Csv/CsvDownloaderTest.php
@@ -8,7 +8,6 @@ use OliverKlee\Oelib\Configuration\ConfigurationRegistry;
 use OliverKlee\Oelib\Configuration\DummyConfiguration;
 use OliverKlee\Seminars\Csv\CsvDownloader;
 use OliverKlee\Seminars\Middleware\ResponseHeadersModifier;
-use OliverKlee\Seminars\Tests\Support\LanguageHelper;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
 
@@ -17,8 +16,6 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
  */
 final class CsvDownloaderTest extends FunctionalTestCase
 {
-    use LanguageHelper;
-
     protected array $testExtensionsToLoad = [
         'typo3conf/ext/static_info_tables',
         'typo3conf/ext/feuserextrafields',
@@ -36,10 +33,7 @@ final class CsvDownloaderTest extends FunctionalTestCase
     {
         parent::setUp();
 
-        $this->importCSVDataSet(__DIR__ . '/Fixtures/BackEndUser.csv');
-        $this->setUpBackendUser(1);
         $this->setUpExtensionConfiguration();
-        $this->initializeBackEndLanguage();
 
         $this->responseHeadersModifier = new ResponseHeadersModifier();
         GeneralUtility::setSingletonInstance(ResponseHeadersModifier::class, $this->responseHeadersModifier);
@@ -53,18 +47,6 @@ final class CsvDownloaderTest extends FunctionalTestCase
         $configurationRegistry->set('plugin', new DummyConfiguration());
         $this->configuration = new DummyConfiguration();
         $configurationRegistry->set('plugin.tx_seminars', $this->configuration);
-    }
-
-    /**
-     * Retrieves the localization for the given locallang key and then strips the trailing colon from it.
-     *
-     * @param non-empty-string $key the locallang key with the localization to remove the trailing colon from
-     *
-     * @return string locallang string with the removed trailing colon, will not be empty
-     */
-    private function localizeAndRemoveColon(string $key): string
-    {
-        return \rtrim($this->translate($key), ':');
     }
 
     /**
@@ -113,26 +95,23 @@ final class CsvDownloaderTest extends FunctionalTestCase
 
         $result = $this->subject->createAndOutputListOfRegistrations(1);
 
-        $expected = $this->localizeAndRemoveColon('LGL.name') . ';' .
-            $this->localizeAndRemoveColon('tx_seminars_attendances.uid') . "\r\n";
-
+        $expected = "fe_users.name;tx_seminars_attendances.uid\r\n";
         self::assertSame($expected, $result);
     }
 
     /**
      * @test
      */
-    public function createListOfRegistrationsForBothConfigurationFieldsNotEmptyAddsSemicolonBetweenFieldsHeaders(): void
+    public function createListOfRegistrationsForBothConfigurationFieldsNotEmptyAddsSemicolonBetweenFieldHeaders(): void
     {
         $this->importDataSet(__DIR__ . '/Fixtures/EventsAndRegistrations.xml');
 
-        $this->configuration->setAsString('fieldsFromAttendanceForCsv', 'address');
         $this->configuration->setAsString('fieldsFromFeUserForCsv', 'name');
+        $this->configuration->setAsString('fieldsFromAttendanceForCsv', 'address');
 
         $result = $this->subject->createAndOutputListOfRegistrations(1);
 
-        $expected = $this->localizeAndRemoveColon('LGL.name') . ';' .
-            $this->localizeAndRemoveColon('tx_seminars_attendances.address');
+        $expected = 'fe_users.name;tx_seminars_attendances.address';
         self::assertStringContainsString($expected, $result);
     }
 

--- a/Tests/Functional/Csv/Fixtures/BackEndUser.csv
+++ b/Tests/Functional/Csv/Fixtures/BackEndUser.csv
@@ -1,3 +1,0 @@
-"be_users"
-,"uid","username","admin"
-,1,"admin",1

--- a/Tests/LegacyFunctional/Csv/AbstractRegistrationListViewTest.php
+++ b/Tests/LegacyFunctional/Csv/AbstractRegistrationListViewTest.php
@@ -9,7 +9,6 @@ use OliverKlee\Oelib\Configuration\DummyConfiguration;
 use OliverKlee\Oelib\Testing\TestingFramework;
 use OliverKlee\Seminars\Csv\AbstractRegistrationListView;
 use OliverKlee\Seminars\Hooks\Interfaces\RegistrationListCsv;
-use OliverKlee\Seminars\Tests\Support\LanguageHelper;
 use PHPUnit\Framework\MockObject\MockObject;
 use TYPO3\CMS\Core\Context\Context;
 use TYPO3\CMS\Core\Context\DateTimeAspect;
@@ -21,8 +20,6 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
  */
 final class AbstractRegistrationListViewTest extends FunctionalTestCase
 {
-    use LanguageHelper;
-
     protected array $testExtensionsToLoad = [
         'typo3conf/ext/static_info_tables',
         'typo3conf/ext/feuserextrafields',
@@ -80,9 +77,6 @@ final class AbstractRegistrationListViewTest extends FunctionalTestCase
 
         $this->extConfBackup = $GLOBALS['TYPO3_CONF_VARS']['EXTCONF'];
         $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['seminars'] = [];
-
-        $this->getLanguageService()->includeLLFile('EXT:core/Resources/Private/Language/locallang_general.xlf');
-        $this->getLanguageService()->includeLLFile('EXT:seminars/Resources/Private/Language/locallang_db.xlf');
 
         $this->testingFramework = new TestingFramework('tx_seminars');
 
@@ -233,20 +227,6 @@ final class AbstractRegistrationListViewTest extends FunctionalTestCase
         $this->purgeMockedInstances();
 
         self::assertNotSame($mockedInstance, GeneralUtility::makeInstance($mockedClassName));
-    }
-
-    /**
-     * Retrieves the localization for the given locallang key and then strips the trailing colon from the localization.
-     *
-     * @param non-empty-string $locallangKey
-     *        the locallang key with the localization to remove the trailing colon from, must not be empty and the localization
-     *        must have a trailing colon
-     *
-     * @return string locallang string with the removed trailing colon, will not be empty
-     */
-    private function localizeAndRemoveColon(string $locallangKey): string
-    {
-        return \rtrim($this->translate($locallangKey), ':');
     }
 
     /**
@@ -613,16 +593,9 @@ final class AbstractRegistrationListViewTest extends FunctionalTestCase
         $this->registrationFieldKeys = ['address'];
 
         $registrationsList = $this->subject->render();
-        $localizedAddress = $this->localizeAndRemoveColon('tx_seminars_attendances.address');
 
-        self::assertStringContainsString(
-            $localizedAddress,
-            $registrationsList
-        );
-        self::assertStringNotContainsString(
-            '"' . $localizedAddress . '"',
-            $registrationsList
-        );
+        self::assertStringContainsString('tx_seminars_attendances.address', $registrationsList);
+        self::assertStringNotContainsString('"tx_seminars_attendances.address"', $registrationsList);
     }
 
     /**
@@ -633,8 +606,7 @@ final class AbstractRegistrationListViewTest extends FunctionalTestCase
         $this->registrationFieldKeys = ['address', 'title'];
 
         self::assertStringContainsString(
-            $this->localizeAndRemoveColon('tx_seminars_attendances.address') .
-            ';' . $this->localizeAndRemoveColon('tx_seminars_attendances.title'),
+            'tx_seminars_attendances.address;tx_seminars_attendances.title',
             $this->subject->render()
         );
     }
@@ -673,12 +645,7 @@ final class AbstractRegistrationListViewTest extends FunctionalTestCase
         $this->registrationFieldKeys = ['address'];
         $this->frontEndUserFieldKeys = ['name'];
 
-        self::assertStringContainsString(
-            $this->localizeAndRemoveColon(
-                'LGL.name'
-            ) . ';' . $this->localizeAndRemoveColon('tx_seminars_attendances.address'),
-            $this->subject->render()
-        );
+        self::assertStringContainsString('fe_users.name;tx_seminars_attendances.address', $this->subject->render());
     }
 
     /**

--- a/Tests/LegacyFunctional/Csv/CsvDownloaderTest.php
+++ b/Tests/LegacyFunctional/Csv/CsvDownloaderTest.php
@@ -72,20 +72,6 @@ final class CsvDownloaderTest extends FunctionalTestCase
         parent::tearDown();
     }
 
-    // Utility functions
-
-    /**
-     * Retrieves the localization for the given locallang key and then strips the trailing colon from it.
-     *
-     * @param non-empty-string $key the locallang key with the localization to remove the trailing colon from
-     *
-     * @return string locallang string with the removed trailing colon, will not be empty
-     */
-    private function localizeAndRemoveColon(string $key): string
-    {
-        return \rtrim($this->translate($key), ':');
-    }
-
     // Tests for the CSV export of registrations.
 
     /**
@@ -183,9 +169,7 @@ final class CsvDownloaderTest extends FunctionalTestCase
         );
 
         self::assertStringContainsString(
-            $this->localizeAndRemoveColon(
-                'tx_seminars_attendances.registered_themselves'
-            ),
+            'tx_seminars_attendances.registered_themselves',
             $this->subject->createListOfRegistrations($this->eventUid)
         );
     }
@@ -208,7 +192,7 @@ final class CsvDownloaderTest extends FunctionalTestCase
         );
 
         self::assertStringContainsString(
-            $this->localizeAndRemoveColon('tx_seminars_attendances.company'),
+            'tx_seminars_attendances.company',
             $this->subject->createListOfRegistrations($this->eventUid)
         );
     }
@@ -660,16 +644,8 @@ final class CsvDownloaderTest extends FunctionalTestCase
         $this->configuration->setAsString('fieldsFromAttendanceForCsv', 'address');
 
         $registrationsList = $this->subject->createAndOutputListOfRegistrations($this->eventUid);
-        $localizedAddress = $this->localizeAndRemoveColon('tx_seminars_attendances.address');
-
-        self::assertStringContainsString(
-            $localizedAddress,
-            $registrationsList
-        );
-        self::assertStringNotContainsString(
-            '"' . $localizedAddress . '"',
-            $registrationsList
-        );
+        self::assertStringContainsString('tx_seminars_attendances.address', $registrationsList);
+        self::assertStringNotContainsString('"tx_seminars_attendances.address"', $registrationsList);
     }
 
     /**
@@ -680,8 +656,7 @@ final class CsvDownloaderTest extends FunctionalTestCase
         $this->configuration->setAsString('fieldsFromAttendanceForCsv', 'address,title');
 
         self::assertStringContainsString(
-            $this->localizeAndRemoveColon('tx_seminars_attendances.address') .
-            ';' . $this->localizeAndRemoveColon('tx_seminars_attendances.title'),
+            'tx_seminars_attendances.address;tx_seminars_attendances.title',
             $this->subject->createAndOutputListOfRegistrations($this->eventUid)
         );
     }


### PR DESCRIPTION
This reduces code complexity. Also, it ensure that all CSV columns have a non-empty heading.

Fixes #2983