### PR TITLE
[TASK] Polish the link texts for displaying the certificate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Added
 
 - Add stub functionality for certificates of attendance
-  (#4669, #4671, #4677, #4678, #4679)
+  (#4669, #4671, #4677, #4678, #4679, #4688)
 - Add `Permissions::isAdmin()` (#4607)
 - Show the registrations statistics in the FE editor list view (#4569, #4584)
 - Show the invoicing status of registrations in the BE module (#4562)

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -2106,11 +2106,11 @@
       <trans-unit id="plugin.myRegistrations.index.heading.certificateOfAttendance">
         <source>Certificate</source>
       </trans-unit>
-      <trans-unit id="plugin.myRegistrations.index.downloadCertificateOfAttendance.short">
-        <source>📄 Download</source>
+      <trans-unit id="plugin.myRegistrations.index.displayCertificateOfAttendance.short">
+        <source>📄 Display</source>
       </trans-unit>
-      <trans-unit id="plugin.myRegistrations.index.downloadCertificateOfAttendance.long">
-        <source>📄 Download certificate of attendance</source>
+      <trans-unit id="plugin.myRegistrations.index.displayCertificateOfAttendance.long">
+        <source>📄 Display certificate of attendance</source>
       </trans-unit>
       <trans-unit id="plugin.myRegistrations.property.registrationStatus.0">
         <source>regular</source>
@@ -2136,8 +2136,8 @@
       <trans-unit id="plugin.myRegistrations.show.heading.unregistration">
         <source>Unregistration</source>
       </trans-unit>
-      <trans-unit id="plugin.myRegistrations.show.downloadCertificateOfAttendance">
-        <source>📄 Download certificate of attendance</source>
+      <trans-unit id="plugin.myRegistrations.show.displayCertificateOfAttendance">
+        <source>📄 Display certificate of attendance</source>
       </trans-unit>
       <trans-unit id="plugin.myRegistrations.show.toUnregistrationForm">
         <source>proceed to unregistration</source>

--- a/Resources/Private/Partials/MyRegistrations/Index.html
+++ b/Resources/Private/Partials/MyRegistrations/Index.html
@@ -66,10 +66,10 @@
                                     <f:if condition="{registration.downloadableCertificate}">
                                         <f:link.action controller="Certificate" action="show"
                                                        arguments="{registration: registration}"
-                                                       title="{f:translate(key: 'plugin.myRegistrations.index.downloadCertificateOfAttendance.long')}"
+                                                       title="{f:translate(key: 'plugin.myRegistrations.index.displayCertificateOfAttendance.long')}"
                                                        target="_blank">
                                             <f:translate
-                                                key="plugin.myRegistrations.index.downloadCertificateOfAttendance.short"/>
+                                                key="plugin.myRegistrations.index.displayCertificateOfAttendance.short"/>
                                         </f:link.action>
                                     </f:if>
                                 </td>

--- a/Resources/Private/Partials/MyRegistrations/Show.html
+++ b/Resources/Private/Partials/MyRegistrations/Show.html
@@ -107,7 +107,7 @@
         <p>
             <f:link.action controller="Certificate" action="show" arguments="{registration: registration}"
                            target="_blank">
-                <f:translate key="plugin.myRegistrations.show.downloadCertificateOfAttendance"/>
+                <f:translate key="plugin.myRegistrations.show.displayCertificateOfAttendance"/>
             </f:link.action>
         </p>
     </f:if>


### PR DESCRIPTION
The attendees can also display their certificates of attendance in the browser, not only download them. The labels should reflect that.

Also update the label keys accordingly.