### PR TITLE
[TASK] Improve the Composer script names

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Show the Composer configuration
         run: composer config --global --list
       - name: Run PHP lint
-        run: "composer ci:php:lint"
+        run: "composer check:php:lint"
     strategy:
       fail-fast: false
       matrix:
@@ -87,7 +87,7 @@ jobs:
       - name: Install Composer dependencies
         run: "composer update --no-ansi --no-progress"
       - name: Run command
-        run: "composer ci:${{ matrix.command }}"
+        run: "composer check:${{ matrix.command }}"
     strategy:
       fail-fast: false
       matrix:
@@ -147,7 +147,7 @@ jobs:
           composer update --no-ansi --no-interaction --no-progress --with-dependencies
           composer show
       - name: Run unit tests
-        run: "composer ci:tests:unit"
+        run: "composer check:tests:unit"
     strategy:
       fail-fast: false
       matrix:
@@ -227,7 +227,7 @@ jobs:
           export typo3DatabaseHost="$DB_HOST";
           export typo3DatabaseUsername="$DB_USER";
           export typo3DatabasePassword="$DB_PASSWORD";
-          composer ci:tests:functional
+          composer check:tests:functional
     strategy:
       fail-fast: false
       matrix:
@@ -304,7 +304,7 @@ jobs:
           export typo3DatabaseHost="$DB_HOST";
           export typo3DatabaseUsername="$DB_USER";
           export typo3DatabasePassword="$DB_PASSWORD";
-          composer ci:tests:legacy-functional
+          composer check:tests:legacy-functional
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/codecoverage.yml
+++ b/.github/workflows/codecoverage.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Create the tests directory
         run: "mkdir -p .Build/public/typo3temp/var/tests"
       - name: Run unit tests with coverage
-        run: composer ci:coverage:unit
+        run: composer check:coverage:unit
       - name: Show generated coverage files
         run: "ls -lahR .Build/coverage/"
       - name: Run functional tests with coverage
@@ -68,7 +68,7 @@ jobs:
           export typo3DatabaseHost="127.0.0.1";
           export typo3DatabaseUsername="root";
           export typo3DatabasePassword="root";
-          composer ci:coverage:functional
+          composer check:coverage:functional
       - name: Show generated coverage files
         run: "ls -lahR .Build/coverage/"
       - name: Run legacy functional tests with coverage
@@ -77,11 +77,11 @@ jobs:
           export typo3DatabaseHost="127.0.0.1";
           export typo3DatabaseUsername="root";
           export typo3DatabasePassword="root";
-          composer ci:coverage:legacy-functional
+          composer check:coverage:legacy-functional
       - name: Show generated coverage files
         run: "ls -lahR .Build/coverage/"
       - name: Merge coverage results
-        run: composer ci:coverage:merge
+        run: composer check:coverage:merge
       - name: Show merged coverage files
         run: "ls -lahR build/logs/"
       - name: Upload coverage results to Coveralls

--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -483,7 +483,7 @@ fi
 case ${TEST_SUITE} in
     cgl)
         if [ "${CGLCHECK_DRY_RUN}" -eq 1 ]; then
-            COMMAND="composer ci:php:cs-fixer"
+            COMMAND="composer check:php:cs-fixer"
         else
             COMMAND="composer fix:php:cs"
         fi
@@ -520,9 +520,9 @@ case ${TEST_SUITE} in
         SUITE_EXIT_CODE=$?
         ;;
     composerNormalize)
-        COMMAND="composer ci:composer:normalize"
+        COMMAND="composer check:composer:normalize"
         if [ "${CGLCHECK_DRY_RUN}" -eq 1 ]; then
-            COMMAND="composer ci:composer:normalize"
+            COMMAND="composer check:composer:normalize"
         else
             COMMAND="composer fix:composer:normalize"
         fi
@@ -530,7 +530,7 @@ case ${TEST_SUITE} in
         SUITE_EXIT_CODE=$?
         ;;
     composerUnused)
-        COMMAND="composer ci:composer:unused"
+        COMMAND="composer check:composer:unused"
         ${CONTAINER_BIN} run ${CONTAINER_COMMON_PARAMS} --name composer-unused-${SUFFIX} -e COMPOSER_CACHE_DIR=.cache/composer -e COMPOSER_ROOT_VERSION=${COMPOSER_ROOT_VERSION} ${IMAGE_PHP} /bin/sh -c "${COMMAND}"
         SUITE_EXIT_CODE=$?
         ;;
@@ -579,18 +579,18 @@ case ${TEST_SUITE} in
         esac
         ;;
     lintTypoScript)
