### PR TITLE
[TASK] Streamline `FrontEndEditorControllerTest`

### DIFF
--- a/Tests/Functional/Controller/Fixtures/FrontEndEditorController/createAction/NewlyCreatedEvent.csv
+++ b/Tests/Functional/Controller/Fixtures/FrontEndEditorController/createAction/NewlyCreatedEvent.csv
@@ -1,0 +1,3 @@
+"tx_seminars_seminars"
+,"uid","title","owner_feuser"
+,1,"Karaoke party",1

--- a/Tests/Functional/Controller/Fixtures/FrontEndEditorController/updateAction/EventWithOwner.csv
+++ b/Tests/Functional/Controller/Fixtures/FrontEndEditorController/updateAction/EventWithOwner.csv
@@ -1,0 +1,3 @@
+"tx_seminars_seminars"
+,"uid","pid","title","owner_feuser"
+,1,2,"event with owner",1

--- a/Tests/Functional/Controller/Fixtures/FrontEndEditorController/updateAction/UpdatedEvent.csv
+++ b/Tests/Functional/Controller/Fixtures/FrontEndEditorController/updateAction/UpdatedEvent.csv
@@ -1,0 +1,3 @@
+"tx_seminars_seminars"
+,"uid","title"
+,1,"Karaoke party"

