### PR TITLE
[BUGFIX] Fix a copy'n'paste error in a label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- Fix a copy'n'paste error in a label (#4127)
 - Avoid crashes for deleted lazy-loaded associations (#4110, #4116)
 - Avoid empty localized email subjects in some cases (#3867)
 

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -1353,7 +1353,7 @@ This event now has been confirmed.</source>
 				<source>How did you hear about this event?</source>
 			</trans-unit>
 			<trans-unit id="plugin.eventRegistration.property.knownFrom_informal">
-				<source>What are is your background knowledge on the topic of this event?</source>
+				<source>How did you hear about this event?</source>
 			</trans-unit>
 			<trans-unit id="plugin.eventRegistration.property.comments">
 				<source>Other comments</source>


### PR DESCRIPTION
This is the 5.x backport of #4126.