### PR TITLE
[BUGFIX] Do not move registrations when moving event records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- Do not move registrations when moving event records (#4551)
 - Display the billing city on the registration confirmation page (#4548)
 - Fully initialize reconstituted domain models (#4248)
 - Change the registration status from a checkbox to a drop-down (#4192)

--- a/Classes/Hooks/DataHandlerHook.php
+++ b/Classes/Hooks/DataHandlerHook.php
@@ -205,7 +205,7 @@ class DataHandlerHook
      */
     public function processCmdmap_preProcess(string $command, string $table): void
     {
-        if (\in_array($command, ['copy', 'localize'], true) && $table === self::TABLE_EVENTS) {
+        if (\in_array($command, ['copy', 'move', 'localize'], true) && $table === self::TABLE_EVENTS) {
             $GLOBALS['TCA'][self::TABLE_EVENTS]['columns']['registrations']['config']['type'] = 'none';
         }
     }
@@ -215,7 +215,7 @@ class DataHandlerHook
      */
     public function processCmdmap_postProcess(string $command, string $table): void
     {
-        if (\in_array($command, ['copy', 'localize'], true) && $table === self::TABLE_EVENTS) {
+        if (\in_array($command, ['copy', 'move', 'localize'], true) && $table === self::TABLE_EVENTS) {
             $GLOBALS['TCA'][self::TABLE_EVENTS]['columns']['registrations']['config']['type'] = 'inline';
         }
     }

--- a/Tests/Functional/Hooks/DataHandlerHookTest.php
+++ b/Tests/Functional/Hooks/DataHandlerHookTest.php
@@ -838,4 +838,38 @@ final class DataHandlerHookTest extends FunctionalTestCase
             __DIR__ . '/Fixtures/DataHandlerHook/copy/SingleEventWithOneRegistrationAndDuplicateWithRegistrations.csv'
         );
     }
+
+    /**
+     * @test
+     */
+    public function canMoveRegistration(): void
+    {
+        $this->initializeBackEndUser();
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/DataHandlerHook/move/SingleEventOnPage.csv');
+
+        $dataHandler = GeneralUtility::makeInstance(DataHandler::class);
+        $dataHandler->start([], ['tx_seminars_seminars' => [1 => ['move' => 2]]]);
+        $dataHandler->process_cmdmap();
+
+        $this->assertCSVDataSet(
+            __DIR__ . '/Fixtures/DataHandlerHook/move/SingleEventOnPageAfterMoving.csv'
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function doesNotMoveRegistrationsWhenMovingEvent(): void
+    {
+        $this->initializeBackEndUser();
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/DataHandlerHook/move/SingleEventWithOneRegistrationOnPage.csv');
+
+        $dataHandler = GeneralUtility::makeInstance(DataHandler::class);
+        $dataHandler->start([], ['tx_seminars_seminars' => [1 => ['move' => 2]]]);
+        $dataHandler->process_cmdmap();
+
+        $this->assertCSVDataSet(
+            __DIR__ . '/Fixtures/DataHandlerHook/move/SingleEventWithOneRegistrationOnPageAfterMoving.csv'
+        );
+    }
 }

--- a/Tests/Functional/Hooks/Fixtures/DataHandlerHook/move/SingleEventOnPage.csv
+++ b/Tests/Functional/Hooks/Fixtures/DataHandlerHook/move/SingleEventOnPage.csv
@@ -1,0 +1,8 @@
+"pages"
+,"uid","pid","doktype","title"
+,1,0,254,"record storage"
+,2,0,254,"another storage"
+
+"tx_seminars_seminars"
+,"uid","pid","object_type"
+,1,1,0

--- a/Tests/Functional/Hooks/Fixtures/DataHandlerHook/move/SingleEventOnPageAfterMoving.csv
+++ b/Tests/Functional/Hooks/Fixtures/DataHandlerHook/move/SingleEventOnPageAfterMoving.csv
@@ -1,0 +1,8 @@
+"pages"
+,"uid","pid","doktype","title"
+,1,0,254,"record storage"
+,2,0,254,"another storage"
+
+"tx_seminars_seminars"
+,"uid","pid","object_type"
+,1,2,0

--- a/Tests/Functional/Hooks/Fixtures/DataHandlerHook/move/SingleEventWithOneRegistrationOnPage.csv
+++ b/Tests/Functional/Hooks/Fixtures/DataHandlerHook/move/SingleEventWithOneRegistrationOnPage.csv
@@ -1,0 +1,17 @@
+"pages"
+,"uid","pid","doktype","title"
+,1,0,254,"record storage"
+,2,0,254,"another storage"
+,3,0,254,"registration storage"
+
+"tx_seminars_seminars"
+,"uid","pid","object_type","registrations"
+,1,1,0,1
+
+"fe_users"
+,"uid","pid"
+,1,1
+
+"tx_seminars_attendances"
+,"uid","pid","seminar","user"
+,1,3,1,1

--- a/Tests/Functional/Hooks/Fixtures/DataHandlerHook/move/SingleEventWithOneRegistrationOnPageAfterMoving.csv
+++ b/Tests/Functional/Hooks/Fixtures/DataHandlerHook/move/SingleEventWithOneRegistrationOnPageAfterMoving.csv
@@ -1,0 +1,17 @@
+"pages"
+,"uid","pid","doktype","title"
+,1,0,254,"record storage"
+,2,0,254,"another storage"
+,3,0,254,"registration storage"
+
+"tx_seminars_seminars"
+,"uid","pid","object_type","registrations"
+,1,2,0,1
+
+"fe_users"
+,"uid","pid"
+,1,1
+
+"tx_seminars_attendances"
+,"uid","pid","seminar","user"
+,1,3,1,1


### PR DESCRIPTION
This is the 5.x backport of #4549.

Fixes #4278