### PR TITLE
[BUGFIX] Avoid overwriting event venues for events with timeslots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- Avoid overwriting event venues for events with timeslots (#4603)
 - Do not move registrations when moving event records (#4551)
 - Display the billing city on the registration confirmation page (#4548)
 - Fully initialize reconstituted domain models (#4248)

--- a/Tests/Functional/Hooks/DataHandlerHookTest.php
+++ b/Tests/Functional/Hooks/DataHandlerHookTest.php
@@ -631,63 +631,6 @@ final class DataHandlerHookTest extends FunctionalTestCase
     }
 
     /**
-     * @return int[][]
-     */
-    public function noPlacesToAddFromTimeSlotsDataProvider(): array
-    {
-        return [
-            'no time slots' => [1],
-            'time slots without place' => [2],
-        ];
-    }
-
-    /**
-     * @test
-     *
-     * @dataProvider noPlacesToAddFromTimeSlotsDataProvider
-     */
-    public function afterDatabaseOperationsOnUpdateForNoPlacesFromTimeSlotsNotAddsPlaces(int $uid): void
-    {
-        $this->importDataSet(__DIR__ . '/Fixtures/DataHandlerHook/NoPlacesFromTimeSlots.xml');
-
-        $this->processUpdateActionForSeminarsTable($uid);
-
-        $associationCount = GeneralUtility::makeInstance(ConnectionPool::class)
-            ->getConnectionForTable('tx_seminars_seminars_place_mm')
-            ->count('*', 'tx_seminars_seminars_place_mm', ['uid_local' => $uid]);
-        self::assertSame(0, $associationCount);
-    }
-
-    /**
-     * @return array<string, array{0: positive-int, 1: positive-int}>
-     */
-    public function placesToAddFromTimeSlotsDataProvider(): array
-    {
-        return [
-            '1 time slot with place' => [1, 1],
-            '2 time slots with the same place' => [2, 1],
-            '2 time slots with different places' => [3, 2],
-        ];
-    }
-
-    /**
-     * @test
-     *
-     * @dataProvider placesToAddFromTimeSlotsDataProvider
-     */
-    public function afterDatabaseOperationsOnUpdateForFromTimeSlotsAddsPlacesToEvent(int $uid, int $expected): void
-    {
-        $this->importDataSet(__DIR__ . '/Fixtures/DataHandlerHook/PlacesFromTimeSlots.xml');
-
-        $this->processUpdateActionForSeminarsTable($uid);
-
-        $associationCount = GeneralUtility::makeInstance(ConnectionPool::class)
-            ->getConnectionForTable('tx_seminars_seminars_place_mm')
-            ->count('*', 'tx_seminars_seminars_place_mm', ['uid_local' => $uid]);
-        self::assertSame($expected, $associationCount);
-    }
-
-    /**
      * @test
      */
     public function afterDatabaseOperationsForSingleEventWithSlugKeepsSlugUnchanged(): void

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1141,11 +1141,6 @@ parameters:
 			path: Classes/Hooks/DataHandlerHook.php
 
 		-
-			message: "#^Call to an undefined method Doctrine\\\\DBAL\\\\Result\\:\\:fetchAll\\(\\)\\.$#"
-			count: 1
-			path: Classes/Hooks/DataHandlerHook.php
-
-		-
 			message: "#^Cannot access offset 'columns' on mixed\\.$#"
 			count: 2
 			path: Classes/Hooks/DataHandlerHook.php
@@ -1192,11 +1187,6 @@ parameters:
 
 		-
 			message: "#^Method OliverKlee\\\\Seminars\\\\Hooks\\\\DataHandlerHook\\:\\:copyEndDateFromTimeSlots\\(\\) has parameter \\$data with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: Classes/Hooks/DataHandlerHook.php
-
-		-
-			message: "#^Method OliverKlee\\\\Seminars\\\\Hooks\\\\DataHandlerHook\\:\\:copyPlacesFromTimeSlots\\(\\) has parameter \\$data with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: Classes/Hooks/DataHandlerHook.php
 


### PR DESCRIPTION
It has turned out that overwriting the event venues with the venues from timeslots is not helpful if the timeslots have no venues, but only the event does.

This is the 5.8.x backport of #4601.

Fixes #4529