### PR TITLE
[BUGFIX] Change the registration status from checkbox to drop-down

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- Change the registration status from a checkbox to a drop-down (#4192)
 - Fix a copy'n'paste error in a label (#4127)
 - Avoid crashes for deleted lazy-loaded associations (#4110, #4116)
 - Avoid empty localized email subjects in some cases (#3867)

--- a/Classes/Domain/Model/Registration/Registration.php
+++ b/Classes/Domain/Model/Registration/Registration.php
@@ -29,6 +29,16 @@ class Registration extends AbstractEntity implements RawDataInterface
     use PaymentTrait;
 
     /**
+     * @var int<0, max>
+     */
+    public const STATUS_REGULAR = 0;
+
+    /**
+     * @var int<0, max>
+     */
+    public const STATUS_WAITING_LIST = 1;
+
+    /**
      * @var string
      * @Extbase\Validate("StringLength", options={"maximum": 255})
      */

--- a/Configuration/TCA/tx_seminars_attendances.php
+++ b/Configuration/TCA/tx_seminars_attendances.php
@@ -75,10 +75,22 @@ $tca = [
             ],
         ],
         'registration_queue' => [
-            'exclude' => 1,
+            'exclude' => true,
             'label' => 'LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_attendances.registration_queue',
             'config' => [
-                'type' => 'check',
+                'type' => 'select',
+                'renderType' => 'selectSingle',
+                'default' => \OliverKlee\Seminars\Domain\Model\Registration\Registration::STATUS_REGULAR,
+                'items' => [
+                    [
+                        'LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_attendances.registration_queue.regular',
+                        \OliverKlee\Seminars\Domain\Model\Registration\Registration::STATUS_REGULAR,
+                    ],
+                    [
+                        'LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_attendances.registration_queue.waitingList',
+                        \OliverKlee\Seminars\Domain\Model\Registration\Registration::STATUS_WAITING_LIST,
+                    ],
+                ],
             ],
         ],
         'seats' => [

--- a/Resources/Private/Language/locallang_db.xlf
+++ b/Resources/Private/Language/locallang_db.xlf
@@ -362,7 +362,13 @@
 				<source>Seminar</source>
 			</trans-unit>
 			<trans-unit id="tx_seminars_attendances.registration_queue">
-				<source>Is on the registration queue</source>
+				<source>Status</source>
+			</trans-unit>
+			<trans-unit id="tx_seminars_attendances.registration_queue.regular">
+				<source>regular registration</source>
+			</trans-unit>
+			<trans-unit id="tx_seminars_attendances.registration_queue.waitingList">
+				<source>waiting list</source>
 			</trans-unit>
 			<trans-unit id="tx_seminars_attendances.price">
 				<source>Price to pay</source>


### PR DESCRIPTION
This avoids confusion with the new labels from `main`.

Fixes #4162

This is the 5.8.1 backport of #4192.