### PR TITLE
[TASK] Drop building the CI workflow for pushes to the 5.x branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - 5.x
   pull_request:
 jobs:
   php-lint:


### PR DESCRIPTION
This is the 5.x backport of #4656.

Fixes #4620