### PR TITLE
[BUGFIX] Use a different MIME type in the functional tests

### DIFF
--- a/Tests/Functional/Controller/Fixtures/MyRegistrationsController/showAction/NonBindingReservationWithDownload.csv
+++ b/Tests/Functional/Controller/Fixtures/MyRegistrationsController/showAction/NonBindingReservationWithDownload.csv
@@ -4,7 +4,7 @@
 
 "sys_file"
 ,"uid","storage","type","folder_hash","identifier","identifier_hash","name","extension","mime_type"
-,1,1,0,"42099b4af021e53fd8fd4e056c2568d7c2e3ffa8","/speaker.jpg","f538498838e47c912a95d34187872e879f8285b6","speaker.jpg","jpg","image/jpeg"
+,1,1,0,"42099b4af021e53fd8fd4e056c2568d7c2e3ffa8","/speaker.txt","f538498838e47c912a95d34187872e879f8285b6","speaker.txt","txt","text/plain"
 
 "sys_file_reference"
 ,"uid","uid_local","uid_foreign","tablenames","fieldname"

--- a/Tests/Functional/Controller/Fixtures/MyRegistrationsController/showAction/RegistrationWithDownloadStartInFuture.csv
+++ b/Tests/Functional/Controller/Fixtures/MyRegistrationsController/showAction/RegistrationWithDownloadStartInFuture.csv
@@ -4,7 +4,7 @@
 
 "sys_file"
 ,"uid","storage","type","folder_hash","identifier","identifier_hash","name","extension","mime_type"
-,1,1,0,"42099b4af021e53fd8fd4e056c2568d7c2e3ffa8","/speaker.jpg","f538498838e47c912a95d34187872e879f8285b6","speaker.jpg","jpg","image/jpeg"
+,1,1,0,"42099b4af021e53fd8fd4e056c2568d7c2e3ffa8","/speaker.txt","f538498838e47c912a95d34187872e879f8285b6","speaker.txt","txt","text/plain"
 
 "sys_file_reference"
 ,"uid","uid_local","uid_foreign","tablenames","fieldname"

--- a/Tests/Functional/Controller/Fixtures/MyRegistrationsController/showAction/RegistrationWithDownloadStartInPast.csv
+++ b/Tests/Functional/Controller/Fixtures/MyRegistrationsController/showAction/RegistrationWithDownloadStartInPast.csv
@@ -4,7 +4,7 @@
 
 "sys_file"
 ,"uid","storage","type","folder_hash","identifier","identifier_hash","name","extension","mime_type"
-,1,1,0,"42099b4af021e53fd8fd4e056c2568d7c2e3ffa8","/speaker.jpg","f538498838e47c912a95d34187872e879f8285b6","speaker.jpg","jpg","image/jpeg"
+,1,1,0,"42099b4af021e53fd8fd4e056c2568d7c2e3ffa8","/speaker.txt","f538498838e47c912a95d34187872e879f8285b6","speaker.txt","txt","text/plain"
 
 "sys_file_reference"
 ,"uid","uid_local","uid_foreign","tablenames","fieldname"

--- a/Tests/Functional/Controller/Fixtures/MyRegistrationsController/showAction/RegularRegistrationWithDownloadWithTitle.csv
+++ b/Tests/Functional/Controller/Fixtures/MyRegistrationsController/showAction/RegularRegistrationWithDownloadWithTitle.csv
@@ -4,7 +4,7 @@
 
 "sys_file"
 ,"uid","storage","type","folder_hash","identifier","identifier_hash","name","extension","mime_type"
-,1,1,0,"42099b4af021e53fd8fd4e056c2568d7c2e3ffa8","/speaker.jpg","f538498838e47c912a95d34187872e879f8285b6","speaker.jpg","jpg","image/jpeg"
+,1,1,0,"42099b4af021e53fd8fd4e056c2568d7c2e3ffa8","/speaker.txt","f538498838e47c912a95d34187872e879f8285b6","speaker.txt","txt","text/plain"
 
 "sys_file_reference"
 ,"uid","uid_local","uid_foreign","tablenames","fieldname","title"

--- a/Tests/Functional/Controller/Fixtures/MyRegistrationsController/showAction/RegularRegistrationWithDownloadWithoutTitle.csv
+++ b/Tests/Functional/Controller/Fixtures/MyRegistrationsController/showAction/RegularRegistrationWithDownloadWithoutTitle.csv
@@ -4,7 +4,7 @@
 
 "sys_file"
 ,"uid","storage","type","folder_hash","identifier","identifier_hash","name","extension","mime_type"
