### PR TITLE
[TASK] Drop `composer-unused`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -10,7 +10,6 @@
 /CODE_OF_CONDUCT.md export-ignore
 /Resources/Private/Patches/ export-ignore
 /Tests/ export-ignore
-/composer-unused.php export-ignore
 /crowdin.yml export-ignore
 /phpcs.xml.dist export-ignore
 /phpstan-baseline.neon export-ignore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,6 @@ jobs:
       matrix:
         command:
           - "composer:normalize"
-          - "composer:unused"
           - "php:cs-fixer"
           - "php:rector"
           - "php:sniff"

--- a/composer-unused.php
+++ b/composer-unused.php
@@ -1,9 +1,0 @@
-<?php
-
-declare(strict_types=1);
-
-use ComposerUnused\ComposerUnused\Configuration\Configuration;
-
-return static function (Configuration $config): Configuration {
-    return $config;
-};

--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,6 @@
 		"ergebnis/composer-normalize": "2.45.0",
 		"friendsofphp/php-cs-fixer": "3.72.0",
 		"helmich/typo3-typoscript-lint": "2.5.2 || 3.3.0",
-		"icanhazstring/composer-unused": "0.8.11",
 		"phpstan/extension-installer": "1.4.3",
 		"phpstan/phpstan": "1.12.18",
 		"phpstan/phpstan-phpunit": "1.4.2",
@@ -117,7 +116,6 @@
 	},
 	"scripts": {
 		"ci:composer:normalize": "@composer normalize --no-check-lock --dry-run",
-		"ci:composer:unused": "composer-unused",
 		"ci:coverage": [
 			"@ci:coverage:unit",
 			"@ci:coverage:functional"
@@ -151,7 +149,6 @@
 		"ci:php:stan": ".Build/bin/phpstan --no-progress",
 		"ci:static": [
 			"@ci:composer:normalize",
-			"@ci:composer:unused",
 			"@ci:php:cs-fixer",
 			"@ci:php:lint",
 			"@ci:php:rector",
@@ -195,7 +192,6 @@
 			"rm .php-cs-fixer.cache",
 			"rm .php-cs-fixer.php",
 			"rm Configuration/TypoScriptLint.yaml",
-			"rm composer-unused.php",
 			"rm composer.lock",
 			"rm crowdin.yml",
 			"rm phpcs.xml.dist",
@@ -206,7 +202,6 @@
 	},
 	"scripts-descriptions": {
 		"ci:composer:normalize": "Checks the composer.json.",
-		"ci:composer:unused": "Finds unused Composer packages required in composer.json.",
 		"ci:coverage": "Generates the code coverage report for unit and functional tests.",
 		"ci:coverage:functional": "Generates the code coverage report for functional tests.",
 		"ci:coverage:legacy-functional": "Generates the code coverage report for legacy functional tests.",


### PR DESCRIPTION
Due to other dependencies, this tool now crashes.

As it does not bring much additional value, we now remove it again.