--- a/Tests/Functional/Controller/FrontEndEditorControllerTest.php
+++ b/Tests/Functional/Controller/FrontEndEditorControllerTest.php
@@ -171,7 +171,7 @@ final class FrontEndEditorControllerTest extends FunctionalTestCase
      */
     public function editActionWithOwnEventAssignsProvidedEventToView(): void
     {
-        $this->importCSVDataSet(__DIR__ . '/Fixtures/FrontEndEditorController/indexAction/EventWithOwner.csv');
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/FrontEndEditorController/editAction/EventWithOwner.csv');
 
         $request = (new InternalRequest())->withPageId(self::PAGE_UID)->withQueryParameters([
             'tx_seminars_frontendeditor[action]' => 'edit',
@@ -213,7 +213,7 @@ final class FrontEndEditorControllerTest extends FunctionalTestCase
      */
     public function editActionWithEventWithoutOwnerThrowsException(): void
     {
-        $this->importCSVDataSet(__DIR__ . '/Fixtures/FrontEndEditorController/indexAction/EventWithoutOwner.csv');
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/FrontEndEditorController/editAction/EventWithoutOwner.csv');
 
         $request = (new InternalRequest())->withPageId(self::PAGE_UID)->withQueryParameters([
             'tx_seminars_frontendeditor[action]' => 'edit',
@@ -233,7 +233,7 @@ final class FrontEndEditorControllerTest extends FunctionalTestCase
      */
     public function updateActionWithOwnEventUpdatesEvent(): void
     {
-        $this->importCSVDataSet(__DIR__ . '/Fixtures/FrontEndEditorController/indexAction/EventWithOwner.csv');
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/FrontEndEditorController/updateAction/EventWithOwner.csv');
 
         $newTitle = 'Karaoke party';
         $request = (new InternalRequest())->withPageId(self::PAGE_UID)->withQueryParameters([
@@ -246,7 +246,7 @@ final class FrontEndEditorControllerTest extends FunctionalTestCase
 
         $this->executeFrontendSubRequest($request, $context);
 
-        self::assertSame($newTitle, $this->getAllRecords('tx_seminars_seminars')[0]['title'] ?? null);
+        $this->assertCSVDataSet(__DIR__ . '/Fixtures/FrontEndEditorController/updateAction/UpdatedEvent.csv');
     }
 
     /**
@@ -296,6 +296,6 @@ final class FrontEndEditorControllerTest extends FunctionalTestCase
 
         $this->executeFrontendSubRequest($request, $context);
 
-        self::assertSame(1, $this->getAllRecords('tx_seminars_seminars')[0]['owner_feuser'] ?? null);
+        $this->assertCSVDataSet(__DIR__ . '/Fixtures/FrontEndEditorController/createAction/NewlyCreatedEvent.csv');
     }
 }

--- a/Tests/Unit/Controller/FrontEndEditorControllerTest.php
+++ b/Tests/Unit/Controller/FrontEndEditorControllerTest.php
@@ -116,25 +116,6 @@ final class FrontEndEditorControllerTest extends UnitTestCase
     /**
      * @test
      */
-    public function editActionAssignsProvidedEventToView(): void
-    {
-        $event = new SingleEvent();
-        $this->eventTypeRepositoryMock->method('findAllPlusNullEventType')->willReturn([]);
-
-        $this->viewMock->expects(self::atLeast(5))->method('assign')->withConsecutive(
-            ['event', $event],
-            ['eventTypes', self::anything()],
-            ['organizers', self::anything()],
-            ['speakers', self::anything()],
-            ['venues', self::anything()]
-        );
-
-        $this->subject->editAction($event);
-    }
-
-    /**
-     * @test
-     */
     public function editActionAssignsAuxiliaryRecordsToView(): void
     {
         $event = new SingleEvent();
@@ -161,55 +142,6 @@ final class FrontEndEditorControllerTest extends UnitTestCase
         );
 
         $this->subject->editAction($event);
-    }
-
-    /**
-     * @test
-     */
-    public function editActionWithEventFromOtherUserThrowsException(): void
-    {
-        $userAuthentication = new FrontendUserAuthentication();
-        $userAuthentication->user = ['uid' => 1];
-        $this->context->setAspect('frontend.user', new UserAspect($userAuthentication));
-
-        $event = new SingleEvent();
-        $event->setOwnerUid(2);
-
-        $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage('You do not have permission to edit this event.');
-        $this->expectExceptionCode(1666954310);
-
-        $this->subject->editAction($event);
-    }
-
-    /**
-     * @test
-     */
-    public function editActionWithEventWithoutOwnerThrowsException(): void
-    {
-        $userAuthentication = new FrontendUserAuthentication();
-        $userAuthentication->user = ['uid' => 1];
-        $this->context->setAspect('frontend.user', new UserAspect($userAuthentication));
-
-        $event = new SingleEvent();
-
-        $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage('You do not have permission to edit this event.');
-        $this->expectExceptionCode(1666954310);
-
-        $this->subject->editAction($event);
-    }
-
-    /**
-     * @test
-     */
-    public function updateActionPersistsProvidedEvent(): void
-    {
-        $event = new SingleEvent();
-        $this->eventRepositoryMock->expects(self::once())->method('update')->with($event);
-        $this->eventRepositoryMock->expects(self::once())->method('persistAll');
-
-        $this->subject->updateAction($event);
     }
 
     /**
@@ -259,25 +191,6 @@ final class FrontEndEditorControllerTest extends UnitTestCase
         $this->expectExceptionCode(1666954310);
 
         $this->subject->updateAction($event);
-    }
-
-    /**
-     * @test
-     */
-    public function newActionWithEventAssignsProvidedEventToView(): void
-    {
-        $event = new SingleEvent();
-        $this->eventTypeRepositoryMock->method('findAllPlusNullEventType')->willReturn([]);
-
-        $this->viewMock->expects(self::atLeast(5))->method('assign')->withConsecutive(
-            ['event', $event],
-            ['eventTypes', self::anything()],
-            ['organizers', self::anything()],
-            ['speakers', self::anything()],
-            ['venues', self::anything()]
-        );
-
-        $this->subject->newAction($event);
     }
 
     /**
@@ -354,23 +267,6 @@ final class FrontEndEditorControllerTest extends UnitTestCase
     /**
      * @test
      */
-    public function createActionSetsCurrentUserAsOwner(): void
-    {
-        $ownerUid = 42;
-        $userAuthentication = new FrontendUserAuthentication();
-        $userAuthentication->user = ['uid' => $ownerUid];
-        $this->context->setAspect('frontend.user', new UserAspect($userAuthentication));
-
-        $event = new SingleEvent();
-
-        $this->subject->createAction($event);
-
-        self::assertSame($ownerUid, $event->getOwnerUid());
-    }
-
-    /**
-     * @test
-     */
     public function createActionWithPageUidInConfigurationSetsProvidedPageUid(): void
     {
         $pageUid = 42;
@@ -392,19 +288,6 @@ final class FrontEndEditorControllerTest extends UnitTestCase
         $this->subject->createAction($event);
 
         self::assertSame(0, $event->getPid());
-    }
-
-    /**
-     * @test
-     */
-    public function createActionPersistsEvent(): void
-    {
-        $event = new SingleEvent();
-
-        $this->eventRepositoryMock->expects(self::once())->method('add')->with($event);
-        $this->eventRepositoryMock->expects(self::once())->method('persistAll');
-
-        $this->subject->createAction($event);
     }
 
     /**


### PR DESCRIPTION
- Drop unit tests for functionality that now is covered by functional tests.
- Use CSV DB assertions for checking the contents of the database.
- Use dedicated per-action DB fixtures.