-        COMMAND="composer ci:typoscript:lint"
+        COMMAND="composer check:typoscript:lint"
         ${CONTAINER_BIN} run ${CONTAINER_COMMON_PARAMS} --name composer-command-${SUFFIX} -e COMPOSER_CACHE_DIR=.cache/composer -e COMPOSER_ROOT_VERSION=${COMPOSER_ROOT_VERSION} ${IMAGE_PHP} /bin/sh -c "${COMMAND}"
         SUITE_EXIT_CODE=$?
         ;;
     lintPhp)
-        COMMAND="composer ci:php:lint"
+        COMMAND="composer check:php:lint"
         ${CONTAINER_BIN} run ${CONTAINER_COMMON_PARAMS} --name composer-command-${SUFFIX} -e COMPOSER_CACHE_DIR=.cache/composer -e COMPOSER_ROOT_VERSION=${COMPOSER_ROOT_VERSION} ${IMAGE_PHP} /bin/sh -c "${COMMAND}"
         SUITE_EXIT_CODE=$?
         ;;
     lintJs)
         if [ "${CGLCHECK_DRY_RUN}" -eq 1 ]; then
-            COMMAND="echo ${HELP_TEXT_NPM_CI}; npm ci --silent || { echo ${HELP_TEXT_NPM_FAILURE}; exit 1; } && npm run ci:lint:js"
+            COMMAND="echo ${HELP_TEXT_NPM_CI}; npm ci --silent || { echo ${HELP_TEXT_NPM_FAILURE}; exit 1; } && npm run check:lint:js"
         else
             COMMAND="echo ${HELP_TEXT_NPM_CI}; npm ci --silent || { echo ${HELP_TEXT_NPM_FAILURE}; exit 1; } && npm run fix:lint:js"
         fi
@@ -599,7 +599,7 @@ case ${TEST_SUITE} in
         ;;
     lintCss)
         if [ "${CGLCHECK_DRY_RUN}" -eq 1 ]; then
-            COMMAND="echo ${HELP_TEXT_NPM_CI}; npm ci --silent || { echo ${HELP_TEXT_NPM_FAILURE}; exit 1; } && npm run ci:lint:css"
+            COMMAND="echo ${HELP_TEXT_NPM_CI}; npm ci --silent || { echo ${HELP_TEXT_NPM_FAILURE}; exit 1; } && npm run check:lint:css"
         else
             COMMAND="echo ${HELP_TEXT_NPM_CI}; npm ci --silent || { echo ${HELP_TEXT_NPM_FAILURE}; exit 1; } && npm run fix:lint:css"
         fi
@@ -607,12 +607,12 @@ case ${TEST_SUITE} in
         SUITE_EXIT_CODE=$?
         ;;
     lintJson)
-        COMMAND="composer ci:json:lint"
+        COMMAND="composer check:json:lint"
         ${CONTAINER_BIN} run ${CONTAINER_COMMON_PARAMS} --name composer-command-${SUFFIX} -e COMPOSER_CACHE_DIR=.cache/composer -e COMPOSER_ROOT_VERSION=${COMPOSER_ROOT_VERSION} ${IMAGE_PHP} /bin/sh -c "${COMMAND}"
         SUITE_EXIT_CODE=$?
         ;;
     lintYaml)
-        COMMAND="composer ci:yaml:lint"
+        COMMAND="composer check:yaml:lint"
         ${CONTAINER_BIN} run ${CONTAINER_COMMON_PARAMS} --name composer-command-${SUFFIX} -e COMPOSER_CACHE_DIR=.cache/composer -e COMPOSER_ROOT_VERSION=${COMPOSER_ROOT_VERSION} ${IMAGE_PHP} /bin/sh -c "${COMMAND}"
         SUITE_EXIT_CODE=$?
         ;;
@@ -622,7 +622,7 @@ case ${TEST_SUITE} in
         SUITE_EXIT_CODE=$?
         ;;
     phpstan)
