### PR TITLE
[TASK] Switch `findActiveRegistrationsByUser` to return array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
-- Add `RegistrationRepository::findActiveRegistrationsByUserUid()` (#4212)
+- Add `RegistrationRepository::findActiveRegistrationsByUserUid()`
+  (#4212, #4213)
 - Add a reimplemented "my events" plugin (#4207, #4209, #4210)
 - Add a field for the attachment download start date (#4202)
 - Allow editing the FE users from the BE module (#4197)

--- a/Classes/Domain/Repository/Registration/RegistrationRepository.php
+++ b/Classes/Domain/Repository/Registration/RegistrationRepository.php
@@ -13,7 +13,6 @@ use TYPO3\CMS\Core\DataHandling\DataHandler;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Persistence\Generic\Typo3QuerySettings;
 use TYPO3\CMS\Extbase\Persistence\QueryInterface;
-use TYPO3\CMS\Extbase\Persistence\QueryResultInterface;
 
 /**
  * @extends AbstractRawDataCapableRepository<Registration>
@@ -201,15 +200,15 @@ class RegistrationRepository extends AbstractRawDataCapableRepository
      *
      * @param int<1, max> $userUid
      *
-     * @return QueryResultInterface<Registration>
+     * @return list<Registration>
      */
-    public function findActiveRegistrationsByUser(int $userUid): QueryResultInterface
+    public function findActiveRegistrationsByUser(int $userUid): array
     {
         $query = $this->createQuery();
-        $query->setOrderings(['uid' => QueryInterface::ORDER_DESCENDING]);
 
-        $query->matching($query->equals('user', $userUid));
-
-        return $query->execute();
+        return $query
+            ->matching($query->equals('user', $userUid))
+            ->setOrderings(['uid' => QueryInterface::ORDER_DESCENDING])
+            ->execute()->toArray();
     }
 }

--- a/Tests/Functional/Domain/Repository/Registration/RegistrationRepositoryTest.php
+++ b/Tests/Functional/Domain/Repository/Registration/RegistrationRepositoryTest.php
@@ -1049,7 +1049,7 @@ final class RegistrationRepositoryTest extends FunctionalTestCase
 
         $result = $this->subject->findActiveRegistrationsByUser(1);
 
-        $firstResult = $result->getFirst();
+        $firstResult = $result[0] ?? null;
         self::assertInstanceOf(Registration::class, $firstResult);
     }
 
@@ -1146,7 +1146,7 @@ final class RegistrationRepositoryTest extends FunctionalTestCase
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/findActiveRegistrationsByUser/RegistrationsForTwoEvents.csv');
 
-        $result = $this->subject->findActiveRegistrationsByUser(1)->toArray();
+        $result = $this->subject->findActiveRegistrationsByUser(1);
 
         self::assertCount(2, $result);
         $firstResult = $result[0];

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -381,6 +381,11 @@ parameters:
 			path: Classes/Domain/Repository/Registration/RegistrationRepository.php
 
 		-
+			message: "#^Method OliverKlee\\\\Seminars\\\\Domain\\\\Repository\\\\Registration\\\\RegistrationRepository\\:\\:findActiveRegistrationsByUser\\(\\) should return list\\<OliverKlee\\\\Seminars\\\\Domain\\\\Model\\\\Registration\\\\Registration\\> but returns array\\<int, OliverKlee\\\\Seminars\\\\Domain\\\\Model\\\\Registration\\\\Registration\\>\\.$#"
+			count: 1
+			path: Classes/Domain/Repository/Registration/RegistrationRepository.php
+
+		-
 			message: "#^Method OliverKlee\\\\Seminars\\\\Domain\\\\Repository\\\\Registration\\\\RegistrationRepository\\:\\:findByEventAndStatus\\(\\) should return list\\<OliverKlee\\\\Seminars\\\\Domain\\\\Model\\\\Registration\\\\Registration\\> but returns array\\<int, OliverKlee\\\\Seminars\\\\Domain\\\\Model\\\\Registration\\\\Registration\\>\\.$#"
 			count: 1
 			path: Classes/Domain/Repository/Registration/RegistrationRepository.php


### PR DESCRIPTION
This allows for further processing in the method without having to change the API.