### PR TITLE
[TASK] Adapt links to the moved repositories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1509,4 +1509,4 @@ Special thanks go to @mk-mxp for his work on the hooks.
 ## 1.3.0
 
 The change log up to version 1.3.0
-[has been archived](https://github.com/oliverklee/ext-seminars/blob/v4.4.0/Documentation/changelog-archive.txt).
+[has been archived](https://github.com/oliverklee-de/seminars/blob/v4.4.0/Documentation/changelog-archive.txt).

--- a/Classes/Service/RegistrationGuard.php
+++ b/Classes/Service/RegistrationGuard.php
@@ -67,7 +67,7 @@ class RegistrationGuard implements SingletonInterface
      * Throws an exception if the event is not a bookable event type.
      *
      * We should probably replace this with a redirect to the deny action:
-     * https://github.com/oliverklee/ext-seminars/issues/1978
+     * https://github.com/oliverklee-de/seminars/issues/1978
      *
      * @throws \InvalidArgumentException
      *

--- a/Documentation/Introduction/Index.rst
+++ b/Documentation/Introduction/Index.rst
@@ -35,7 +35,7 @@ Compatibility with TYPO3 12LTS/12.4
 -----------------------------------
 
 A TYPO3-12LTS-compatible version of this extension is available via an
-`early-acces program <https://github.com/oliverklee/ext-seminars/wiki/Early-access-program-for-newer-TYPO3-versions>`_.
+`early-acces program <https://github.com/oliverklee-de/seminars/wiki/Early-access-program-for-newer-TYPO3-versions>`_.
 
 Staying informed about the extension
 ------------------------------------

--- a/Documentation/Introduction/LiveExamples.rst
+++ b/Documentation/Introduction/LiveExamples.rst
@@ -6,7 +6,7 @@ Give it a try!
 ==============
 
 If you would like to test the extension yourself, there is a
-`DDEV-based TYPO3 distribution <https://github.com/oliverklee/TYPO3-testing-distribution>`_
+`DDEV-based TYPO3 distribution <https://github.com/oliverklee-de/TYPO3-testing-distribution>`_
 with this extension installed and some test records ready to go.
 
 References

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 [![TYPO3 V10](https://img.shields.io/badge/TYPO3-10-orange.svg)](https://get.typo3.org/version/10)
 [![TYPO3 V11](https://img.shields.io/badge/TYPO3-11-orange.svg)](https://get.typo3.org/version/11)
-[![License](https://img.shields.io/github/license/oliverklee/ext-seminars)](https://packagist.org/packages/oliverklee/seminars)
-[![GitHub CI Status](https://github.com/oliverklee/ext-seminars/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/oliverklee/ext-seminars/actions)
-[![Coverage Status](https://coveralls.io/repos/github/oliverklee/ext-seminars/badge.svg?branch=main)](https://coveralls.io/github/oliverklee/ext-seminars?branch=main)
+[![License](https://img.shields.io/github/license/oliverklee-de/seminars)](https://packagist.org/packages/oliverklee/seminars)
+[![GitHub CI Status](https://github.com/oliverklee-de/seminars/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/oliverklee-de/seminars/actions)
+[![Coverage Status](https://coveralls.io/repos/github/oliverklee-de/seminars/badge.svg?branch=main)](https://coveralls.io/github/oliverklee-de/seminars?branch=main)
 
 This TYPO3 extension allows you to create and manage a list of seminars,
 workshops, lectures, theater performances and other events, allowing front-end
@@ -17,12 +17,12 @@ Most of the documentation is in ReST format
 ## Compatibility with TYPO3 12LTS/12.4
 
 A TYPO3-12LTS-compatible version of this extension is available via an
-[early-acces program](https://github.com/oliverklee/ext-seminars/wiki/Early-access-program-for-newer-TYPO3-versions).
+[early-acces program](https://github.com/oliverklee-de/seminars/wiki/Early-access-program-for-newer-TYPO3-versions).
 
 ## Give it a try!
 
 If you would like to test the extension yourself, there is a
-[DDEV-based TYPO3 distribution](https://github.com/oliverklee/TYPO3-testing-distribution)
+[DDEV-based TYPO3 distribution](https://github.com/oliverklee-de/TYPO3-testing-distribution)
 with this extension installed and some test records ready to go.
 
 ## Staying informed about the extension

--- a/Resources/Private/Partials/BackEnd/EarlyAccess.html
+++ b/Resources/Private/Partials/BackEnd/EarlyAccess.html
@@ -6,7 +6,7 @@
         </p>
         <p>
             <a class="btn btn-info" role="button" target="_blank"
-               href="https://github.com/oliverklee/ext-seminars/wiki/Early-access-program-for-newer-TYPO3-versions">
+               href="https://github.com/oliverklee-de/seminars/wiki/Early-access-program-for-newer-TYPO3-versions">
                 Packages and pricing
             </a>
         </p>

--- a/composer.json
+++ b/composer.json
@@ -21,8 +21,8 @@
 	],
 	"homepage": "https://www.oliverklee.de/typo3-services/seminarmanager/",
 	"support": {
-		"issues": "https://github.com/oliverklee/ext-seminars/issues",
-		"source": "https://github.com/oliverklee/ext-seminars"
+		"issues": "https://github.com/oliverklee-de/seminars/issues",
+		"source": "https://github.com/oliverklee-de/seminars"
 	},
 	"require": {
 		"php": "^7.2.0 || ~8.0.0 || ~8.1.0 || ~8.1.0 || ~8.2.0 || ~8.3.0",


### PR DESCRIPTION
This repository was moved to a GitHub organization.
 Hence we need to adapt all corresponding links.