### PR TITLE
[TASK] Drop the `tablenames` column from the MM tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- Rely on the Core to autogenerate the MM tables (#4578)
 - Make a BE label in the billing address more specific (#4533)
 - Make the registration title editable in the backend (#4531)
 - Add inheritance to the event interfaces (#4523)

--- a/Tests/Functional/Controller/Fixtures/EventController/archiveAction/PastEventWithOneVenue.csv
+++ b/Tests/Functional/Controller/Fixtures/EventController/archiveAction/PastEventWithOneVenue.csv
@@ -7,5 +7,5 @@
 ,1,2,"Maritim Hotel","Kurt-Georg-Kiesinger-Allee 1, 53175 Bonn","Bonn"
 
 "tx_seminars_seminars_place_mm"
-,"uid_local","uid_foreign","tablenames"
-,1,1,"tx_seminars_sites"
+,"uid_local","uid_foreign",
+,1,1

--- a/Tests/Functional/Controller/Fixtures/EventController/archiveAction/PastEventWithTwoVenuesInDifferentCities.csv
+++ b/Tests/Functional/Controller/Fixtures/EventController/archiveAction/PastEventWithTwoVenuesInDifferentCities.csv
@@ -8,6 +8,6 @@
 ,2,2,"Premier Inn","Perlengraben 2, 50676 Köln","Köln"
 
 "tx_seminars_seminars_place_mm"
-,"uid_local","uid_foreign","tablenames"
-,1,1,"tx_seminars_sites"
-,1,2,"tx_seminars_sites"
+,"uid_local","uid_foreign"
+,1,1
+,1,2

--- a/Tests/Functional/Controller/Fixtures/EventController/archiveAction/PastEventWithTwoVenuesInSameCity.csv
+++ b/Tests/Functional/Controller/Fixtures/EventController/archiveAction/PastEventWithTwoVenuesInSameCity.csv
@@ -8,6 +8,6 @@
 ,2,2,"Kameha Grand","Am Bonner Bogen 1, 53227 Bonn","Bonn"
 
 "tx_seminars_seminars_place_mm"
-,"uid_local","uid_foreign","tablenames"
-,1,1,"tx_seminars_sites"
-,1,2,"tx_seminars_sites"
+,"uid_local","uid_foreign"
+,1,1
+,1,2

--- a/Tests/Functional/Controller/Fixtures/EventController/outlookAction/FutureEventWithOneVenue.csv
+++ b/Tests/Functional/Controller/Fixtures/EventController/outlookAction/FutureEventWithOneVenue.csv
@@ -7,5 +7,5 @@
 ,1,2,"Maritim Hotel","Kurt-Georg-Kiesinger-Allee 1, 53175 Bonn","Bonn"
 
 "tx_seminars_seminars_place_mm"
-,"uid_local","uid_foreign","tablenames"
-,1,1,"tx_seminars_sites"
+,"uid_local","uid_foreign"
+,1,1

--- a/Tests/Functional/Controller/Fixtures/EventController/outlookAction/FutureEventWithTwoVenuesInDifferentCities.csv
+++ b/Tests/Functional/Controller/Fixtures/EventController/outlookAction/FutureEventWithTwoVenuesInDifferentCities.csv
@@ -8,6 +8,6 @@
 ,2,2,"Premier Inn","Perlengraben 2, 50676 Köln","Köln"
 
 "tx_seminars_seminars_place_mm"
-,"uid_local","uid_foreign","tablenames"
-,1,1,"tx_seminars_sites"
-,1,2,"tx_seminars_sites"
+,"uid_local","uid_foreign"
+,1,1
+,1,2

--- a/Tests/Functional/Controller/Fixtures/EventController/outlookAction/FutureEventWithTwoVenuesInSameCity.csv
+++ b/Tests/Functional/Controller/Fixtures/EventController/outlookAction/FutureEventWithTwoVenuesInSameCity.csv
@@ -8,6 +8,6 @@
 ,2,2,"Kameha Grand","Am Bonner Bogen 1, 53227 Bonn","Bonn"
 
 "tx_seminars_seminars_place_mm"
-,"uid_local","uid_foreign","tablenames"
-,1,1,"tx_seminars_sites"
-,1,2,"tx_seminars_sites"
+,"uid_local","uid_foreign"
+,1,1
+,1,2

--- a/Tests/Functional/Controller/Fixtures/EventController/showAction/PastEventWithOneVenue.csv
+++ b/Tests/Functional/Controller/Fixtures/EventController/showAction/PastEventWithOneVenue.csv
@@ -8,5 +8,5 @@
 53175 Bonn","Bonn"
 
 "tx_seminars_seminars_place_mm"
-,"uid_local","uid_foreign","tablenames"
-,1,1,"tx_seminars_sites"
+,"uid_local","uid_foreign"
+,1,1

--- a/Tests/Functional/Controller/Fixtures/EventController/showAction/PastEventWithTwoVenuesInSameCity.csv
+++ b/Tests/Functional/Controller/Fixtures/EventController/showAction/PastEventWithTwoVenuesInSameCity.csv
@@ -8,6 +8,6 @@
 ,2,2,"Kameha Grand","Am Bonner Bogen 1, 53227 Bonn","Bonn"
 
 "tx_seminars_seminars_place_mm"
-,"uid_local","uid_foreign","tablenames"
-,1,1,"tx_seminars_sites"
-,1,2,"tx_seminars_sites"
+,"uid_local","uid_foreign"
+,1,1
+,1,2

--- a/Tests/Functional/Controller/Fixtures/MyRegistrationsController/showAction/RegistrationWithOneVenue.csv
+++ b/Tests/Functional/Controller/Fixtures/MyRegistrationsController/showAction/RegistrationWithOneVenue.csv
@@ -8,8 +8,8 @@
 53175 Bonn","Bonn"
 
 "tx_seminars_seminars_place_mm"
-,"uid_local","uid_foreign","tablenames"
-,1,1,"tx_seminars_sites"
+,"uid_local","uid_foreign"
+,1,1
 
 "tx_seminars_attendances"
 ,"uid","pid","seminar","user"

--- a/Tests/Functional/Controller/Fixtures/MyRegistrationsController/showAction/RegistrationWithTwoVenuesInSameCity.csv
+++ b/Tests/Functional/Controller/Fixtures/MyRegistrationsController/showAction/RegistrationWithTwoVenuesInSameCity.csv
@@ -8,9 +8,9 @@
 ,2,2,"Kameha Grand","Am Bonner Bogen 1, 53227 Bonn","Bonn"
 
 "tx_seminars_seminars_place_mm"
-,"uid_local","uid_foreign","tablenames"
-,1,1,"tx_seminars_sites"
-,1,2,"tx_seminars_sites"
+,"uid_local","uid_foreign"
+,1,1
+,1,2
 
 "tx_seminars_attendances"
 ,"uid","pid","seminar","user"

--- a/Tests/Functional/Domain/Repository/Event/Fixtures/EventDateWithAccommodationOption.xml
+++ b/Tests/Functional/Domain/Repository/Event/Fixtures/EventDateWithAccommodationOption.xml
@@ -8,7 +8,6 @@
     <tx_seminars_seminars_lodgings_mm>
         <uid_local>1</uid_local>
         <uid_foreign>2</uid_foreign>
-        <tablenames>tx_seminars_lodgings</tablenames>
     </tx_seminars_seminars_lodgings_mm>
     <tx_seminars_lodgings>
         <uid>2</uid>

--- a/Tests/Functional/Domain/Repository/Event/Fixtures/EventDateWithFoodOption.xml
+++ b/Tests/Functional/Domain/Repository/Event/Fixtures/EventDateWithFoodOption.xml
@@ -8,7 +8,6 @@
     <tx_seminars_seminars_foods_mm>
         <uid_local>1</uid_local>
         <uid_foreign>2</uid_foreign>
-        <tablenames>tx_seminars_foods</tablenames>
     </tx_seminars_seminars_foods_mm>
     <tx_seminars_foods>
         <uid>2</uid>

--- a/Tests/Functional/Domain/Repository/Event/Fixtures/EventDateWithOrganizer.xml
+++ b/Tests/Functional/Domain/Repository/Event/Fixtures/EventDateWithOrganizer.xml
@@ -8,7 +8,6 @@
     <tx_seminars_seminars_organizers_mm>
         <uid_local>1</uid_local>
         <uid_foreign>2</uid_foreign>
-        <tablenames>tx_seminars_organizers</tablenames>
     </tx_seminars_seminars_organizers_mm>
     <tx_seminars_organizers>
         <uid>2</uid>

--- a/Tests/Functional/Domain/Repository/Event/Fixtures/EventDateWithRegistrationCheckbox.xml
+++ b/Tests/Functional/Domain/Repository/Event/Fixtures/EventDateWithRegistrationCheckbox.xml
@@ -8,7 +8,6 @@
     <tx_seminars_seminars_checkboxes_mm>
         <uid_local>1</uid_local>
         <uid_foreign>2</uid_foreign>
-        <tablenames>tx_seminars_checkboxes</tablenames>
     </tx_seminars_seminars_checkboxes_mm>
     <tx_seminars_checkboxes>
         <uid>2</uid>

--- a/Tests/Functional/Domain/Repository/Event/Fixtures/EventDateWithSpeaker.xml
+++ b/Tests/Functional/Domain/Repository/Event/Fixtures/EventDateWithSpeaker.xml
@@ -8,7 +8,6 @@
     <tx_seminars_seminars_speakers_mm>
         <uid_local>1</uid_local>
         <uid_foreign>2</uid_foreign>
-        <tablenames>tx_seminars_speakers</tablenames>
     </tx_seminars_seminars_speakers_mm>
     <tx_seminars_speakers>
         <uid>2</uid>

--- a/Tests/Functional/Domain/Repository/Event/Fixtures/EventDateWithVenue.xml
+++ b/Tests/Functional/Domain/Repository/Event/Fixtures/EventDateWithVenue.xml
@@ -8,7 +8,6 @@
     <tx_seminars_seminars_place_mm>
         <uid_local>1</uid_local>
         <uid_foreign>2</uid_foreign>
-        <tablenames>tx_seminars_sites</tablenames>
     </tx_seminars_seminars_place_mm>
     <tx_seminars_sites>
         <uid>2</uid>

--- a/Tests/Functional/Domain/Repository/Event/Fixtures/EventTopicWithPaymentMethod.xml
+++ b/Tests/Functional/Domain/Repository/Event/Fixtures/EventTopicWithPaymentMethod.xml
@@ -8,7 +8,6 @@
     <tx_seminars_seminars_payment_methods_mm>
         <uid_local>1</uid_local>
         <uid_foreign>2</uid_foreign>
-        <tablenames>tx_seminars_payment_methods</tablenames>
     </tx_seminars_seminars_payment_methods_mm>
     <tx_seminars_payment_methods>
         <uid>2</uid>

--- a/Tests/Functional/Domain/Repository/Event/Fixtures/SingleEventWithAccommodationOption.xml
+++ b/Tests/Functional/Domain/Repository/Event/Fixtures/SingleEventWithAccommodationOption.xml
@@ -8,7 +8,6 @@
     <tx_seminars_seminars_lodgings_mm>
         <uid_local>1</uid_local>
         <uid_foreign>2</uid_foreign>
-        <tablenames>tx_seminars_lodgings</tablenames>
     </tx_seminars_seminars_lodgings_mm>
     <tx_seminars_lodgings>
         <uid>2</uid>

--- a/Tests/Functional/Domain/Repository/Event/Fixtures/SingleEventWithFoodOption.xml
+++ b/Tests/Functional/Domain/Repository/Event/Fixtures/SingleEventWithFoodOption.xml
@@ -8,7 +8,6 @@
     <tx_seminars_seminars_foods_mm>
         <uid_local>1</uid_local>
         <uid_foreign>2</uid_foreign>
-        <tablenames>tx_seminars_foods</tablenames>
     </tx_seminars_seminars_foods_mm>
     <tx_seminars_foods>
         <uid>2</uid>

--- a/Tests/Functional/Domain/Repository/Event/Fixtures/SingleEventWithOrganizer.xml
+++ b/Tests/Functional/Domain/Repository/Event/Fixtures/SingleEventWithOrganizer.xml
@@ -8,7 +8,6 @@
     <tx_seminars_seminars_organizers_mm>
         <uid_local>1</uid_local>
         <uid_foreign>2</uid_foreign>
-        <tablenames>tx_seminars_organizers</tablenames>
     </tx_seminars_seminars_organizers_mm>
     <tx_seminars_organizers>
         <uid>2</uid>

--- a/Tests/Functional/Domain/Repository/Event/Fixtures/SingleEventWithPaymentMethod.xml
+++ b/Tests/Functional/Domain/Repository/Event/Fixtures/SingleEventWithPaymentMethod.xml
@@ -8,7 +8,6 @@
     <tx_seminars_seminars_payment_methods_mm>
         <uid_local>1</uid_local>
         <uid_foreign>2</uid_foreign>
-        <tablenames>tx_seminars_payment_methods</tablenames>
     </tx_seminars_seminars_payment_methods_mm>
     <tx_seminars_payment_methods>
         <uid>2</uid>

--- a/Tests/Functional/Domain/Repository/Event/Fixtures/SingleEventWithRegistrationCheckbox.xml
+++ b/Tests/Functional/Domain/Repository/Event/Fixtures/SingleEventWithRegistrationCheckbox.xml
@@ -8,7 +8,6 @@
     <tx_seminars_seminars_checkboxes_mm>
         <uid_local>1</uid_local>
         <uid_foreign>2</uid_foreign>
-        <tablenames>tx_seminars_checkboxes</tablenames>
     </tx_seminars_seminars_checkboxes_mm>
     <tx_seminars_checkboxes>
         <uid>2</uid>

--- a/Tests/Functional/Domain/Repository/Event/Fixtures/SingleEventWithSpeaker.xml
+++ b/Tests/Functional/Domain/Repository/Event/Fixtures/SingleEventWithSpeaker.xml
@@ -8,7 +8,6 @@
     <tx_seminars_seminars_speakers_mm>
         <uid_local>1</uid_local>
         <uid_foreign>2</uid_foreign>
-        <tablenames>tx_seminars_speakers</tablenames>
     </tx_seminars_seminars_speakers_mm>
     <tx_seminars_speakers>
         <uid>2</uid>

--- a/Tests/Functional/Domain/Repository/Event/Fixtures/SingleEventWithVenue.xml
+++ b/Tests/Functional/Domain/Repository/Event/Fixtures/SingleEventWithVenue.xml
@@ -8,7 +8,6 @@
     <tx_seminars_seminars_place_mm>
         <uid_local>1</uid_local>
         <uid_foreign>2</uid_foreign>
-        <tablenames>tx_seminars_sites</tablenames>
     </tx_seminars_seminars_place_mm>
     <tx_seminars_sites>
         <uid>2</uid>

--- a/Tests/Functional/Domain/Repository/Registration/Fixtures/RegistrationWithAccommodationOption.xml
+++ b/Tests/Functional/Domain/Repository/Registration/Fixtures/RegistrationWithAccommodationOption.xml
@@ -10,6 +10,5 @@
     <tx_seminars_attendances_lodgings_mm>
         <uid_local>1</uid_local>
         <uid_foreign>2</uid_foreign>
-        <tablenames>tx_seminars_lodgings</tablenames>
     </tx_seminars_attendances_lodgings_mm>
 </dataset>

--- a/Tests/Functional/Domain/Repository/Registration/Fixtures/RegistrationWithFoodOption.xml
+++ b/Tests/Functional/Domain/Repository/Registration/Fixtures/RegistrationWithFoodOption.xml
@@ -10,6 +10,5 @@
     <tx_seminars_attendances_foods_mm>
         <uid_local>1</uid_local>
         <uid_foreign>2</uid_foreign>
-        <tablenames>tx_seminars_foods</tablenames>
     </tx_seminars_attendances_foods_mm>
 </dataset>

--- a/Tests/Functional/Domain/Repository/Registration/Fixtures/RegistrationWithRegistrationCheckbox.xml
+++ b/Tests/Functional/Domain/Repository/Registration/Fixtures/RegistrationWithRegistrationCheckbox.xml
@@ -10,6 +10,5 @@
     <tx_seminars_attendances_checkboxes_mm>
         <uid_local>1</uid_local>
         <uid_foreign>2</uid_foreign>
-        <tablenames>tx_seminars_checkboxes</tablenames>
     </tx_seminars_attendances_checkboxes_mm>
 </dataset>

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -22,7 +22,6 @@ CREATE TABLE tx_seminars_test (
 CREATE TABLE tx_seminars_test_test_mm (
 	uid_local   int(11) unsigned DEFAULT '0' NOT NULL,
 	uid_foreign int(11) unsigned DEFAULT '0' NOT NULL,
-	tablenames  varchar(30)      DEFAULT ''  NOT NULL,
 	sorting     int(11) unsigned DEFAULT '0' NOT NULL,
 	KEY uid_local(uid_local),
 	KEY uid_foreign(uid_foreign)
@@ -35,7 +34,6 @@ CREATE TABLE tx_seminars_test_test_mm (
 CREATE TABLE tx_seminars_seminars_place_mm (
 	uid_local   int(11) unsigned DEFAULT '0' NOT NULL,
 	uid_foreign int(11) unsigned DEFAULT '0' NOT NULL,
-	tablenames  varchar(30)      DEFAULT ''  NOT NULL,
 	sorting     int(11) unsigned DEFAULT '0' NOT NULL,
 	KEY uid_local(uid_local),
 	KEY uid_foreign(uid_foreign)
@@ -48,7 +46,6 @@ CREATE TABLE tx_seminars_seminars_place_mm (
 CREATE TABLE tx_seminars_seminars_speakers_mm (
 	uid_local   int(11) unsigned DEFAULT '0' NOT NULL,
 	uid_foreign int(11) unsigned DEFAULT '0' NOT NULL,
-	tablenames  varchar(30)      DEFAULT ''  NOT NULL,
 	sorting     int(11) unsigned DEFAULT '0' NOT NULL,
 	KEY uid_local(uid_local),
 	KEY uid_foreign(uid_foreign)
@@ -61,7 +58,6 @@ CREATE TABLE tx_seminars_seminars_speakers_mm (
 CREATE TABLE tx_seminars_seminars_speakers_mm_partners (
 	uid_local   int(11) unsigned DEFAULT '0' NOT NULL,
 	uid_foreign int(11) unsigned DEFAULT '0' NOT NULL,
-	tablenames  varchar(30)      DEFAULT ''  NOT NULL,
 	sorting     int(11) unsigned DEFAULT '0' NOT NULL,
 	KEY uid_local(uid_local),
 	KEY uid_foreign(uid_foreign)
@@ -74,7 +70,6 @@ CREATE TABLE tx_seminars_seminars_speakers_mm_partners (
 CREATE TABLE tx_seminars_seminars_speakers_mm_tutors (
 	uid_local   int(11) unsigned DEFAULT '0' NOT NULL,
 	uid_foreign int(11) unsigned DEFAULT '0' NOT NULL,
-	tablenames  varchar(30)      DEFAULT ''  NOT NULL,
 	sorting     int(11) unsigned DEFAULT '0' NOT NULL,
 	KEY uid_local(uid_local),
 	KEY uid_foreign(uid_foreign)
@@ -87,7 +82,6 @@ CREATE TABLE tx_seminars_seminars_speakers_mm_tutors (
 CREATE TABLE tx_seminars_seminars_speakers_mm_leaders (
 	uid_local   int(11) unsigned DEFAULT '0' NOT NULL,
 	uid_foreign int(11) unsigned DEFAULT '0' NOT NULL,
-	tablenames  varchar(30)      DEFAULT ''  NOT NULL,
 	sorting     int(11) unsigned DEFAULT '0' NOT NULL,
 	KEY uid_local(uid_local),
 	KEY uid_foreign(uid_foreign)
@@ -100,7 +94,6 @@ CREATE TABLE tx_seminars_seminars_speakers_mm_leaders (
 CREATE TABLE tx_seminars_seminars_target_groups_mm (
 	uid_local   int(11) unsigned DEFAULT '0' NOT NULL,
 	uid_foreign int(11) unsigned DEFAULT '0' NOT NULL,
-	tablenames  varchar(30)      DEFAULT ''  NOT NULL,
 	sorting     int(11) unsigned DEFAULT '0' NOT NULL,
 	KEY uid_local(uid_local),
 	KEY uid_foreign(uid_foreign)
@@ -113,7 +106,6 @@ CREATE TABLE tx_seminars_seminars_target_groups_mm (
 CREATE TABLE tx_seminars_seminars_categories_mm (
 	uid_local   int(11) unsigned DEFAULT '0' NOT NULL,
 	uid_foreign int(11) unsigned DEFAULT '0' NOT NULL,
-	tablenames  varchar(30)      DEFAULT ''  NOT NULL,
 	sorting     int(11) unsigned DEFAULT '0' NOT NULL,
 	KEY uid_local(uid_local),
 	KEY uid_foreign(uid_foreign)
@@ -126,7 +118,6 @@ CREATE TABLE tx_seminars_seminars_categories_mm (
 CREATE TABLE tx_seminars_seminars_organizers_mm (
 	uid_local   int(11) unsigned DEFAULT '0' NOT NULL,
 	uid_foreign int(11) unsigned DEFAULT '0' NOT NULL,
-	tablenames  varchar(30)      DEFAULT ''  NOT NULL,
 	sorting     int(11) unsigned DEFAULT '0' NOT NULL,
 	KEY uid_local(uid_local),
 	KEY uid_foreign(uid_foreign)
@@ -139,7 +130,6 @@ CREATE TABLE tx_seminars_seminars_organizers_mm (
 CREATE TABLE tx_seminars_seminars_organizing_partners_mm (
 	uid_local   int(11) unsigned DEFAULT '0' NOT NULL,
 	uid_foreign int(11) unsigned DEFAULT '0' NOT NULL,
-	tablenames  varchar(30)      DEFAULT ''  NOT NULL,
 	sorting     int(11) unsigned DEFAULT '0' NOT NULL,
 	KEY uid_local(uid_local),
 	KEY uid_foreign(uid_foreign)
@@ -152,7 +142,6 @@ CREATE TABLE tx_seminars_seminars_organizing_partners_mm (
 CREATE TABLE tx_seminars_seminars_payment_methods_mm (
 	uid_local   int(11) unsigned DEFAULT '0' NOT NULL,
 	uid_foreign int(11) unsigned DEFAULT '0' NOT NULL,
-	tablenames  varchar(30)      DEFAULT ''  NOT NULL,
 	sorting     int(11) unsigned DEFAULT '0' NOT NULL,
 	KEY uid_local(uid_local),
 	KEY uid_foreign(uid_foreign)
@@ -248,7 +237,6 @@ CREATE TABLE tx_seminars_seminars (
 CREATE TABLE tx_seminars_seminars_feusers_mm (
 	uid_local   int(11) unsigned DEFAULT '0' NOT NULL,
 	uid_foreign int(11) unsigned DEFAULT '0' NOT NULL,
-	tablenames  varchar(30)      DEFAULT ''  NOT NULL,
 	sorting     int(11) unsigned DEFAULT '0' NOT NULL,
 	KEY uid_local(uid_local),
 	KEY uid_foreign(uid_foreign)
@@ -284,7 +272,6 @@ CREATE TABLE tx_seminars_speakers (
 CREATE TABLE tx_seminars_speakers_skills_mm (
 	uid_local   int(11) unsigned DEFAULT '0' NOT NULL,
 	uid_foreign int(11) unsigned DEFAULT '0' NOT NULL,
-	tablenames  varchar(30)      DEFAULT ''  NOT NULL,
 	sorting     int(11) unsigned DEFAULT '0' NOT NULL,
 	KEY uid_local(uid_local),
 	KEY uid_foreign(uid_foreign)
@@ -408,7 +395,6 @@ CREATE TABLE tx_seminars_checkboxes (
 CREATE TABLE tx_seminars_seminars_checkboxes_mm (
 	uid_local   int(11) unsigned DEFAULT '0' NOT NULL,
 	uid_foreign int(11) unsigned DEFAULT '0' NOT NULL,
-	tablenames  varchar(30)      DEFAULT ''  NOT NULL,
 	sorting     int(11) unsigned DEFAULT '0' NOT NULL,
 	KEY uid_local(uid_local),
 	KEY uid_foreign(uid_foreign)
@@ -421,7 +407,6 @@ CREATE TABLE tx_seminars_seminars_checkboxes_mm (
 CREATE TABLE tx_seminars_attendances_checkboxes_mm (
 	uid_local   int(11) unsigned DEFAULT '0' NOT NULL,
 	uid_foreign int(11) unsigned DEFAULT '0' NOT NULL,
-	tablenames  varchar(30)      DEFAULT ''  NOT NULL,
 	sorting     int(11) unsigned DEFAULT '0' NOT NULL,
 	KEY uid_local(uid_local),
 	KEY uid_foreign(uid_foreign)
@@ -442,7 +427,6 @@ CREATE TABLE tx_seminars_lodgings (
 CREATE TABLE tx_seminars_seminars_lodgings_mm (
 	uid_local   int(11) unsigned DEFAULT '0' NOT NULL,
 	uid_foreign int(11) unsigned DEFAULT '0' NOT NULL,
-	tablenames  varchar(30)      DEFAULT ''  NOT NULL,
 	sorting     int(11) unsigned DEFAULT '0' NOT NULL,
 	KEY uid_local(uid_local),
 	KEY uid_foreign(uid_foreign)
@@ -455,7 +439,6 @@ CREATE TABLE tx_seminars_seminars_lodgings_mm (
 CREATE TABLE tx_seminars_attendances_lodgings_mm (
 	uid_local   int(11) unsigned DEFAULT '0' NOT NULL,
 	uid_foreign int(11) unsigned DEFAULT '0' NOT NULL,
-	tablenames  varchar(30)      DEFAULT ''  NOT NULL,
 	sorting     int(11) unsigned DEFAULT '0' NOT NULL,
 	KEY uid_local(uid_local),
 	KEY uid_foreign(uid_foreign)
@@ -476,7 +459,6 @@ CREATE TABLE tx_seminars_foods (
 CREATE TABLE tx_seminars_seminars_foods_mm (
 	uid_local   int(11) unsigned DEFAULT '0' NOT NULL,
 	uid_foreign int(11) unsigned DEFAULT '0' NOT NULL,
-	tablenames  varchar(30)      DEFAULT ''  NOT NULL,
 	sorting     int(11) unsigned DEFAULT '0' NOT NULL,
 	KEY uid_local(uid_local),
 	KEY uid_foreign(uid_foreign)
@@ -489,7 +471,6 @@ CREATE TABLE tx_seminars_seminars_foods_mm (
 CREATE TABLE tx_seminars_attendances_foods_mm (
 	uid_local   int(11) unsigned DEFAULT '0' NOT NULL,
 	uid_foreign int(11) unsigned DEFAULT '0' NOT NULL,
-	tablenames  varchar(30)      DEFAULT ''  NOT NULL,
 	sorting     int(11) unsigned DEFAULT '0' NOT NULL,
 	KEY uid_local(uid_local),
 	KEY uid_foreign(uid_foreign)
@@ -549,7 +530,6 @@ CREATE TABLE tx_seminars_skills (
 CREATE TABLE tx_seminars_seminars_requirements_mm (
 	uid_local       int(11) unsigned DEFAULT '0' NOT NULL,
 	uid_foreign     int(11) unsigned DEFAULT '0' NOT NULL,
-	tablenames      varchar(30)      DEFAULT ''  NOT NULL,
 	sorting         int(11) unsigned DEFAULT '0' NOT NULL,
 	sorting_foreign int(11) unsigned DEFAULT '0' NOT NULL,
 
@@ -564,7 +544,6 @@ CREATE TABLE tx_seminars_seminars_requirements_mm (
 CREATE TABLE tx_seminars_usergroups_categories_mm (
 	uid_local   int(11) unsigned DEFAULT '0' NOT NULL,
 	uid_foreign int(11) unsigned DEFAULT '0' NOT NULL,
-	tablenames  varchar(30)      DEFAULT ''  NOT NULL,
 	sorting     int(11) unsigned DEFAULT '0' NOT NULL,
 	KEY uid_local(uid_local),
 	KEY uid_foreign(uid_foreign)


### PR DESCRIPTION
This column is not needed anymore with current TYPO3 versions.