### PR TITLE
[BUGFIX] Avoid empty localized email subjects in some cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- Avoid empty localized email subjects in some cases (#3867)
+
 ## 5.8.0: Usability features for the BE module
 
 ### Added

--- a/Classes/Localization/TranslateTrait.php
+++ b/Classes/Localization/TranslateTrait.php
@@ -26,6 +26,6 @@ trait TranslateTrait
     {
         $label = LocalizationUtility::translate($key, 'seminars');
 
-        return \is_string($label) ? $label : $key;
+        return (\is_string($label) && $label !== '') ? $label : $key;
     }
 }

--- a/Classes/Service/RegistrationManager.php
+++ b/Classes/Service/RegistrationManager.php
@@ -1307,9 +1307,10 @@ class RegistrationManager
         $labelWithSalutation = LocalizationUtility::translate($key . $salutationSuffix, 'seminars');
         $labelWithoutSalutation = LocalizationUtility::translate($key, 'seminars');
 
-        $label = \is_string($labelWithSalutation) ? $labelWithSalutation : $labelWithoutSalutation;
+        $label = (\is_string($labelWithSalutation) && $labelWithSalutation !== '')
+            ? $labelWithSalutation : $labelWithoutSalutation;
 
-        return \is_string($label) ? $label : $key;
+        return (\is_string($label) && $label !== '') ? $label : $key;
     }
 
     private function nowAsTimestamp(): int


### PR DESCRIPTION
This is the 5.8.x backport of #3866.

Fixes #3865