### PR TITLE
[TASK] Always show the statistics in the FE editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   (#4669, #4671, #4677, #4678, #4679, #4690)
 - Add `Permissions::isAdmin()` (#4607)
 - Show the registrations statistics in the FE editor list view
-  (#4569, #4584, #4764)
+  (#4569, #4584, #4764, #4765)
 - Show the invoicing status of registrations in the BE module (#4562)
 - Add accessors for the payment status of registrations (#4560)
 - Add more invoicing-related fields to registrations

--- a/Resources/Private/Partials/FrontEndEditor/Vacancies.html
+++ b/Resources/Private/Partials/FrontEndEditor/Vacancies.html
@@ -1,18 +1,17 @@
 <html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers" data-namespace-typo3-fluid="true">
     <f:if condition="{event.registrationRequired}">
         <f:variable name="statistics" value="{event.statistics}"/>
-        <span class="text-nowrap">
-            <f:if condition="{event.unlimitedSeats}">
-                <f:then>
-                    <f:translate key="plugin.{viewName}.events.property.vacancies.unlimited"/>
-                </f:then>
-                <f:else if="{statistics.fullyBooked}">
-                    <f:translate key="plugin.{viewName}.events.property.vacancies.fullyBooked"/> 🔴
-                </f:else>
-                <f:else>
-                    {statistics.vacancies}
-                </f:else>
-            </f:if>
-        </span>
+
+        <f:if condition="{event.unlimitedSeats}">
+            <f:then>
+                <f:translate key="plugin.{viewName}.events.property.vacancies.unlimited"/>
+            </f:then>
+            <f:else if="{statistics.fullyBooked}">
+                <f:translate key="plugin.{viewName}.events.property.vacancies.fullyBooked"/> 🔴
+            </f:else>
+            <f:else>
+                {statistics.vacancies}
+            </f:else>
+        </f:if>
     </f:if>
 </html>

--- a/Resources/Private/Templates/FrontEndEditor/Index.html
+++ b/Resources/Private/Templates/FrontEndEditor/Index.html
@@ -55,11 +55,11 @@
                             <f:render partial="EventDate" arguments="{event: event}"/>
                         </td>
                         <td class="text-end">
-                            <f:if condition="{statistics} && {statistics.regularSeatsCount}">
+                            <f:if condition="{event.registrationRequired} && {statistics}">
                                 {statistics.regularSeatsCount}
                             </f:if>
                         </td>
-                        <td class="text-end">
+                        <td class="text-end text-nowrap">
                             <f:render partial="FrontEndEditor/Vacancies"
                                       arguments="{event: event, viewName: 'frontEndEditor'}"/>
                         </td>

--- a/Tests/Functional/Controller/Fixtures/FrontEndEditorController/indexAction/SingleEventWithNonBindingReservations.csv
+++ b/Tests/Functional/Controller/Fixtures/FrontEndEditorController/indexAction/SingleEventWithNonBindingReservations.csv
@@ -3,8 +3,6 @@
 ,1,2,0,"event with owner",1,100,4
 
 "tx_seminars_attendances"
-,"uid","seminar"
-,1,1
-,2,1
-,3,1
-,4,1
+,"uid","seminar","registration_queue"
+,1,1,2
+,2,1,2

--- a/Tests/Functional/Controller/Fixtures/FrontEndEditorController/indexAction/SingleEventWithRegularRegistrations.csv
+++ b/Tests/Functional/Controller/Fixtures/FrontEndEditorController/indexAction/SingleEventWithRegularRegistrations.csv
@@ -1,0 +1,10 @@
+"tx_seminars_seminars"
+,"uid","pid","object_type","title","owner_feuser","attendees_max","registrations"
+,1,2,0,"event with owner",1,100,4
+
+"tx_seminars_attendances"
+,"uid","seminar","registration_queue"
+,1,1,0
+,2,1,0
+,3,1,0
+,4,1,0

--- a/Tests/Functional/Controller/Fixtures/FrontEndEditorController/indexAction/SingleEventWithWaitingListRegistrations.csv
+++ b/Tests/Functional/Controller/Fixtures/FrontEndEditorController/indexAction/SingleEventWithWaitingListRegistrations.csv
@@ -1,0 +1,8 @@
+"tx_seminars_seminars"
+,"uid","pid","object_type","title","owner_feuser","attendees_max","registrations"
+,1,2,0,"event with owner",1,100,4
+
+"tx_seminars_attendances"
+,"uid","seminar","registration_queue"
+,1,1,1
+,2,1,1

--- a/Tests/Functional/Controller/Fixtures/FrontEndEditorController/indexAction/SingleEventWithoutRegistrations.csv
+++ b/Tests/Functional/Controller/Fixtures/FrontEndEditorController/indexAction/SingleEventWithoutRegistrations.csv
@@ -1,0 +1,3 @@
+"tx_seminars_seminars"
+,"uid","pid","object_type","title","owner_feuser","attendees_max","registrations"
+,1,2,0,"event with owner",1,100,0

--- a/Tests/Functional/Controller/FrontEndEditorControllerTest.php
+++ b/Tests/Functional/Controller/FrontEndEditorControllerTest.php
@@ -344,14 +344,59 @@ final class FrontEndEditorControllerTest extends FunctionalTestCase
      */
     public function indexActionForEventWithRegularRegistrationsRendersRegistrationCount(): void
     {
-        $this->importCSVDataSet(self::FIXTURES_PATH . '/indexAction/SingleEventWithRegistrations.csv');
+        $this->importCSVDataSet(self::FIXTURES_PATH . '/indexAction/SingleEventWithRegularRegistrations.csv');
 
         $request = (new InternalRequest())->withPageId(self::PAGE_UID);
         $requestContext = (new InternalRequestContext())->withFrontendUserId(1);
         $response = $this->executeFrontendSubRequest($request, $requestContext);
         $body = (string)$response->getBody();
 
-        self::assertStringContainsString(' 4', $body);
+        self::assertMatchesRegularExpression('#<td[^>]*>\\s*4\\s*</td>#', $body);
+    }
+
+    /**
+     * @test
+     */
+    public function indexActionForEventWithZeroRegistrationsRendersRegistrationCount(): void
+    {
+        $this->importCSVDataSet(self::FIXTURES_PATH . '/indexAction/SingleEventWithoutRegistrations.csv');
+
+        $request = (new InternalRequest())->withPageId(self::PAGE_UID);
+        $requestContext = (new InternalRequestContext())->withFrontendUserId(1);
+        $response = $this->executeFrontendSubRequest($request, $requestContext);
+        $body = (string)$response->getBody();
+
+        self::assertMatchesRegularExpression('#<td[^>]*>\\s*0\\s*</td>#', $body);
+    }
+
+    /**
+     * @test
+     */
+    public function indexActionForEventWithZeroRegistrationsDoesDisplayCountOfWaitingListRegistrations(): void
+    {
+        $this->importCSVDataSet(self::FIXTURES_PATH . '/indexAction/SingleEventWithWaitingListRegistrations.csv');
+
+        $request = (new InternalRequest())->withPageId(self::PAGE_UID);
+        $requestContext = (new InternalRequestContext())->withFrontendUserId(1);
+        $response = $this->executeFrontendSubRequest($request, $requestContext);
+        $body = (string)$response->getBody();
+
+        self::assertMatchesRegularExpression('#<td[^>]*>\\s*0\\s*</td>#', $body);
+    }
+
+    /**
+     * @test
+     */
+    public function indexActionForEventWithZeroRegistrationsDoesDisplayCountOfNonBindingReservations(): void
+    {
+        $this->importCSVDataSet(self::FIXTURES_PATH . '/indexAction/SingleEventWithNonBindingReservations.csv');
+
+        $request = (new InternalRequest())->withPageId(self::PAGE_UID);
+        $requestContext = (new InternalRequestContext())->withFrontendUserId(1);
+        $response = $this->executeFrontendSubRequest($request, $requestContext);
+        $body = (string)$response->getBody();
+
+        self::assertMatchesRegularExpression('#<td[^>]*>\\s*0\\s*</td>#', $body);
     }
 
     /**
@@ -366,7 +411,7 @@ final class FrontEndEditorControllerTest extends FunctionalTestCase
         $response = $this->executeFrontendSubRequest($request, $requestContext);
         $body = (string)$response->getBody();
 
-        self::assertStringContainsString('17', $body);
+        self::assertMatchesRegularExpression('#<td[^>]*>\\s*17\\s*</td>#', $body);
     }
 
     /**


### PR DESCRIPTION
If an event allows registrations, always show the number of registrations, even if it is zero.

Also add some additional tests to check that waiting list registrations and non-binding reservations are not counted.

Also simplify the markup a bit.

Also make some tests more strict.