### PR TITLE
[FEATURE] Add STI type check methods to the event methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
-- Allow editing event date records in the FE editor (#4399)
+- Allow editing event date records in the FE editor (#4399, #4401)
 - Add `EventRepository::findAllTopics()`/`::findTopicsByUids()` (#4391, #4392)
 - Allow editing the event categories in the FE editor (#4380, #4389)
 - Add `Event.categories` (#4388)

--- a/Classes/Domain/Model/Event/EventDate.php
+++ b/Classes/Domain/Model/Event/EventDate.php
@@ -29,6 +29,21 @@ class EventDate extends Event implements EventDateInterface
         $this->initializeEventDate();
     }
 
+    public function isSingleEvent(): bool
+    {
+        return false;
+    }
+
+    public function isEventDate(): bool
+    {
+        return true;
+    }
+
+    public function isEventTopic(): bool
+    {
+        return false;
+    }
+
     public function getTopic(): ?EventTopic
     {
         return $this->topic;

--- a/Classes/Domain/Model/Event/EventInterface.php
+++ b/Classes/Domain/Model/Event/EventInterface.php
@@ -48,6 +48,12 @@ interface EventInterface
 
     public function setHidden(bool $hidden): void;
 
+    public function isSingleEvent(): bool;
+
+    public function isEventDate(): bool;
+
+    public function isEventTopic(): bool;
+
     public function getInternalTitle(): string;
 
     public function getDisplayTitle(): string;

--- a/Classes/Domain/Model/Event/EventTopic.php
+++ b/Classes/Domain/Model/Event/EventTopic.php
@@ -22,6 +22,21 @@ class EventTopic extends Event implements EventTopicInterface
         $this->initializeEventTopic();
     }
 
+    public function isSingleEvent(): bool
+    {
+        return false;
+    }
+
+    public function isEventDate(): bool
+    {
+        return false;
+    }
+
+    public function isEventTopic(): bool
+    {
+        return true;
+    }
+
     /**
      * @internal
      */

--- a/Classes/Domain/Model/Event/SingleEvent.php
+++ b/Classes/Domain/Model/Event/SingleEvent.php
@@ -23,4 +23,19 @@ class SingleEvent extends Event implements EventDateInterface, EventTopicInterfa
         $this->initializeEventTopic();
         $this->initializeEventDate();
     }
+
+    public function isSingleEvent(): bool
+    {
+        return true;
+    }
+
+    public function isEventDate(): bool
+    {
+        return false;
+    }
+
+    public function isEventTopic(): bool
+    {
+        return false;
+    }
 }

--- a/Tests/Unit/Domain/Model/Event/EventDateTest.php
+++ b/Tests/Unit/Domain/Model/Event/EventDateTest.php
@@ -1727,4 +1727,28 @@ final class EventDateTest extends UnitTestCase
 
         self::assertSame($value, $this->subject->getSlug());
     }
+
+    /**
+     * @test
+     */
+    public function isSingleEventAlwaysReturnsFalse(): void
+    {
+        self::assertFalse($this->subject->isSingleEvent());
+    }
+
+    /**
+     * @test
+     */
+    public function isEventDateAlwaysReturnsTrue(): void
+    {
+        self::assertTrue($this->subject->isEventDate());
+    }
+
+    /**
+     * @test
+     */
+    public function isEventTopicAlwaysReturnsFalse(): void
+    {
+        self::assertFalse($this->subject->isEventTopic());
+    }
 }

--- a/Tests/Unit/Domain/Model/Event/EventTopicTest.php
+++ b/Tests/Unit/Domain/Model/Event/EventTopicTest.php
@@ -632,4 +632,28 @@ final class EventTopicTest extends UnitTestCase
 
         self::assertSame($associatedModels, $this->subject->getCategories());
     }
+
+    /**
+     * @test
+     */
+    public function isSingleEventAlwaysReturnsFalse(): void
+    {
+        self::assertFalse($this->subject->isSingleEvent());
+    }
+
+    /**
+     * @test
+     */
+    public function isEventDateAlwaysReturnsFalse(): void
+    {
+        self::assertFalse($this->subject->isEventDate());
+    }
+
+    /**
+     * @test
+     */
+    public function isEventTopicAlwaysReturnsTrue(): void
+    {
+        self::assertTrue($this->subject->isEventTopic());
+    }
 }

--- a/Tests/Unit/Domain/Model/Event/SingleEventTest.php
+++ b/Tests/Unit/Domain/Model/Event/SingleEventTest.php
@@ -1872,4 +1872,28 @@ final class SingleEventTest extends UnitTestCase
 
         self::assertSame($associatedModels, $this->subject->getCategories());
     }
+
+    /**
+     * @test
+     */
+    public function isSingleEventAlwaysReturnsTrue(): void
+    {
+        self::assertTrue($this->subject->isSingleEvent());
+    }
+
+    /**
+     * @test
+     */
+    public function isEventDateAlwaysReturnsFalse(): void
+    {
+        self::assertFalse($this->subject->isEventDate());
+    }
+
+    /**
+     * @test
+     */
+    public function isEventTopicAlwaysReturnsFalse(): void
+    {
+        self::assertFalse($this->subject->isEventTopic());
+    }
 }


### PR DESCRIPTION
These methods are needed to differentiate between different object types in the FE editor form.

Part of #4282