### PR TITLE
[TASK] Set the default for the hidden billing address flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,7 +74,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Changed
 
 - !!! Make the billing address for registrations required
-  (#4487, #4491, #4492, #4493, #4494, #4495)
+  (#4487, #4491, #4492, #4493, #4494, #4495, #4496)
 - !!! Reduce the length of the billing address fields (#4480, #4488)
 - Change the label for the TCEforms billing tab of registrations (#4478)
 - Require Emogrifier >= 8.0.0 (#4455)

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -308,7 +308,7 @@ CREATE TABLE tx_seminars_attendances (
 	additional_persons       int(11) unsigned    DEFAULT '0'    NOT NULL,
 	datepaid                 int(11) unsigned    DEFAULT '0'    NOT NULL,
 	method_of_payment        int(11) unsigned    DEFAULT '0'    NOT NULL,
-	separate_billing_address tinyint(1) unsigned DEFAULT '0'    NOT NULL,
+	separate_billing_address tinyint(1) unsigned DEFAULT '1'    NOT NULL,
 	company                  varchar(80)         DEFAULT '',
 	name                     varchar(80)         DEFAULT ''     NOT NULL,
 	gender                   tinyint(1) unsigned DEFAULT '0'    NOT NULL,


### PR DESCRIPTION
This prevents the newly created records to be processed by the upgrade wizard (which would overwrite the billing address the attendee entered).