### PR TITLE
[TASK] Drop optional `product-name` attribute from XLIFF files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -148,6 +148,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Removed
 
+- Drop the optional `product-name` attribute from XLIFF files (#4581)
 - !!! Drop the checkbox for the separate billing address (#4495)
 - Drop the `unregistrationDeadlineDaysBeforeBeginDate` setting (#4251)
 - Drop the `allowRegistrationForEventsWithoutDate` option (#4348)

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes" ?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-	<file source-language="en" datatype="plaintext" original="messages" date="2016-07-18T21:20:42Z"
-		  product-name="seminars">
+	<file source-language="en" datatype="plaintext" original="messages" date="2016-07-18T21:20:42Z">
 		<header/>
 		<body>
 			<trans-unit id="test-label">

--- a/Resources/Private/Language/locallang_db.xlf
+++ b/Resources/Private/Language/locallang_db.xlf
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes" ?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-	<file source-language="en" datatype="plaintext" original="messages" date="2016-07-18T21:20:33Z"
-		  product-name="seminars">
+	<file source-language="en" datatype="plaintext" original="messages" date="2016-07-18T21:20:33Z">
 		<header/>
 		<body>
 			<trans-unit id="moduleFunction.tx_seminars_modfunc1">


### PR DESCRIPTION
According to the XLIFF 1.2 specs, this attribute is optional.

Also, the TYPO3 Core does not process this attribute.