### PR TITLE
[TASK] Drop default argument from `newSingleEventAction`

### DIFF
--- a/Classes/Controller/FrontEndEditorController.php
+++ b/Classes/Controller/FrontEndEditorController.php
@@ -115,12 +115,9 @@ class FrontEndEditorController extends ActionController
         return $this->redirect('index');
     }
 
-    /**
-     * @IgnoreValidation("event")
-     */
-    public function newSingleEventAction(?SingleEvent $event = null): ResponseInterface
+    public function newSingleEventAction(): ResponseInterface
     {
-        $eventToCreate = $event instanceof SingleEvent ? $event : GeneralUtility::makeInstance(SingleEvent::class);
+        $eventToCreate = GeneralUtility::makeInstance(SingleEvent::class);
         $this->view->assign('event', $eventToCreate);
         $this->assignAuxiliaryRecordsToView();
 

--- a/Tests/Functional/Controller/FrontEndEditorControllerTest.php
+++ b/Tests/Functional/Controller/FrontEndEditorControllerTest.php
@@ -403,7 +403,7 @@ final class FrontEndEditorControllerTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function newSingleEventActionWithNoProvidedEventCanBeRendered(): void
+    public function newSingleEventActionCanBeRendered(): void
     {
         $request = (new InternalRequest())->withPageId(self::PAGE_UID)->withQueryParameters([
             'tx_seminars_frontendeditor[action]' => 'newSingleEvent',
@@ -472,24 +472,6 @@ final class FrontEndEditorControllerTest extends FunctionalTestCase
         $html = (string)$this->executeFrontendSubRequest($request, $context)->getBody();
 
         self::assertStringContainsString('name="tx_seminars_frontendeditor[event][' . $key . ']"', $html);
-    }
-
-    /**
-     * @test
-     */
-    public function newSingleEventActionWithEventProvidedRendersProvidedEventData(): void
-    {
-        $newTitle = 'Karaoke party';
-        $request = (new InternalRequest())->withPageId(self::PAGE_UID)->withQueryParameters([
-            'tx_seminars_frontendeditor[__trustedProperties]' => $this->getTrustedPropertiesFromNewForm(1),
-            'tx_seminars_frontendeditor[action]' => 'newSingleEvent',
-            'tx_seminars_frontendeditor[event][internalTitle]' => $newTitle,
-        ]);
-        $context = (new InternalRequestContext())->withFrontendUserId(1);
-
-        $html = (string)$this->executeFrontendSubRequest($request, $context)->getBody();
-
-        self::assertStringContainsString($newTitle, $html);
     }
 
     /**

--- a/Tests/Unit/Controller/FrontEndEditorControllerTest.php
+++ b/Tests/Unit/Controller/FrontEndEditorControllerTest.php
@@ -206,27 +206,7 @@ final class FrontEndEditorControllerTest extends UnitTestCase
     /**
      * @test
      */
-    public function newSingleEventActionWithNullEventAssignsNewEventToView(): void
-    {
-        $event = new SingleEvent();
-        GeneralUtility::addInstance(SingleEvent::class, $event);
-        $this->eventTypeRepositoryMock->method('findAllPlusNullEventType')->willReturn([]);
-
-        $this->viewMock->expects(self::atLeast(5))->method('assign')->withConsecutive(
-            ['event', $event],
-            ['eventTypes', self::anything()],
-            ['organizers', self::anything()],
-            ['speakers', self::anything()],
-            ['venues', self::anything()]
-        );
-
-        $this->subject->newSingleEventAction(null);
-    }
-
-    /**
-     * @test
-     */
-    public function newSingleEventActionWithoutEventAssignsNewEventToView(): void
+    public function newSingleEventActionAssignsNewEventToView(): void
     {
         $event = new SingleEvent();
         GeneralUtility::addInstance(SingleEvent::class, $event);
@@ -248,8 +228,6 @@ final class FrontEndEditorControllerTest extends UnitTestCase
      */
     public function newSingleEventActionAssignsAuxiliaryRecordsToView(): void
     {
-        $event = new SingleEvent();
-
         /** @var list<EventTypeInterface> $eventTypes */
         $eventTypes = [new NullEventType()];
         $this->eventTypeRepositoryMock->method('findAllPlusNullEventType')->willReturn($eventTypes);
@@ -271,7 +249,7 @@ final class FrontEndEditorControllerTest extends UnitTestCase
             ['venues', $venues]
         );
 
-        $this->subject->newSingleEventAction($event);
+        $this->subject->newSingleEventAction();
     }
 
     /**


### PR DESCRIPTION
With recent TYPO3 versions, form values on failed validation are restored in a different way, and so this mechanism is no longer needed.

Fixes #4358