### PR TITLE
[BUGFIX] Reconstitute a label that was erroneously deleted

### DIFF
--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -133,6 +133,9 @@
 			<trans-unit id="label_city">
 				<source>City</source>
 			</trans-unit>
+			<trans-unit id="label_country">
+				<source>Country</source>
+			</trans-unit>
 			<trans-unit id="label_attendees">
 				<source>Attendees</source>
 			</trans-unit>


### PR DESCRIPTION
The label for the country was not only used in the FE, but also in the emails.

Followup to #4261

Fixes #4359