### PR TITLE
[TASK] Restrict access to event downloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
-- Provide downloads in the "my registrations" view (#4249)
+- Provide downloads in the "my registrations" view (#4249, #4250, #4251)
 - Add `Event.downloadsForAttendees` (#4243)
 - Add unregistration to the `my registrations` single view (#4236)
 - Add a reimplemented "my registrations" plugin

--- a/Resources/Private/Partials/MyRegistrations/Show.html
+++ b/Resources/Private/Partials/MyRegistrations/Show.html
@@ -56,7 +56,7 @@
         </p>
     </f:if>
 
-    <f:if condition="{event.downloadsForAttendees}">
+    <f:if condition="{event.downloadsForAttendees} && {event.downloadsPossibleByDate} && {registration.regularRegistration}">
         <h3>
             <f:translate key="plugin.myRegistrations.show.heading.downloads"/>
         </h3>

--- a/Tests/Functional/Controller/Fixtures/MyRegistrationsController/showAction/NonBindingReservationWithDownload.csv
+++ b/Tests/Functional/Controller/Fixtures/MyRegistrationsController/showAction/NonBindingReservationWithDownload.csv
@@ -1,0 +1,15 @@
+"tx_seminars_seminars"
+,"uid","pid","title","registrations","attached_files"
+,1,1,"the event title",1,1
+
+"sys_file"
+,"uid","storage","type","folder_hash","identifier","identifier_hash","name","extension","mime_type"
+,1,1,0,"42099b4af021e53fd8fd4e056c2568d7c2e3ffa8","/speaker.jpg","f538498838e47c912a95d34187872e879f8285b6","speaker.jpg","jpg","image/jpeg"
+
+"sys_file_reference"
+,"uid","uid_local","uid_foreign","tablenames","fieldname"
+,1,1,1,"tx_seminars_seminars","attached_files"
+
+"tx_seminars_attendances"
+,"uid","pid","seminar","user","registration_queue"
+,1,1,1,1,2

--- a/Tests/Functional/Controller/Fixtures/MyRegistrationsController/showAction/RegistrationWithDownloadStartInFuture.csv
+++ b/Tests/Functional/Controller/Fixtures/MyRegistrationsController/showAction/RegistrationWithDownloadStartInFuture.csv
@@ -1,0 +1,15 @@
+"tx_seminars_seminars"
+,"uid","pid","title","registrations","attached_files","download_start_date"
+,1,1,"the event title",1,1,2121519380
+
+"sys_file"
+,"uid","storage","type","folder_hash","identifier","identifier_hash","name","extension","mime_type"
+,1,1,0,"42099b4af021e53fd8fd4e056c2568d7c2e3ffa8","/speaker.jpg","f538498838e47c912a95d34187872e879f8285b6","speaker.jpg","jpg","image/jpeg"
+
+"sys_file_reference"
+,"uid","uid_local","uid_foreign","tablenames","fieldname"
+,1,1,1,"tx_seminars_seminars","attached_files"
+
+"tx_seminars_attendances"
+,"uid","pid","seminar","user","registration_queue"
+,1,1,1,1,0

--- a/Tests/Functional/Controller/Fixtures/MyRegistrationsController/showAction/RegistrationWithDownloadStartInPast.csv
+++ b/Tests/Functional/Controller/Fixtures/MyRegistrationsController/showAction/RegistrationWithDownloadStartInPast.csv
@@ -1,0 +1,15 @@
+"tx_seminars_seminars"
+,"uid","pid","title","registrations","attached_files","download_start_date"
+,1,1,"the event title",1,1,1
+
+"sys_file"
+,"uid","storage","type","folder_hash","identifier","identifier_hash","name","extension","mime_type"
+,1,1,0,"42099b4af021e53fd8fd4e056c2568d7c2e3ffa8","/speaker.jpg","f538498838e47c912a95d34187872e879f8285b6","speaker.jpg","jpg","image/jpeg"
+
+"sys_file_reference"
+,"uid","uid_local","uid_foreign","tablenames","fieldname"
+,1,1,1,"tx_seminars_seminars","attached_files"
+
+"tx_seminars_attendances"
+,"uid","pid","seminar","user","registration_queue"
+,1,1,1,1,0

--- a/Tests/Functional/Controller/Fixtures/MyRegistrationsController/showAction/WaitingListRegistrationWithDownload.csv
+++ b/Tests/Functional/Controller/Fixtures/MyRegistrationsController/showAction/WaitingListRegistrationWithDownload.csv
@@ -1,0 +1,15 @@
+"tx_seminars_seminars"
+,"uid","pid","title","registrations","attached_files"
+,1,1,"the event title",1,1
+
+"sys_file"
+,"uid","storage","type","folder_hash","identifier","identifier_hash","name","extension","mime_type"
+,1,1,0,"42099b4af021e53fd8fd4e056c2568d7c2e3ffa8","/speaker.jpg","f538498838e47c912a95d34187872e879f8285b6","speaker.jpg","jpg","image/jpeg"
+
+"sys_file_reference"
+,"uid","uid_local","uid_foreign","tablenames","fieldname"
+,1,1,1,"tx_seminars_seminars","attached_files"
+
+"tx_seminars_attendances"
+,"uid","pid","seminar","user","registration_queue"
+,1,1,1,1,1

--- a/Tests/Functional/Controller/MyRegistrationsControllerTest.php
+++ b/Tests/Functional/Controller/MyRegistrationsControllerTest.php
@@ -921,4 +921,88 @@ final class MyRegistrationsControllerTest extends FunctionalTestCase
 
         self::assertMatchesRegularExpression('#>\\s*speaker portrait\\s*</a>#', (string)$response->getBody());
     }
+
+    /**
+     * @test
+     */
+    public function showActionForWaitingListRegistrationWithDownloadsDoesNotRendersDownload(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/MyRegistrationsController/FrontEndUserAndGroup.csv');
+        $this->importCSVDataSet(
+            __DIR__ . '/Fixtures/MyRegistrationsController/showAction/WaitingListRegistrationWithDownload.csv'
+        );
+
+        $request = (new InternalRequest())->withPageId(7)
+            ->withQueryParameter('tx_seminars_myregistrations[action]', 'show')
+            ->withQueryParameter('tx_seminars_myregistrations[controller]', 'MyRegistrations')
+            ->withQueryParameter('tx_seminars_myregistrations[registration]', 1);
+        $requestContext = (new InternalRequestContext())->withFrontendUserId(1);
+
+        $response = $this->executeFrontendSubRequest($request, $requestContext);
+
+        self::assertStringNotContainsString('speaker.jpg', (string)$response->getBody());
+    }
+
+    /**
+     * @test
+     */
+    public function showActionForNonBindingReservationWithDownloadsDoesNotRendersDownload(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/MyRegistrationsController/FrontEndUserAndGroup.csv');
+        $this->importCSVDataSet(
+            __DIR__ . '/Fixtures/MyRegistrationsController/showAction/NonBindingReservationWithDownload.csv'
+        );
+
+        $request = (new InternalRequest())->withPageId(7)
+            ->withQueryParameter('tx_seminars_myregistrations[action]', 'show')
+            ->withQueryParameter('tx_seminars_myregistrations[controller]', 'MyRegistrations')
+            ->withQueryParameter('tx_seminars_myregistrations[registration]', 1);
+        $requestContext = (new InternalRequestContext())->withFrontendUserId(1);
+
+        $response = $this->executeFrontendSubRequest($request, $requestContext);
+
+        self::assertStringNotContainsString('speaker.jpg', (string)$response->getBody());
+    }
+
+    /**
+     * @test
+     */
+    public function showActionForRegularRegistrationWithDownloadStartDateInPastRendersDownload(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/MyRegistrationsController/FrontEndUserAndGroup.csv');
+        $this->importCSVDataSet(
+            __DIR__ . '/Fixtures/MyRegistrationsController/showAction/RegistrationWithDownloadStartInPast.csv'
+        );
+
+        $request = (new InternalRequest())->withPageId(7)
+            ->withQueryParameter('tx_seminars_myregistrations[action]', 'show')
+            ->withQueryParameter('tx_seminars_myregistrations[controller]', 'MyRegistrations')
+            ->withQueryParameter('tx_seminars_myregistrations[registration]', 1);
+        $requestContext = (new InternalRequestContext())->withFrontendUserId(1);
+
+        $response = $this->executeFrontendSubRequest($request, $requestContext);
+
+        self::assertStringContainsString('speaker.jpg', (string)$response->getBody());
+    }
+
+    /**
+     * @test
+     */
+    public function showActionForRegularRegistrationWithDownloadStartDateInFuturesDoesNotRenderDownload(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/MyRegistrationsController/FrontEndUserAndGroup.csv');
+        $this->importCSVDataSet(
+            __DIR__ . '/Fixtures/MyRegistrationsController/showAction/RegistrationWithDownloadStartInFuture.csv'
+        );
+
+        $request = (new InternalRequest())->withPageId(7)
+            ->withQueryParameter('tx_seminars_myregistrations[action]', 'show')
+            ->withQueryParameter('tx_seminars_myregistrations[controller]', 'MyRegistrations')
+            ->withQueryParameter('tx_seminars_myregistrations[registration]', 1);
+        $requestContext = (new InternalRequestContext())->withFrontendUserId(1);
+
+        $response = $this->executeFrontendSubRequest($request, $requestContext);
+
+        self::assertStringNotContainsString('speaker.jpg', (string)$response->getBody());
+    }
 }


### PR DESCRIPTION
Registered persone may only download event downloads

- if their registration is a regular registration (instead of a waiting list registration or non-binding reservation)
- and if the download embargo has passed (if there is any)