### PR TITLE
[FEATURE] Add seminars-specific frontend user model/repository

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- Add seminars-specific frontend user model and repository (#4370)
 - Add the number of offline registrations to the FE editor (#4364, #4365)
 - Make the fields in the FE editor configurable (#4362)
 - Add an `Event.slug` property (#4331)

--- a/Classes/BackEnd/EmailService.php
+++ b/Classes/BackEnd/EmailService.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace OliverKlee\Seminars\BackEnd;
 
-use OliverKlee\FeUserExtraFields\Domain\Model\FrontendUser;
 use OliverKlee\Oelib\Email\SystemEmailFromBuilder;
 use OliverKlee\Oelib\Exception\NotFoundException;
 use OliverKlee\Oelib\Interfaces\MailRole;
 use OliverKlee\Seminars\Domain\Model\Event\Event;
 use OliverKlee\Seminars\Domain\Model\Event\EventDateInterface;
+use OliverKlee\Seminars\Domain\Model\FrontendUser;
 use OliverKlee\Seminars\Domain\Model\Organizer;
 use OliverKlee\Seminars\Domain\Repository\Registration\RegistrationRepository;
 use OliverKlee\Seminars\Email\EmailBuilder;

--- a/Classes/Domain/Model/FrontendUser.php
+++ b/Classes/Domain/Model/FrontendUser.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OliverKlee\Seminars\Domain\Model;
+
+use OliverKlee\FeUserExtraFields\Domain\Model\FrontendUser as ExtraFieldsFrontendUser;
+
+/**
+ * This class represents a frontend user with some additional data specific to the seminars extension.
+ */
+class FrontendUser extends ExtraFieldsFrontendUser
+{
+}

--- a/Classes/Domain/Model/Registration/AttendeesTrait.php
+++ b/Classes/Domain/Model/Registration/AttendeesTrait.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace OliverKlee\Seminars\Domain\Model\Registration;
 
-use OliverKlee\FeUserExtraFields\Domain\Model\FrontendUser;
+use OliverKlee\Seminars\Domain\Model\FrontendUser;
 use TYPO3\CMS\Extbase\Annotation\ORM\Lazy;
 use TYPO3\CMS\Extbase\Annotation\ORM\Transient;
 use TYPO3\CMS\Extbase\Annotation\Validate;

--- a/Classes/Domain/Model/Registration/Registration.php
+++ b/Classes/Domain/Model/Registration/Registration.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace OliverKlee\Seminars\Domain\Model\Registration;
 
-use OliverKlee\FeUserExtraFields\Domain\Model\FrontendUser;
 use OliverKlee\Seminars\Domain\Model\AccommodationOption;
 use OliverKlee\Seminars\Domain\Model\Event\Event;
 use OliverKlee\Seminars\Domain\Model\Event\EventDate;
 use OliverKlee\Seminars\Domain\Model\Event\SingleEvent;
 use OliverKlee\Seminars\Domain\Model\FoodOption;
+use OliverKlee\Seminars\Domain\Model\FrontendUser;
 use OliverKlee\Seminars\Domain\Model\RawDataInterface;
 use OliverKlee\Seminars\Domain\Model\RawDataTrait;
 use OliverKlee\Seminars\Domain\Model\RegistrationCheckbox;

--- a/Classes/Domain/Repository/FrontendUserRepository.php
+++ b/Classes/Domain/Repository/FrontendUserRepository.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OliverKlee\Seminars\Domain\Repository;
+
+use OliverKlee\Seminars\Domain\Model\FrontendUser;
+use TYPO3\CMS\Extbase\Persistence\Repository;
+
+/**
+ * @extends Repository<FrontendUser>
+ */
+class FrontendUserRepository extends Repository
+{
+}

--- a/Classes/Email/EmailBuilder.php
+++ b/Classes/Email/EmailBuilder.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace OliverKlee\Seminars\Email;
 
-use OliverKlee\FeUserExtraFields\Domain\Model\FrontendUser;
 use OliverKlee\Oelib\Interfaces\MailRole;
+use OliverKlee\Seminars\Domain\Model\FrontendUser;
 use Symfony\Component\Mime\Address;
 use TYPO3\CMS\Core\Mail\MailMessage;
 use TYPO3\CMS\Core\Utility\GeneralUtility;

--- a/Classes/Service/RegistrationProcessor.php
+++ b/Classes/Service/RegistrationProcessor.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace OliverKlee\Seminars\Service;
 
-use OliverKlee\FeUserExtraFields\Domain\Model\FrontendUser;
 use OliverKlee\FeUserExtraFields\Domain\Repository\FrontendUserRepository;
 use OliverKlee\Seminars\Configuration\LegacyConfiguration;
 use OliverKlee\Seminars\Domain\Model\Event\Event;
 use OliverKlee\Seminars\Domain\Model\Event\EventDateInterface;
+use OliverKlee\Seminars\Domain\Model\FrontendUser;
 use OliverKlee\Seminars\Domain\Model\Price;
 use OliverKlee\Seminars\Domain\Model\Registration\Registration;
 use OliverKlee\Seminars\Domain\Repository\Event\EventRepository;

--- a/Configuration/Extbase/Persistence/Classes.php
+++ b/Configuration/Extbase/Persistence/Classes.php
@@ -10,6 +10,7 @@ use OliverKlee\Seminars\Domain\Model\Event\EventTopic;
 use OliverKlee\Seminars\Domain\Model\Event\SingleEvent;
 use OliverKlee\Seminars\Domain\Model\EventType;
 use OliverKlee\Seminars\Domain\Model\FoodOption;
+use OliverKlee\Seminars\Domain\Model\FrontendUser;
 use OliverKlee\Seminars\Domain\Model\Organizer;
 use OliverKlee\Seminars\Domain\Model\PaymentMethod;
 use OliverKlee\Seminars\Domain\Model\Registration\Registration;
@@ -113,6 +114,9 @@ return [
     ],
     FoodOption::class => [
         'tableName' => 'tx_seminars_foods',
+    ],
+    FrontendUser::class => [
+        'tableName' => 'fe_users',
     ],
     Organizer::class => [
         'tableName' => 'tx_seminars_organizers',

--- a/Tests/Functional/Domain/Repository/Fixtures/FrontendUserRepository/propertyMapping/FrontendUserWithAllScalarData.csv
+++ b/Tests/Functional/Domain/Repository/Fixtures/FrontendUserRepository/propertyMapping/FrontendUserWithAllScalarData.csv
@@ -1,0 +1,3 @@
+"fe_users"
+,"uid","crdate","tstamp","username","password","usergroup","name","first_name","middle_name","last_name","address","telephone","email","title","zip","city","country","www","company","image","lastlogin","zone","privacy","terms_acknowledged","full_salutation","gender","date_of_birth","status","comments","terms_date_of_acceptance","privacy_date_of_acceptance","vat_in"
+,1,1546300800,1672531200,"max","luif3ui4t12","","Max M. Minimau","Max","Murri","Minimau","Near the heating 4","+49 1111 1233456-78","max@example.com","Head of fur","01234","Kattingen","United States of CAT","www.example.com","Cat Scans Inc.","",1648922400,"NRW",1,1,"Welcome, Max MM!",2,1648857600,2,"Here we go!",1716000000,1713000000,"DE123456789"

--- a/Tests/Functional/Domain/Repository/FrontendUserRepositoryTest.php
+++ b/Tests/Functional/Domain/Repository/FrontendUserRepositoryTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OliverKlee\Seminars\Tests\Functional\Domain\Repository;
+
+use OliverKlee\FeUserExtraFields\Domain\Model\Gender;
+use OliverKlee\Seminars\Domain\Model\FrontendUser;
+use OliverKlee\Seminars\Domain\Repository\FrontendUserRepository;
+use TYPO3\CMS\Extbase\Persistence\Repository;
+use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
+
+/**
+ * @covers \OliverKlee\Seminars\Domain\Model\FrontendUser
+ * @covers \OliverKlee\Seminars\Domain\Repository\FrontendUserRepository
+ */
+final class FrontendUserRepositoryTest extends FunctionalTestCase
+{
+    protected array $testExtensionsToLoad = [
+        'oliverklee/feuserextrafields',
+        'oliverklee/oelib',
+        'oliverklee/seminars',
+    ];
+
+    private FrontendUserRepository $subject;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->subject = $this->get(FrontendUserRepository::class);
+    }
+
+    /**
+     * @test
+     */
+    public function isRepository(): void
+    {
+        self::assertInstanceOf(Repository::class, $this->subject);
+    }
+
+    /**
+     * @test
+     */
+    public function mapsAllModelFields(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/FrontendUserRepository/propertyMapping/FrontendUserWithAllScalarData.csv');
+
+        $model = $this->subject->findByUid(1);
+
+        self::assertInstanceOf(FrontendUser::class, $model);
+        self::assertEquals(new \DateTime('2019-01-01 00:00:00'), $model->getCreationDate());
+        self::assertEquals(new \DateTime('2023-01-01 00:00:00'), $model->getModificationDate());
+        self::assertSame('max', $model->getUsername());
+        self::assertSame('luif3ui4t12', $model->getPassword());
+        self::assertSame('Max M. Minimau', $model->getName());
+        self::assertSame('Max', $model->getFirstName());
+        self::assertSame('Murri', $model->getMiddleName());
+        self::assertSame('Minimau', $model->getLastName());
+        self::assertSame('Near the heating 4', $model->getAddress());
+        self::assertSame('+49 1111 1233456-78', $model->getTelephone());
+        self::assertSame('max@example.com', $model->getEmail());
+        self::assertSame('Head of fur', $model->getTitle());
+        self::assertSame('01234', $model->getZip());
+        self::assertSame('Kattingen', $model->getCity());
+        self::assertSame('United States of CAT', $model->getCountry());
+        self::assertSame('www.example.com', $model->getWww());
+        self::assertSame('Cat Scans Inc.', $model->getCompany());
+        self::assertSame('DE123456789', $model->getVatIn());
+        self::assertEquals(new \DateTime('2022-04-02T18:00'), $model->getLastLogin());
+        self::assertTrue($model->getPrivacy());
+        self::assertEquals(new \DateTime('2024-04-13T09:20'), $model->getPrivacyDateOfAcceptance());
+        self::assertTrue($model->hasTermsAcknowledged());
+        self::assertEquals(new \DateTime('2024-05-18T02:40'), $model->getTermsDateOfAcceptance());
+        self::assertSame('NRW', $model->getZone());
+        self::assertSame('Welcome, Max MM!', $model->getFullSalutation());
+        self::assertSame(Gender::diverse(), $model->getGender());
+        self::assertEquals(new \DateTime('2022-04-02T00:00'), $model->getDateOfBirth());
+        self::assertSame(FrontendUser::STATUS_JOB_SEEKING_FULL_TIME, $model->getStatus());
+        self::assertSame('Here we go!', $model->getComments());
+    }
+}

--- a/Tests/Functional/Domain/Repository/Registration/RegistrationRepositoryTest.php
+++ b/Tests/Functional/Domain/Repository/Registration/RegistrationRepositoryTest.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace OliverKlee\Seminars\Tests\Functional\Domain\Repository\Registration;
 
-use OliverKlee\FeUserExtraFields\Domain\Model\FrontendUser;
 use OliverKlee\Seminars\Domain\Model\AccommodationOption;
 use OliverKlee\Seminars\Domain\Model\Event\EventDate;
 use OliverKlee\Seminars\Domain\Model\Event\EventTopic;
 use OliverKlee\Seminars\Domain\Model\Event\SingleEvent;
 use OliverKlee\Seminars\Domain\Model\FoodOption;
+use OliverKlee\Seminars\Domain\Model\FrontendUser;
 use OliverKlee\Seminars\Domain\Model\PaymentMethod;
 use OliverKlee\Seminars\Domain\Model\Price;
 use OliverKlee\Seminars\Domain\Model\Registration\Registration;

--- a/Tests/Functional/Service/RegistrationProcessorTest.php
+++ b/Tests/Functional/Service/RegistrationProcessorTest.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace OliverKlee\Seminars\Tests\Functional\Service;
 
-use OliverKlee\FeUserExtraFields\Domain\Model\FrontendUser;
 use OliverKlee\FeUserExtraFields\Domain\Repository\FrontendUserRepository;
 use OliverKlee\Seminars\Domain\Model\Event\SingleEvent;
+use OliverKlee\Seminars\Domain\Model\FrontendUser;
 use OliverKlee\Seminars\Domain\Model\Registration\Registration;
 use OliverKlee\Seminars\Domain\Repository\Event\EventRepository;
 use OliverKlee\Seminars\Domain\Repository\Registration\RegistrationRepository;

--- a/Tests/Unit/Controller/EventUnregistrationControllerTest.php
+++ b/Tests/Unit/Controller/EventUnregistrationControllerTest.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace OliverKlee\Seminars\Tests\Unit\Controller;
 
-use OliverKlee\FeUserExtraFields\Domain\Model\FrontendUser;
 use OliverKlee\Seminars\Configuration\LegacyConfiguration;
 use OliverKlee\Seminars\Controller\EventUnregistrationController;
 use OliverKlee\Seminars\Domain\Model\Event\SingleEvent;
+use OliverKlee\Seminars\Domain\Model\FrontendUser;
 use OliverKlee\Seminars\Domain\Model\Registration\Registration;
 use OliverKlee\Seminars\OldModel\LegacyEvent;
 use OliverKlee\Seminars\OldModel\LegacyRegistration;

--- a/Tests/Unit/Domain/Model/FrontendUserTest.php
+++ b/Tests/Unit/Domain/Model/FrontendUserTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OliverKlee\Seminars\Tests\Unit\Domain\Model;
+
+use OliverKlee\FeUserExtraFields\Domain\Model\FrontendUser as ExtraFieldsFrontendUser;
+use OliverKlee\Seminars\Domain\Model\FrontendUser;
+use TYPO3\CMS\Extbase\DomainObject\AbstractEntity;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+/**
+ * @covers \OliverKlee\Seminars\Domain\Model\FrontendUser
+ */
+final class FrontendUserTest extends UnitTestCase
+{
+    private FrontendUser $subject;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->subject = new FrontendUser();
+    }
+
+    /**
+     * @test
+     */
+    public function isAbstractEntity(): void
+    {
+        self::assertInstanceOf(AbstractEntity::class, $this->subject);
+    }
+
+    /**
+     * @test
+     */
+    public function isExtraFieldsFrontendUserEntity(): void
+    {
+        self::assertInstanceOf(ExtraFieldsFrontendUser::class, $this->subject);
+    }
+}

--- a/Tests/Unit/Domain/Model/Registration/RegistrationTest.php
+++ b/Tests/Unit/Domain/Model/Registration/RegistrationTest.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 namespace OliverKlee\Seminars\Tests\Unit\Domain\Model\Registration;
 
-use OliverKlee\FeUserExtraFields\Domain\Model\FrontendUser;
 use OliverKlee\Seminars\Domain\Model\AccommodationOption;
 use OliverKlee\Seminars\Domain\Model\Event\Event;
 use OliverKlee\Seminars\Domain\Model\Event\EventDate;
 use OliverKlee\Seminars\Domain\Model\Event\EventTopic;
 use OliverKlee\Seminars\Domain\Model\Event\SingleEvent;
 use OliverKlee\Seminars\Domain\Model\FoodOption;
+use OliverKlee\Seminars\Domain\Model\FrontendUser;
 use OliverKlee\Seminars\Domain\Model\PaymentMethod;
 use OliverKlee\Seminars\Domain\Model\Price;
 use OliverKlee\Seminars\Domain\Model\RawDataInterface;

--- a/Tests/Unit/Email/EmailBuilderTest.php
+++ b/Tests/Unit/Email/EmailBuilderTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace OliverKlee\Seminars\Tests\Unit\Email;
 
-use OliverKlee\FeUserExtraFields\Domain\Model\FrontendUser;
+use OliverKlee\Seminars\Domain\Model\FrontendUser;
 use OliverKlee\Seminars\Email\EmailBuilder;
 use OliverKlee\Seminars\Tests\Unit\Email\Fixtures\TestingMailRole;
 use Symfony\Component\Mime\Part\DataPart;

--- a/Tests/Unit/Service/RegistrationProcessorTest.php
+++ b/Tests/Unit/Service/RegistrationProcessorTest.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace OliverKlee\Seminars\Tests\Unit\Service;
 
-use OliverKlee\FeUserExtraFields\Domain\Model\FrontendUser;
 use OliverKlee\FeUserExtraFields\Domain\Repository\FrontendUserRepository;
 use OliverKlee\Seminars\Configuration\LegacyConfiguration;
 use OliverKlee\Seminars\Domain\Model\Event\SingleEvent;
+use OliverKlee\Seminars\Domain\Model\FrontendUser;
 use OliverKlee\Seminars\Domain\Model\Price;
 use OliverKlee\Seminars\Domain\Model\Registration\Registration;
 use OliverKlee\Seminars\Domain\Repository\Event\EventRepository;

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -286,12 +286,7 @@ parameters:
 			path: Classes/Domain/Model/Registration/Registration.php
 
 		-
-			message: "#^Method OliverKlee\\\\Seminars\\\\Domain\\\\Model\\\\Registration\\\\Registration\\:\\:getUser\\(\\) should return OliverKlee\\\\FeUserExtraFields\\\\Domain\\\\Model\\\\FrontendUser\\|null but returns object\\|null\\.$#"
-			count: 1
-			path: Classes/Domain/Model/Registration/Registration.php
-
-		-
-			message: "#^Parameters should have \"TYPO3\\\\CMS\\\\Extbase\\\\Persistence\\\\ObjectStorage\\<OliverKlee\\\\FeUserExtraFields\\\\Domain\\\\Model\\\\FrontendUser\\>\" types as the only types passed to this method$#"
+			message: "#^Method OliverKlee\\\\Seminars\\\\Domain\\\\Model\\\\Registration\\\\Registration\\:\\:getUser\\(\\) should return OliverKlee\\\\Seminars\\\\Domain\\\\Model\\\\FrontendUser\\|null but returns object\\|null\\.$#"
 			count: 1
 			path: Classes/Domain/Model/Registration/Registration.php
 
@@ -302,6 +297,11 @@ parameters:
 
 		-
 			message: "#^Parameters should have \"TYPO3\\\\CMS\\\\Extbase\\\\Persistence\\\\ObjectStorage\\<OliverKlee\\\\Seminars\\\\Domain\\\\Model\\\\FoodOption\\>\" types as the only types passed to this method$#"
+			count: 1
+			path: Classes/Domain/Model/Registration/Registration.php
+
+		-
+			message: "#^Parameters should have \"TYPO3\\\\CMS\\\\Extbase\\\\Persistence\\\\ObjectStorage\\<OliverKlee\\\\Seminars\\\\Domain\\\\Model\\\\FrontendUser\\>\" types as the only types passed to this method$#"
 			count: 1
 			path: Classes/Domain/Model/Registration/Registration.php
 
@@ -1526,7 +1526,7 @@ parameters:
 			path: Classes/Service/RegistrationManager.php
 
 		-
-			message: "#^Parameter \\#1 \\.\\.\\.\\$recipients of method OliverKlee\\\\Seminars\\\\Email\\\\EmailBuilder\\:\\:to\\(\\) expects OliverKlee\\\\FeUserExtraFields\\\\Domain\\\\Model\\\\FrontendUser\\|OliverKlee\\\\Oelib\\\\Interfaces\\\\MailRole, OliverKlee\\\\Seminars\\\\OldModel\\\\LegacyOrganizer\\|null given\\.$#"
+			message: "#^Parameter \\#1 \\.\\.\\.\\$recipients of method OliverKlee\\\\Seminars\\\\Email\\\\EmailBuilder\\:\\:to\\(\\) expects OliverKlee\\\\Oelib\\\\Interfaces\\\\MailRole\\|OliverKlee\\\\Seminars\\\\Domain\\\\Model\\\\FrontendUser, OliverKlee\\\\Seminars\\\\OldModel\\\\LegacyOrganizer\\|null given\\.$#"
 			count: 2
 			path: Classes/Service/RegistrationManager.php
 


### PR DESCRIPTION
This is required so we can store the per-user default organizer for the FE editor.