### PR TITLE
[TASK] Reduce the PHP_CodeSniffer ruleset

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,19 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<ruleset name="phpList Coding Standard">
-    <description>
-        This standard requires PHP_CodeSniffer >= 3.5.4.
-    </description>
-
+<ruleset name="oliverklee.de coding standard">
     <arg name="colors"/>
     <arg name="extensions" value="php"/>
 
-    <!-- The complete PSR-12 ruleset -->
-    <rule ref="PSR12">
-        <!-- We'll enable this rule once the line lengths are fixed. -->
-        <exclude name="Generic.Files.LineLength"/>
-        <!-- This rule contradict the TYPO3 CS-Fixer ruleset. -->
-        <exclude name="Generic.WhiteSpace.ScopeIndent"/>
-        <!-- This rule contradict the TYPO3 CS-Fixer ruleset. -->
-        <exclude name="Squiz.WhiteSpace.ScopeClosingBrace"/>
-    </rule>
+    <!-- We'll enable this rule once the line lengths are fixed. -->
+<!--    <rule ref="Generic.Files.LineLength">-->
+<!--        <properties>-->
+<!--            <property name="lineLimit" value="120"/>-->
+<!--            <property name="absoluteLineLimit" value="120"/>-->
+<!--        </properties>-->
+<!--    </rule>-->
+    <rule ref="Squiz.PHP.Heredoc"/>
 </ruleset>


### PR DESCRIPTION
Nowadays, PHP-CS-Fixer covers most of our code style checking needs. So we should only have those rules in the PHP_CodeSniffer configuration that are not covered by PHP-CS-Fixer.

This gets rid of the hassle of resolving rule conflicts between the two tools.

Also fix some copy'n'paste in the ruleset name.

Fixes #4507