-        COMMAND="composer ci:php:stan"
+        COMMAND="composer check:php:stan"
         ${CONTAINER_BIN} run ${CONTAINER_COMMON_PARAMS} --name composer-command-${SUFFIX} -e COMPOSER_CACHE_DIR=.cache/composer -e COMPOSER_ROOT_VERSION=${COMPOSER_ROOT_VERSION} ${IMAGE_PHP} /bin/sh -c "${COMMAND}"
         SUITE_EXIT_CODE=$?
         ;;

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ with the Composer dependencies installed.
 To run all unit tests on the command line:
 
 ```bash
-composer ci:tests:unit
+composer check:tests:unit
 ```
 
 To run all unit tests in a directory or file (using the directory
@@ -90,7 +90,7 @@ running the functional tests:
 To run all functional tests on the command line:
 
 ```bash
-typo3DatabaseUsername=typo3 typo3DatabasePassword=typo3pass typo3DatabaseName=typo3_test composer ci:tests:functional
+typo3DatabaseUsername=typo3 typo3DatabasePassword=typo3pass typo3DatabaseName=typo3_test composer check:tests:functional
 ```
 
 To run all functional tests in a directory or file (using the directory

--- a/composer.json
+++ b/composer.json
@@ -120,53 +120,53 @@
 		}
 	},
 	"scripts": {
-		"ci:composer:normalize": "@composer normalize --no-check-lock --dry-run",
-		"ci:coverage": [
-			"@ci:coverage:unit",
-			"@ci:coverage:functional"
+		"check:composer:normalize": "@composer normalize --no-check-lock --dry-run",
+		"check:coverage": [
+			"@check:coverage:unit",
+			"@check:coverage:functional"
 		],
-		"ci:coverage:functional": [
+		"check:coverage:functional": [
 			"@coverage:create-directories",
 			"find 'Tests/Functional' -wholename '*Test.php' | parallel --gnu 'echo; echo \"Running functional test suite {}\"; .Build/bin/phpunit -c Build/phpunit/FunctionalTests.xml --whitelist Classes --coverage-php=\".Build/coverage/{}.cov\" {}';"
 		],
-		"ci:coverage:legacy-functional": [
+		"check:coverage:legacy-functional": [
 			"@coverage:create-directories",
 			"find 'Tests/LegacyFunctional' -wholename '*Test.php' | parallel --gnu 'echo; echo \"Running legacy functional test suite {}\"; .Build/bin/phpunit -c Build/phpunit/FunctionalTests.xml --whitelist Classes --coverage-php=\".Build/coverage/{}.cov\" {}';"
 		],
-		"ci:coverage:merge": [
+		"check:coverage:merge": [
 			"@coverage:create-directories",
 			"tools/phpcov merge --clover=./build/logs/clover.xml ./.Build/coverage/"
 		],
-		"ci:coverage:unit": [
+		"check:coverage:unit": [
 			"@coverage:create-directories",
 			"phpunit -c Build/phpunit/UnitTests.xml --whitelist Classes --coverage-php=.Build/coverage/unit.cov Tests/Unit"
 		],
-		"ci:php": [
-			"@ci:php:cs-fixer",
-			"@ci:php:lint",
-			"@ci:php:sniff",
-			"@ci:php:stan"
+		"check:php": [
+			"@check:php:cs-fixer",
+			"@check:php:lint",
+			"@check:php:sniff",
+			"@check:php:stan"
 		],
-		"ci:php:cs-fixer": "php-cs-fixer fix -v --dry-run --diff",
-		"ci:php:lint": "find .*.php *.php Classes Configuration Documentation Tests -name '*.php' -print0 | xargs -0 -n 1 -P 4 php -l",
-		"ci:php:rector": "rector --dry-run",
-		"ci:php:sniff": "phpcs *.php Classes Documentation Configuration Tests",
-		"ci:php:stan": "phpstan --no-progress",
-		"ci:static": [
-			"@ci:composer:normalize",
-			"@ci:php:cs-fixer",
-			"@ci:php:lint",
-			"@ci:php:rector",
-			"@ci:php:sniff",
-			"@ci:php:stan",
-			"@ci:ts:lint",
-			"@ci:xliff:lint"
+		"check:php:cs-fixer": "php-cs-fixer fix -v --dry-run --diff",
+		"check:php:lint": "find .*.php *.php Classes Configuration Documentation Tests -name '*.php' -print0 | xargs -0 -n 1 -P 4 php -l",
+		"check:php:rector": "rector --dry-run",
+		"check:php:sniff": "phpcs *.php Classes Documentation Configuration Tests",
+		"check:php:stan": "phpstan --no-progress",
+		"check:static": [
+			"@check:composer:normalize",
+			"@check:php:cs-fixer",
+			"@check:php:lint",
+			"@check:php:rector",
+			"@check:php:sniff",
+			"@check:php:stan",
+			"@check:ts:lint",
+			"@check:xliff:lint"
 		],
-		"ci:tests:functional": "find 'Tests/Functional' -wholename '*Test.php' | parallel --gnu 'echo; echo \"Running functional test suite {}\"; .Build/bin/phpunit -c Build/phpunit/FunctionalTests.xml {}';",
-		"ci:tests:legacy-functional": "find 'Tests/LegacyFunctional' -wholename '*Test.php' | parallel --gnu 'echo; echo \"Running legacy functional test suite {}\"; .Build/bin/phpunit -c Build/phpunit/FunctionalTests.xml {}';",
-		"ci:tests:unit": "phpunit -c Build/phpunit/UnitTests.xml Tests/Unit",
-		"ci:ts:lint": "typoscript-lint -c Configuration/TypoScriptLint.yaml --ansi -n --fail-on-warnings -vvv Configuration/TypoScript Tests/Functional/Controller/Fixtures/TypoScript",
-		"ci:xliff:lint": "php Build/xliff/xliff-lint lint:xliff Resources/Private/Language",
+		"check:tests:functional": "find 'Tests/Functional' -wholename '*Test.php' | parallel --gnu 'echo; echo \"Running functional test suite {}\"; .Build/bin/phpunit -c Build/phpunit/FunctionalTests.xml {}';",
+		"check:tests:legacy-functional": "find 'Tests/LegacyFunctional' -wholename '*Test.php' | parallel --gnu 'echo; echo \"Running legacy functional test suite {}\"; .Build/bin/phpunit -c Build/phpunit/FunctionalTests.xml {}';",
+		"check:tests:unit": "phpunit -c Build/phpunit/UnitTests.xml Tests/Unit",
+		"check:ts:lint": "typoscript-lint -c Configuration/TypoScriptLint.yaml --ansi -n --fail-on-warnings -vvv Configuration/TypoScript Tests/Functional/Controller/Fixtures/TypoScript",
+		"check:xliff:lint": "php Build/xliff/xliff-lint lint:xliff Resources/Private/Language",
 		"coverage:create-directories": "mkdir -p build/logs .Build/coverage",
 		"fix": [
 			"@fix:composer",
@@ -203,24 +203,24 @@
 		]
 	},
 	"scripts-descriptions": {
-		"ci:composer:normalize": "Checks the composer.json.",
-		"ci:coverage": "Generates the code coverage report for unit and functional tests.",
-		"ci:coverage:functional": "Generates the code coverage report for functional tests.",
-		"ci:coverage:legacy-functional": "Generates the code coverage report for legacy functional tests.",
-		"ci:coverage:merge": "Merges the code coverage reports for unit and functional tests.",
-		"ci:coverage:unit": "Generates the code coverage report for unit tests.",
-		"ci:php": "Runs all static checks for the PHP files.",
-		"ci:php:cs-fixer": "Checks the code style with the PHP Coding Standards Fixer (PHP-CS-Fixer).",
-		"ci:php:lint": "Lints the PHP files for syntax errors.",
-		"ci:php:rector": "Checks for code for changes by Rector.",
-		"ci:php:sniff": "Checks the code style with PHP_CodeSniffer (PHPCS).",
-		"ci:php:stan": "Checks the PHP types using PHPStan.",
-		"ci:static": "Runs all static code analysis checks for the code.",
-		"ci:tests:functional": "Runs the functional tests.",
-		"ci:tests:legacy-functional": "Runs the legacy functional tests.",
-		"ci:tests:unit": "Runs the unit tests.",
-		"ci:ts:lint": "Lints all TypoScript files.",
-		"ci:xliff:lint": "Lints the XLIFF files.",
+		"check:composer:normalize": "Checks the composer.json.",
+		"check:coverage": "Generates the code coverage report for unit and functional tests.",
+		"check:coverage:functional": "Generates the code coverage report for functional tests.",
+		"check:coverage:legacy-functional": "Generates the code coverage report for legacy functional tests.",
+		"check:coverage:merge": "Merges the code coverage reports for unit and functional tests.",
+		"check:coverage:unit": "Generates the code coverage report for unit tests.",
+		"check:php": "Runs all static checks for the PHP files.",
+		"check:php:cs-fixer": "Checks the code style with the PHP Coding Standards Fixer (PHP-CS-Fixer).",
+		"check:php:lint": "Lints the PHP files for syntax errors.",
+		"check:php:rector": "Checks for code for changes by Rector.",
+		"check:php:sniff": "Checks the code style with PHP_CodeSniffer (PHPCS).",
+		"check:php:stan": "Checks the PHP types using PHPStan.",
+		"check:static": "Runs all static code analysis checks for the code.",
+		"check:tests:functional": "Runs the functional tests.",
+		"check:tests:legacy-functional": "Runs the legacy functional tests.",
+		"check:tests:unit": "Runs the unit tests.",
+		"check:ts:lint": "Lints all TypoScript files.",
+		"check:xliff:lint": "Lints the XLIFF files.",
 		"coverage:create-directories": "Creates the directories needed for recording and merging the code coverage reports.",
 		"fix": "Runs all automatic code style fixes.",
 		"fix:composer": "Runs all fixers for the PHP code.",


### PR DESCRIPTION
As long as we still are using the Composer scripts, the names should not be misleading.

We have had scripts with the `ci:` prefix for a long time.

However, these scripts are not only for CI, but generally for checks that can (mostly) also be run locally.

So this prefix now has been changed to `check:` to be less misleading.