### PR TITLE
[BUGFIX] Display the billing city on the registration confirmation page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- Display the billing city on the registration confirmation page (#4548)
 - Fully initialize reconstituted domain models (#4248)
 - Change the registration status from a checkbox to a drop-down (#4192)
 - Fix a copy'n'paste error in a label (#4127)

--- a/Resources/Private/Templates/EventRegistration/Confirm.html
+++ b/Resources/Private/Templates/EventRegistration/Confirm.html
@@ -375,7 +375,7 @@
                                     <f:translate key="{labelPrefix}.city"/>
                                 </th>
                                 <td>
-                                    {registration.billingZipCode}
+                                    {registration.billingCity}
                                 </td>
                             </tr>
                         </f:if>


### PR DESCRIPTION
This is the 5.8.x backport of #4546.

Fixes #4544