### PR TITLE
[TASK] Make a BE label in the billing address more specific

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- Make a BE label in the billing address more specific (#4534)
 - Make the registration title editable in the backend (#4532)
 - Reduce the length of the billing address fields (#4481)
 - Allow Emogrifier >= 8.0.0 (#4456)

--- a/Resources/Private/Language/locallang_db.xlf
+++ b/Resources/Private/Language/locallang_db.xlf
@@ -419,7 +419,7 @@
 				<source>diverse</source>
 			</trans-unit>
 			<trans-unit id="tx_seminars_attendances.address">
-				<source>Address</source>
+				<source>Street address</source>
 			</trans-unit>
 			<trans-unit id="tx_seminars_attendances.zip">
 				<source>ZIP</source>


### PR DESCRIPTION
Make it more clear that this field is the street address, not the complete address.

This is the 5.x backport of #4533.

[ci skip]