### PR TITLE
[TASK] Make the room in the BE a one-line input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- Make the room in the BE a one-line input (#4687)
 - Suggest the `seminars_premium` extension (#4676)
 - Rely on the Core to autogenerate the MM tables (#4577, #4578)
 - Make a BE label in the billing address more specific (#4533)

--- a/Configuration/TCA/tx_seminars_seminars.php
+++ b/Configuration/TCA/tx_seminars_seminars.php
@@ -386,9 +386,10 @@ $tca = [
             'exclude' => 1,
             'label' => 'LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_seminars.room',
             'config' => [
-                'type' => 'text',
-                'cols' => 30,
-                'rows' => 5,
+                'type' => 'input',
+                'size' => 20,
+                'max' => 255,
+                'eval' => 'trim',
             ],
         ],
         'webinar_url' => [

--- a/Configuration/TCA/tx_seminars_timeslots.php
+++ b/Configuration/TCA/tx_seminars_timeslots.php
@@ -61,9 +61,9 @@ $tca = [
             'exclude' => 1,
             'label' => 'LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_timeslots.room',
             'config' => [
-                'type' => 'text',
-                'cols' => 30,
-                'rows' => 5,
+                'type' => 'input',
+                'size' => 20,
+                'max' => 255,
                 'eval' => 'trim',
             ],
         ],


### PR DESCRIPTION
For the room field of events and timeslots, it does not make sense to have it as a multiline textarea.

To improve usability and save screen space, this field now is a single-line input in both places.

Also set a maximum length of 255 to make the validation in the TCEform consistent with the validation in the Extbase model.

https://docs.typo3.org/permalink/t3tca:columns-input-rendertype-default

Fixes #4135