### PR TITLE
[BUGFIX] Add `typo3/cms-install` as a production dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -216,6 +216,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- Add `typo3/cms-install` as a production dependency (#4775)
 - Fix crash in the CSV export for deleted FE users (#4712, #4714)
 - Ensure that `Registration::getEvent()` returns an `EventDateInterface` (#4668)
 - Avoid overwriting event venues for events with timeslots (#4601)

--- a/composer.json
+++ b/composer.json
@@ -44,6 +44,7 @@
 		"typo3/cms-extbase": "^11.5.41",
 		"typo3/cms-fluid": "^11.5.41",
 		"typo3/cms-frontend": "^11.5.41",
+		"typo3/cms-install": "^11.5 || ^12.4",
 		"typo3fluid/fluid": "^2.7.4 || ^4.0"
 	},
 	"require-dev": {
@@ -75,8 +76,7 @@
 	},
 	"suggest": {
 		"oliverklee/onetimeaccount": "for event registration without an explicit FE login",
-		"oliverklee/seminars_premium": "for premium functionality",
-		"typo3/cms-install": "for running the upgrade wizards"
+		"oliverklee/seminars_premium": "for premium functionality"
 	},
 	"prefer-stable": true,
 	"autoload": {

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -11,6 +11,7 @@ $EM_CONF[$_EXTKEY] = [
             'typo3' => '11.5.41-11.5.99',
             'extbase' => '11.5.41-11.5.99',
             'feuserextrafields' => '6.7.0-6.99.99',
+            'install' => '11.5.41-11.5.99',
             'oelib' => '6.2.0-6.99.99',
             'static_info_tables' => '11.5.5-12.4.99',
         ],


### PR DESCRIPTION
This is required for the upgrade wizards and should not be optional.