### PR TITLE
[DOCS] Fix version number in deprecation comment

### DIFF
--- a/Tests/Functional/Domain/Repository/Event/EventRepositoryTest.php
+++ b/Tests/Functional/Domain/Repository/Event/EventRepositoryTest.php
@@ -1829,7 +1829,7 @@ final class EventRepositoryTest extends FunctionalTestCase
     /**
      * @test
      *
-     * @deprecated #1324 will be removed in seminars 5.0
+     * @deprecated #1324 will be removed in seminars 6.0
      */
     public function duplicateViaDataHandlerForEventWithRegistrationsResetsRegistrationsCounterToZero(): void
     {
@@ -1846,7 +1846,7 @@ final class EventRepositoryTest extends FunctionalTestCase
     /**
      * @test
      *
-     * @deprecated #1324 will be removed in seminars 5.0
+     * @deprecated #1324 will be removed in seminars 6.0
      */
     public function duplicateViaDataHandlerForEventWithRegistrationsDoesNotDuplicateRegistrations(): void
     {


### PR DESCRIPTION
This is the 5.x backport of #3883.

[ci skip]