### PR TITLE
[TASK] Rename `Registration.areDownloadsPossibleByDate()`

### DIFF
--- a/Classes/Domain/Model/Event/EventDateInterface.php
+++ b/Classes/Domain/Model/Event/EventDateInterface.php
@@ -50,7 +50,7 @@ interface EventDateInterface
 
     public function getDownloadStartDate(): ?\DateTime;
 
-    public function areDownloadsPossibleByDate(): bool;
+    public function isDownloadsPossibleByDate(): bool;
 
     public function isRegistrationRequired(): bool;
 

--- a/Classes/Domain/Model/Event/EventDateTrait.php
+++ b/Classes/Domain/Model/Event/EventDateTrait.php
@@ -247,7 +247,7 @@ trait EventDateTrait
         $this->downloadStartDate = $startDate;
     }
 
-    public function areDownloadsPossibleByDate(): bool
+    public function isDownloadsPossibleByDate(): bool
     {
         $downloadStartDate = $this->getDownloadStartDate();
         if (!($downloadStartDate instanceof \DateTimeInterface)) {

--- a/Tests/Unit/Domain/Model/Event/EventDateTest.php
+++ b/Tests/Unit/Domain/Model/Event/EventDateTest.php
@@ -1625,33 +1625,33 @@ final class EventDateTest extends UnitTestCase
     /**
      * @test
      */
-    public function areDownloadsPossibleByDateForNoDownloadStartDateReturnsTrue(): void
+    public function isDownloadsPossibleByDateForNoDownloadStartDateReturnsTrue(): void
     {
-        self::assertTrue($this->subject->areDownloadsPossibleByDate());
+        self::assertTrue($this->subject->isDownloadsPossibleByDate());
     }
 
     /**
      * @test
      */
-    public function areDownloadsPossibleByDateForDownloadStartInPastReturnsTrue(): void
+    public function isDownloadsPossibleByDateForDownloadStartInPastReturnsTrue(): void
     {
         $context = GeneralUtility::makeInstance(Context::class);
         $context->setAspect('date', new DateTimeAspect(new \DateTimeImmutable('now')));
         $this->subject->setDownloadStartDate(new \DateTime('now -1 day'));
 
-        self::assertTrue($this->subject->areDownloadsPossibleByDate());
+        self::assertTrue($this->subject->isDownloadsPossibleByDate());
     }
 
     /**
      * @test
      */
-    public function areDownloadsPossibleByDateForDownloadStartInFutureReturnsFalse(): void
+    public function isDownloadsPossibleByDateForDownloadStartInFutureReturnsFalse(): void
     {
         $context = GeneralUtility::makeInstance(Context::class);
         $context->setAspect('date', new DateTimeAspect(new \DateTimeImmutable('now')));
         $this->subject->setDownloadStartDate(new \DateTime('now +1 day'));
 
-        self::assertFalse($this->subject->areDownloadsPossibleByDate());
+        self::assertFalse($this->subject->isDownloadsPossibleByDate());
     }
 
     /**

--- a/Tests/Unit/Domain/Model/Event/SingleEventTest.php
+++ b/Tests/Unit/Domain/Model/Event/SingleEventTest.php
@@ -1746,33 +1746,33 @@ final class SingleEventTest extends UnitTestCase
     /**
      * @test
      */
-    public function areDownloadsPossibleByDateForNoDownloadStartDateReturnsTrue(): void
+    public function isDownloadsPossibleByDateForNoDownloadStartDateReturnsTrue(): void
     {
-        self::assertTrue($this->subject->areDownloadsPossibleByDate());
+        self::assertTrue($this->subject->isDownloadsPossibleByDate());
     }
 
     /**
      * @test
      */
-    public function areDownloadsPossibleByDateForDownloadStartInPastReturnsTrue(): void
+    public function isDownloadsPossibleByDateForDownloadStartInPastReturnsTrue(): void
     {
         $context = GeneralUtility::makeInstance(Context::class);
         $context->setAspect('date', new DateTimeAspect(new \DateTimeImmutable('now')));
         $this->subject->setDownloadStartDate(new \DateTime('now -1 day'));
 
-        self::assertTrue($this->subject->areDownloadsPossibleByDate());
+        self::assertTrue($this->subject->isDownloadsPossibleByDate());
     }
 
     /**
      * @test
      */
-    public function areDownloadsPossibleByDateForDownloadStartInFutureReturnsFalse(): void
+    public function isDownloadsPossibleByDateForDownloadStartInFutureReturnsFalse(): void
     {
         $context = GeneralUtility::makeInstance(Context::class);
         $context->setAspect('date', new DateTimeAspect(new \DateTimeImmutable('now')));
         $this->subject->setDownloadStartDate(new \DateTime('now +1 day'));
 
-        self::assertFalse($this->subject->areDownloadsPossibleByDate());
+        self::assertFalse($this->subject->isDownloadsPossibleByDate());
     }
 
     /**


### PR DESCRIPTION
Rename to `isDownloadsPossibleByDate` to make this method usable in Fluid (which only recognizes the prefixes `get`, `is` and `has`).