### PR TITLE
[TASK] Split up the partial for the vacancies

### DIFF
--- a/Resources/Private/Partials/Event/OutlookList.html
+++ b/Resources/Private/Partials/Event/OutlookList.html
@@ -80,7 +80,7 @@
                         </oelib:isFieldEnabled>
                         <oelib:isFieldEnabled fieldName="vacancies">
                             <td class="text-end">
-                                <f:render partial="Event/Vacancies"
+                                <f:render partial="Event/VacanciesIfRegistrationPossibleByDate"
                                           arguments="{event: event, viewName: 'eventOutlook'}"/>
                             </td>
                         </oelib:isFieldEnabled>

--- a/Resources/Private/Partials/Event/Vacancies.html
+++ b/Resources/Private/Partials/Event/Vacancies.html
@@ -1,6 +1,6 @@
 <html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers" data-namespace-typo3-fluid="true">
-    <f:variable name="statistics" value="{event.statistics}"/>
-    <f:if condition="{event.registrationRequired} && {event.registrationPossibleByDate}">
+    <f:if condition="{event.registrationRequired}">
+        <f:variable name="statistics" value="{event.statistics}"/>
         <span class="text-nowrap">
             <f:if condition="{event.unlimitedSeats}">
                 <f:then>

--- a/Resources/Private/Partials/Event/VacanciesIfRegistrationPossibleByDate.html
+++ b/Resources/Private/Partials/Event/VacanciesIfRegistrationPossibleByDate.html
@@ -1,0 +1,5 @@
+<html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers" data-namespace-typo3-fluid="true">
+    <f:if condition="{event.registrationRequired} && {event.registrationPossibleByDate}">
+        <f:render partial="Event/Vacancies" arguments="{event: event, viewName: viewName}"/>
+    </f:if>
+</html>

--- a/Resources/Private/Templates/Event/Show.html
+++ b/Resources/Private/Templates/Event/Show.html
@@ -83,7 +83,8 @@
                 </h3>
 
                 <p>
-                    <f:render partial="Event/Vacancies" arguments="{event: event, viewName: 'eventSingleView'}"/>
+                    <f:render partial="Event/VacanciesIfRegistrationPossibleByDate"
+                              arguments="{event: event, viewName: 'eventSingleView'}"/>
                 </p>
             </f:if>
         </oelib:isFieldEnabled>


### PR DESCRIPTION
This is a pre-patch for displaying the vacancies for all events (without the check that registration is possible by date).

Part of #4290