### PR TITLE
[TASK] Show the exact number of vacancies in the FE editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Add stub functionality for certificates of attendance
   (#4669, #4671, #4677, #4678, #4679, #4690)
 - Add `Permissions::isAdmin()` (#4607)
-- Show the registrations statistics in the FE editor list view (#4569, #4584)
+- Show the registrations statistics in the FE editor list view
+  (#4569, #4584, #4764)
 - Show the invoicing status of registrations in the BE module (#4562)
 - Add accessors for the payment status of registrations (#4560)
 - Add more invoicing-related fields to registrations

--- a/Resources/Private/Partials/FrontEndEditor/Vacancies.html
+++ b/Resources/Private/Partials/FrontEndEditor/Vacancies.html
@@ -4,16 +4,13 @@
         <span class="text-nowrap">
             <f:if condition="{event.unlimitedSeats}">
                 <f:then>
-                    <f:translate key="plugin.{viewName}.events.property.vacancies.unlimited"/> 🟢
+                    <f:translate key="plugin.{viewName}.events.property.vacancies.unlimited"/>
                 </f:then>
-                <f:else if="{statistics.vacancies} >= {settings.enoughVacanciesThreshold}">
-                    ≥ {settings.enoughVacanciesThreshold} 🟢
-                </f:else>
                 <f:else if="{statistics.fullyBooked}">
                     <f:translate key="plugin.{viewName}.events.property.vacancies.fullyBooked"/> 🔴
                 </f:else>
                 <f:else>
-                    {statistics.vacancies} 🟡
+                    {statistics.vacancies}
                 </f:else>
             </f:if>
         </span>

--- a/Tests/Functional/Controller/FrontEndEditorControllerTest.php
+++ b/Tests/Functional/Controller/FrontEndEditorControllerTest.php
@@ -366,7 +366,7 @@ final class FrontEndEditorControllerTest extends FunctionalTestCase
         $response = $this->executeFrontendSubRequest($request, $requestContext);
         $body = (string)$response->getBody();
 
-        self::assertStringContainsString('≥ 5 🟢', $body);
+        self::assertStringContainsString('17', $body);
     }
 
     /**


### PR DESCRIPTION
Editors should always be able to see all registration data.