### PR TITLE
[BUGFIX] Load all required core extensions in the functionals

### DIFF
--- a/Tests/Functional/Domain/Repository/PageRepositoryTest.php
+++ b/Tests/Functional/Domain/Repository/PageRepositoryTest.php
@@ -13,7 +13,11 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
  */
 final class PageRepositoryTest extends FunctionalTestCase
 {
-    protected array $testExtensionsToLoad = ['oliverklee/feuserextrafields', 'oliverklee/oelib', 'oliverklee/seminars'];
+    protected array $testExtensionsToLoad = [
+        'oliverklee/feuserextrafields',
+        'oliverklee/oelib',
+        'oliverklee/seminars',
+    ];
 
     private PageRepository $subject;
 

--- a/Tests/Functional/OldModel/LegacyEventTest.php
+++ b/Tests/Functional/OldModel/LegacyEventTest.php
@@ -39,6 +39,8 @@ final class LegacyEventTest extends FunctionalTestCase
         'oliverklee/seminars',
     ];
 
+    protected array $coreExtensionsToLoad = ['typo3/cms-install'];
+
     private TestingFramework $testingFramework;
 
     protected function setUp(): void

--- a/Tests/Functional/SchedulerTasks/MailNotifierConfigurationTest.php
+++ b/Tests/Functional/SchedulerTasks/MailNotifierConfigurationTest.php
@@ -22,7 +22,7 @@ final class MailNotifierConfigurationTest extends FunctionalTestCase
 {
     private const LABEL_PREFIX = 'LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:';
 
-    protected array $coreExtensionsToLoad = ['scheduler'];
+    protected array $coreExtensionsToLoad = ['typo3/cms-scheduler'];
 
     protected array $testExtensionsToLoad = [
         'oliverklee/feuserextrafields',

--- a/Tests/Functional/SchedulerTasks/MailNotifierTest.php
+++ b/Tests/Functional/SchedulerTasks/MailNotifierTest.php
@@ -20,7 +20,7 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
  */
 final class MailNotifierTest extends FunctionalTestCase
 {
-    protected array $coreExtensionsToLoad = ['scheduler'];
+    protected array $coreExtensionsToLoad = ['typo3/cms-scheduler'];
 
     protected array $testExtensionsToLoad = [
         'oliverklee/feuserextrafields',

--- a/Tests/Functional/SchedulerTasks/RegistrationDigestTest.php
+++ b/Tests/Functional/SchedulerTasks/RegistrationDigestTest.php
@@ -26,7 +26,7 @@ final class RegistrationDigestTest extends FunctionalTestCase
 {
     use EmailTrait;
 
-    protected array $coreExtensionsToLoad = ['scheduler'];
+    protected array $coreExtensionsToLoad = ['typo3/cms-scheduler'];
 
     protected array $testExtensionsToLoad = [
         'oliverklee/feuserextrafields',

--- a/Tests/LegacyFunctional/FrontEnd/DefaultControllerTest.php
+++ b/Tests/LegacyFunctional/FrontEnd/DefaultControllerTest.php
@@ -47,6 +47,8 @@ final class DefaultControllerTest extends FunctionalTestCase
         'oliverklee/seminars',
     ];
 
+    protected array $coreExtensionsToLoad = ['typo3/cms-install'];
+
     private TestingDefaultController $subject;
 
     private TestingFramework $testingFramework;

--- a/Tests/LegacyFunctional/OldModel/LegacyEventTest.php
+++ b/Tests/LegacyFunctional/OldModel/LegacyEventTest.php
@@ -39,6 +39,8 @@ final class LegacyEventTest extends FunctionalTestCase
         'oliverklee/seminars',
     ];
 
+    protected array $coreExtensionsToLoad = ['typo3/cms-install'];
+
     private DummyConfiguration $configuration;
 
     private TestingLegacyEvent $subject;

--- a/Tests/LegacyFunctional/OldModel/LegacyRegistrationTest.php
+++ b/Tests/LegacyFunctional/OldModel/LegacyRegistrationTest.php
@@ -33,6 +33,8 @@ final class LegacyRegistrationTest extends FunctionalTestCase
         'oliverklee/seminars',
     ];
 
+    protected array $coreExtensionsToLoad = ['typo3/cms-install'];
+
     private LegacyRegistration $subject;
 
     private TestingFramework $testingFramework;

--- a/Tests/LegacyFunctional/SchedulerTasks/MailNotifierTest.php
+++ b/Tests/LegacyFunctional/SchedulerTasks/MailNotifierTest.php
@@ -36,7 +36,7 @@ final class MailNotifierTest extends FunctionalTestCase
     use EmailTrait;
     use MakeInstanceTrait;
 
-    protected array $coreExtensionsToLoad = ['scheduler'];
+    protected array $coreExtensionsToLoad = ['typo3/cms-scheduler'];
 
     protected array $testExtensionsToLoad = [
         'oliverklee/feuserextrafields',


### PR DESCRIPTION
The `static_info_tables` has a dependency on `typo3/cms-install`. So whenever we load `static_info_tables` in a functional test, we also need to load `typo3/cms-install`.

Also switch the required Core extensions in the functional tests to always use the extensions' Composer names.