### PR TITLE
[BUGFIX] Avoid inlining CSS into empty HTML for the email

### DIFF
--- a/Classes/Service/RegistrationManager.php
+++ b/Classes/Service/RegistrationManager.php
@@ -1015,7 +1015,8 @@ class RegistrationManager
         );
 
         if ($useHtml) {
-            $emailBody = $this->addCssToHtmlEmail($template->getSubpart('MAIL_THANKYOU_HTML'));
+            $html = $template->getSubpart('MAIL_THANKYOU_HTML');
+            $emailBody = ($html !== '') ? $this->addCssToHtmlEmail($html) : '';
         } else {
             $emailBody = $template->getSubpart('MAIL_THANKYOU');
         }
@@ -1036,6 +1037,9 @@ class RegistrationManager
         return new FallbackConfiguration($flexFormsConfiguration, $typoScriptConfiguration);
     }
 
+    /**
+     * @param non-empty-string $emailBody
+     */
     private function addCssToHtmlEmail(string $emailBody): string
     {
         // The CSS inlining uses a Composer-provided library and hence is a Composer-only feature.


### PR DESCRIPTION
This is the 5.x backport of #4520.