### PR TITLE
[TASK] Add helper method for date aux records in the FE editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Added
 
 - Allow editing event date records in the FE editor
-  (#4399, #4401, #4402, #4404, #4407)
+  (#4399, #4401, #4402, #4404, #4407, #4415)
 - Add `EventRepository::findAllTopics()`/`::findTopicsByUids()`
   (#4391, #4392, #4410, #4411)
 - Allow editing the event categories in the FE editor (#4380, #4389)

--- a/Classes/Controller/FrontEndEditorController.php
+++ b/Classes/Controller/FrontEndEditorController.php
@@ -207,11 +207,18 @@ class FrontEndEditorController extends ActionController
         $this->checkEventOwner($event);
 
         $this->view->assign('event', $event);
-        $this->view->assign('topics', $this->eventRepository->findAllTopicsPlusNullTopic());
-        $this->assignAuxiliaryRecordsForSingleEventToView();
+        $this->assignAuxiliaryRecordsForEventDateToView();
         $this->view->assign('defaultOrganizerUid', $this->getDefaultOrganizerUid());
 
         return $this->htmlResponse();
+    }
+
+    private function assignAuxiliaryRecordsForEventDateToView(): void
+    {
+        $this->view->assign('topics', $this->eventRepository->findAllTopicsPlusNullTopic());
+        $this->view->assign('organizers', $this->organizerRepository->findAll());
+        $this->view->assign('speakers', $this->speakerRepository->findAll());
+        $this->view->assign('venues', $this->venueRepository->findAll());
     }
 
     public function updateEventDateAction(EventDate $event): ResponseInterface


### PR DESCRIPTION
When editing event date records, we don't need some auxiliary records (event types, categories), but we need the topics.

Follow-up to #4407