### PR TITLE
[TASK] Show the "attended" checkbox for regular registrations only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- Show the "attended" checkbox for regular registrations only (#4697)
 - Add a certificate tab to the registration TCEforms (#4696)
 - Make the room in the BE a one-line input (#4687)
 - Suggest the `seminars_premium` extension (#4676)

--- a/Configuration/TCA/tx_seminars_attendances.php
+++ b/Configuration/TCA/tx_seminars_attendances.php
@@ -78,6 +78,7 @@ $tca = [
         'been_there' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_attendances.been_there',
+            'displayCond' => 'FIELD:registration_queue:=:' . Registration::STATUS_REGULAR,
             'config' => [
                 'type' => 'check',
             ],
@@ -117,6 +118,7 @@ $tca = [
         'registration_queue' => [
             'exclude' => true,
             'label' => 'LLL:EXT:seminars/Resources/Private/Language/locallang_db.xlf:tx_seminars_attendances.registration_queue',
+            'onChange' => 'reload',
             'config' => [
                 'type' => 'select',
                 'renderType' => 'selectSingle',


### PR DESCRIPTION
Hiding irrelevant UI elements improves usability.

Also reload the form if the dropdown for the registration type is changed, allowing TYPO3 to hide or show the checkbox accordingly.