### PR TITLE
[BUGFIX] Update slug after editing an event in the FE editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -166,6 +166,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- Update the slug after editing or creating an event in the FE editor (#4332)
 - Make the tables in the FE and BE responsive (#4318)
 - Fully initialize reconstituted domain models (#4246)
 - Use the user's display name in the registration record title (#4194)

--- a/Tests/Functional/Controller/Fixtures/FrontEndEditorController/createAction/CreatedEventWithSlug.csv
+++ b/Tests/Functional/Controller/Fixtures/FrontEndEditorController/createAction/CreatedEventWithSlug.csv
@@ -1,0 +1,3 @@
+"tx_seminars_seminars"
+,"uid","title","slug"
+,1,"Karaoke party","karaoke-party/1"

--- a/Tests/Functional/Controller/Fixtures/FrontEndEditorController/updateAction/EventWithOwner.csv
+++ b/Tests/Functional/Controller/Fixtures/FrontEndEditorController/updateAction/EventWithOwner.csv
@@ -1,3 +1,3 @@
 "tx_seminars_seminars"
-,"uid","pid","title","owner_feuser"
-,1,2,"event with owner",1
+,"uid","pid","title","owner_feuser","slug"
+,1,2,"event with owner",1,"old-slug"

--- a/Tests/Functional/Controller/Fixtures/FrontEndEditorController/updateAction/UpdatedEventWithSlug.csv
+++ b/Tests/Functional/Controller/Fixtures/FrontEndEditorController/updateAction/UpdatedEventWithSlug.csv
@@ -1,0 +1,3 @@
+"tx_seminars_seminars"
+,"uid","title","slug"
+,1,"Karaoke party","karaoke-party/1"

--- a/Tests/Functional/Controller/FrontEndEditorControllerTest.php
+++ b/Tests/Functional/Controller/FrontEndEditorControllerTest.php
@@ -252,6 +252,27 @@ final class FrontEndEditorControllerTest extends FunctionalTestCase
     /**
      * @test
      */
+    public function updateActionUpdatesSlug(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/FrontEndEditorController/updateAction/EventWithOwner.csv');
+
+        $newTitle = 'Karaoke party';
+        $request = (new InternalRequest())->withPageId(self::PAGE_UID)->withQueryParameters([
+            'tx_seminars_frontendeditor[__trustedProperties]' => $this->getTrustedPropertiesFromEditForm(1, 1),
+            'tx_seminars_frontendeditor[action]' => 'update',
+            'tx_seminars_frontendeditor[event][__identity]' => '1',
+            'tx_seminars_frontendeditor[event][internalTitle]' => $newTitle,
+        ]);
+        $context = (new InternalRequestContext())->withFrontendUserId(1);
+
+        $this->executeFrontendSubRequest($request, $context);
+
+        $this->assertCSVDataSet(__DIR__ . '/Fixtures/FrontEndEditorController/updateAction/UpdatedEventWithSlug.csv');
+    }
+
+    /**
+     * @test
+     */
     public function newActionWithNoProvidedEventCanBeRendered(): void
     {
         $request = (new InternalRequest())->withPageId(self::PAGE_UID)->withQueryParameters([
@@ -297,5 +318,22 @@ final class FrontEndEditorControllerTest extends FunctionalTestCase
         $this->executeFrontendSubRequest($request, $context);
 
         $this->assertCSVDataSet(__DIR__ . '/Fixtures/FrontEndEditorController/createAction/NewlyCreatedEvent.csv');
+    }
+
+    /**
+     * @test
+     */
+    public function createActionSetsSlug(): void
+    {
+        $request = (new InternalRequest())->withPageId(self::PAGE_UID)->withQueryParameters([
+            'tx_seminars_frontendeditor[__trustedProperties]' => $this->getTrustedPropertiesFromNewForm(1),
+            'tx_seminars_frontendeditor[action]' => 'create',
+            'tx_seminars_frontendeditor[event][internalTitle]' => 'Karaoke party',
+        ]);
+        $context = (new InternalRequestContext())->withFrontendUserId(1);
+
+        $this->executeFrontendSubRequest($request, $context);
+
+        $this->assertCSVDataSet(__DIR__ . '/Fixtures/FrontEndEditorController/createAction/CreatedEventWithSlug.csv');
     }
 }

--- a/Tests/Unit/Controller/FrontEndEditorControllerTest.php
+++ b/Tests/Unit/Controller/FrontEndEditorControllerTest.php
@@ -13,7 +13,9 @@ use OliverKlee\Seminars\Domain\Repository\EventTypeRepository;
 use OliverKlee\Seminars\Domain\Repository\OrganizerRepository;
 use OliverKlee\Seminars\Domain\Repository\SpeakerRepository;
 use OliverKlee\Seminars\Domain\Repository\VenueRepository;
+use OliverKlee\Seminars\Seo\SlugGenerator;
 use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\MockObject\Stub;
 use TYPO3\CMS\Core\Context\Context;
 use TYPO3\CMS\Core\Context\UserAspect;
 use TYPO3\CMS\Core\Http\HtmlResponse;
@@ -69,6 +71,11 @@ final class FrontEndEditorControllerTest extends UnitTestCase
      */
     private VenueRepository $venueRepositoryMock;
 
+    /**
+     * @var SlugGenerator&Stub
+     */
+    private SlugGenerator $slugGeneratorStub;
+
     private Context $context;
 
     protected function setUp(): void
@@ -80,6 +87,7 @@ final class FrontEndEditorControllerTest extends UnitTestCase
         $this->organizerRepositoryMock = $this->createMock(OrganizerRepository::class);
         $this->speakerRepositoryMock = $this->createMock(SpeakerRepository::class);
         $this->venueRepositoryMock = $this->createMock(VenueRepository::class);
+        $this->slugGeneratorStub = $this->createStub(SlugGenerator::class);
 
         $methodsToMock = ['htmlResponse', 'redirect', 'redirectToUri'];
         /** @var FrontEndEditorController&AccessibleObjectInterface&MockObject $subject */
@@ -92,6 +100,7 @@ final class FrontEndEditorControllerTest extends UnitTestCase
                 $this->organizerRepositoryMock,
                 $this->speakerRepositoryMock,
                 $this->venueRepositoryMock,
+                $this->slugGeneratorStub,
             ]
         );
         $this->subject = $subject;
@@ -150,6 +159,7 @@ final class FrontEndEditorControllerTest extends UnitTestCase
     public function updateActionRedirectsToIndexAction(): void
     {
         $event = new SingleEvent();
+        $event->_setProperty('uid', 1);
 
         $this->mockRedirect('index');
 
@@ -271,6 +281,7 @@ final class FrontEndEditorControllerTest extends UnitTestCase
     {
         $pageUid = 42;
         $event = new SingleEvent();
+        $event->_setProperty('uid', 1);
         $this->subject->_set('settings', ['folderForCreatedEvents' => (string)$pageUid]);
 
         $this->subject->createAction($event);
@@ -284,6 +295,7 @@ final class FrontEndEditorControllerTest extends UnitTestCase
     public function createActionWithoutPageUidInConfigurationSetsZeroPageUid(): void
     {
         $event = new SingleEvent();
+        $event->_setProperty('uid', 1);
 
         $this->subject->createAction($event);
 
@@ -296,6 +308,7 @@ final class FrontEndEditorControllerTest extends UnitTestCase
     public function createActionRedirectsToIndexAction(): void
     {
         $event = new SingleEvent();
+        $event->_setProperty('uid', 1);
 
         $this->mockRedirect('index');
 


### PR DESCRIPTION
This covers single event records. Event date records will come in a later change.

Fixes #4283