### PR TITLE
[FEATURE] Provide certificate in "my registrations" single view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
-- Add stub functionality for certificates of attendance (#4669, #4671, #4677)
+- Add stub functionality for certificates of attendance
+  (#4669, #4671, #4677, #4678)
 - Add `Permissions::isAdmin()` (#4607)
 - Show the registrations statistics in the FE editor list view (#4569, #4584)
 - Show the invoicing status of registrations in the BE module (#4562)

--- a/Resources/Private/Partials/MyRegistrations/Show.html
+++ b/Resources/Private/Partials/MyRegistrations/Show.html
@@ -99,4 +99,16 @@
             </ul>
         </f:if>
     </oelib:isFieldEnabled>
+
+    <f:if condition="{registration.downloadableCertificate}">
+        <h3>
+            <f:translate key="plugin.myRegistrations.show.heading.certificateOfAttendance"/>
+        </h3>
+        <p>
+            <f:link.action controller="Certificate" action="show" arguments="{registration: registration}"
+                           target="_blank">
+                <f:translate key="plugin.myRegistrations.show.downloadCertificateOfAttendance"/>
+            </f:link.action>
+        </p>
+    </f:if>
 </html>


### PR DESCRIPTION
This is a stub functionality that requires the "seminars_premium" extension to actually create the PDF for the certificate of attendance.