### PR TITLE
[BUGFIX] Use correct extension name for label references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 - Show the invoicing status of registrations in the BE module (#4562)
 - Add accessors for the payment status of registrations (#4560)
-- Add more invoicing-related fields to registrations (#4556, #4563)
+- Add more invoicing-related fields to registrations (#4556, #4563, #4564)
 - Add a field for the billing start for an event (#4476)
 - Add a PSR-14 event for modifying an attendee download (#4463)
 - Add documentation for the PSR-14 event for slug generation (#4465)

--- a/Configuration/TCA/tx_seminars_attendances.php
+++ b/Configuration/TCA/tx_seminars_attendances.php
@@ -389,7 +389,7 @@ $tca = [
         ],
         'invoice_number' => [
             'exclude' => true,
-            'label' => 'LLL:EXT:seminars_premium/Resources/Private/Language/locallang_db.xlf:tx_seminars_attendances.invoice_number',
+            'label' => 'LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_attendances.invoice_number',
             'config' => [
                 'type' => 'input',
                 'size' => 8,
@@ -399,7 +399,7 @@ $tca = [
         ],
         'customer_number' => [
             'exclude' => true,
-            'label' => 'LLL:EXT:seminars_premium/Resources/Private/Language/locallang_db.xlf:tx_seminars_attendances.customer_number',
+            'label' => 'LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_attendances.customer_number',
             'config' => [
                 'type' => 'input',
                 'size' => 8,


### PR DESCRIPTION
This is a followup to #4556 to fix a copy'n'paste error.