-,1,1,0,"42099b4af021e53fd8fd4e056c2568d7c2e3ffa8","/speaker.jpg","f538498838e47c912a95d34187872e879f8285b6","speaker.jpg","jpg","image/jpeg"
+,1,1,0,"42099b4af021e53fd8fd4e056c2568d7c2e3ffa8","/speaker.txt","f538498838e47c912a95d34187872e879f8285b6","speaker.txt","txt","text/plain"
 
 "sys_file_reference"
 ,"uid","uid_local","uid_foreign","tablenames","fieldname"

--- a/Tests/Functional/Controller/Fixtures/MyRegistrationsController/showAction/WaitingListRegistrationWithDownload.csv
+++ b/Tests/Functional/Controller/Fixtures/MyRegistrationsController/showAction/WaitingListRegistrationWithDownload.csv
@@ -4,7 +4,7 @@
 
 "sys_file"
 ,"uid","storage","type","folder_hash","identifier","identifier_hash","name","extension","mime_type"
-,1,1,0,"42099b4af021e53fd8fd4e056c2568d7c2e3ffa8","/speaker.jpg","f538498838e47c912a95d34187872e879f8285b6","speaker.jpg","jpg","image/jpeg"
+,1,1,0,"42099b4af021e53fd8fd4e056c2568d7c2e3ffa8","/speaker.txt","f538498838e47c912a95d34187872e879f8285b6","speaker.txt","txt","text/plain"
 
 "sys_file_reference"
 ,"uid","uid_local","uid_foreign","tablenames","fieldname"

--- a/Tests/Functional/Controller/MyRegistrationsControllerTest.php
+++ b/Tests/Functional/Controller/MyRegistrationsControllerTest.php
@@ -873,7 +873,7 @@ final class MyRegistrationsControllerTest extends FunctionalTestCase
 
         $response = $this->executeFrontendSubRequest($request, $requestContext);
 
-        self::assertStringContainsString('/speaker.jpg', (string)$response->getBody());
+        self::assertStringContainsString('/speaker.txt', (string)$response->getBody());
     }
 
     /**
@@ -894,7 +894,7 @@ final class MyRegistrationsControllerTest extends FunctionalTestCase
 
         $response = $this->executeFrontendSubRequest($request, $requestContext);
 
-        self::assertMatchesRegularExpression('#>\\s*speaker\\.jpg\\s*</a>#', (string)$response->getBody());
+        self::assertMatchesRegularExpression('#>\\s*speaker\\.txt\\s*</a>#', (string)$response->getBody());
     }
 
     /**
@@ -936,7 +936,7 @@ final class MyRegistrationsControllerTest extends FunctionalTestCase
 
         $response = $this->executeFrontendSubRequest($request, $requestContext);
 
-        self::assertStringNotContainsString('speaker.jpg', (string)$response->getBody());
+        self::assertStringNotContainsString('speaker.txt', (string)$response->getBody());
     }
 
     /**
@@ -957,7 +957,7 @@ final class MyRegistrationsControllerTest extends FunctionalTestCase
 
         $response = $this->executeFrontendSubRequest($request, $requestContext);
 
-        self::assertStringNotContainsString('speaker.jpg', (string)$response->getBody());
+        self::assertStringNotContainsString('speaker.txt', (string)$response->getBody());
     }
 
     /**
@@ -978,7 +978,7 @@ final class MyRegistrationsControllerTest extends FunctionalTestCase
 
         $response = $this->executeFrontendSubRequest($request, $requestContext);
 
-        self::assertStringContainsString('speaker.jpg', (string)$response->getBody());
+        self::assertStringContainsString('speaker.txt', (string)$response->getBody());
     }
 
     /**
@@ -999,6 +999,6 @@ final class MyRegistrationsControllerTest extends FunctionalTestCase
 
         $response = $this->executeFrontendSubRequest($request, $requestContext);
 
-        self::assertStringNotContainsString('speaker.jpg', (string)$response->getBody());
+        self::assertStringNotContainsString('speaker.txt', (string)$response->getBody());
     }
 }


### PR DESCRIPTION
This works around a problem in the testing framework for non-text response contents.