### PR TITLE
[TASK] Drop `Registration.hasNecessaryAssociations`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -152,6 +152,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Removed
 
+- Drop `Registration.hasNecessaryAssociations` (#4686)
 - Drop the optional `product-name` attribute from XLIFF files (#4581)
 - !!! Drop the checkbox for the separate billing address (#4495)
 - Drop the `unregistrationDeadlineDaysBeforeBeginDate` setting (#4251)

--- a/Classes/Domain/Model/Registration/Registration.php
+++ b/Classes/Domain/Model/Registration/Registration.php
@@ -8,7 +8,6 @@ use OliverKlee\Seminars\Domain\Model\AccommodationOption;
 use OliverKlee\Seminars\Domain\Model\Event\Event;
 use OliverKlee\Seminars\Domain\Model\Event\EventDateInterface;
 use OliverKlee\Seminars\Domain\Model\FoodOption;
-use OliverKlee\Seminars\Domain\Model\FrontendUser;
 use OliverKlee\Seminars\Domain\Model\RawDataInterface;
 use OliverKlee\Seminars\Domain\Model\RawDataTrait;
 use OliverKlee\Seminars\Domain\Model\RegistrationCheckbox;
@@ -168,16 +167,6 @@ class Registration extends AbstractEntity implements RawDataInterface
     public function setEvent(EventDateInterface $event): void
     {
         $this->event = $event;
-    }
-
-    /**
-     * Checks whether all associations are set in a way that this registration can be used.
-     *
-     * This safeguards against cases where an event or a user is deleted, but the registration is not.
-     */
-    public function hasNecessaryAssociations(): bool
-    {
-        return ($this->getEvent() instanceof EventDateInterface) && ($this->getUser() instanceof FrontendUser);
     }
 
     /**

--- a/Tests/Unit/Domain/Model/Registration/RegistrationTest.php
+++ b/Tests/Unit/Domain/Model/Registration/RegistrationTest.php
@@ -6,7 +6,6 @@ namespace OliverKlee\Seminars\Tests\Unit\Domain\Model\Registration;
 
 use OliverKlee\Seminars\Domain\Model\AccommodationOption;
 use OliverKlee\Seminars\Domain\Model\Event\EventDate;
-use OliverKlee\Seminars\Domain\Model\Event\EventDateInterface;
 use OliverKlee\Seminars\Domain\Model\Event\SingleEvent;
 use OliverKlee\Seminars\Domain\Model\FoodOption;
 use OliverKlee\Seminars\Domain\Model\FrontendUser;
@@ -103,17 +102,6 @@ final class RegistrationTest extends UnitTestCase
     }
 
     /**
-     * @return array<string, array{0: EventDateInterface}>
-     */
-    public function validEventTypesDataProvider(): array
-    {
-        return [
-            'single event' => [new SingleEvent()],
-            'event date' => [new EventDate()],
-        ];
-    }
-
-    /**
      * @test
      */
     public function getUserInitiallyReturnsNull(): void
@@ -195,49 +183,6 @@ final class RegistrationTest extends UnitTestCase
         $this->subject->setUser($user);
 
         self::assertTrue($this->subject->belongsToUser($userUid));
-    }
-
-    /**
-     * @test
-     *
-     * @dataProvider validEventTypesDataProvider
-     */
-    public function hasNecessaryAssociationsWithUserAndWithEventReturnsTrue(EventDateInterface $event): void
-    {
-        $this->subject->setUser(new FrontendUser());
-        $this->subject->setEvent($event);
-
-        self::assertTrue($this->subject->hasNecessaryAssociations());
-    }
-
-    /**
-     * @test
-     *
-     * @dataProvider validEventTypesDataProvider
-     */
-    public function hasNecessaryAssociationsWithoutUserAndWithEventReturnsFalse(EventDateInterface $event): void
-    {
-        $this->subject->setEvent($event);
-
-        self::assertFalse($this->subject->hasNecessaryAssociations());
-    }
-
-    /**
-     * @test
-     */
-    public function hasNecessaryAssociationsWithUserAndWithoutEventReturnsFalse(): void
-    {
-        $this->subject->setUser(new FrontendUser());
-
-        self::assertFalse($this->subject->hasNecessaryAssociations());
-    }
-
-    /**
-     * @test
-     */
-    public function hasNecessaryAssociationsWithNeitherUserNorEventReturnsFalse(): void
-    {
-        self::assertFalse($this->subject->hasNecessaryAssociations());
     }
 
     /**


### PR DESCRIPTION
This method (introduced in #1752) is never called.

Also drop the unit tests for the method.

Fixes #4670