### PR TITLE
[BUGFIX] Do not use constructor DI in repositories

### DIFF
--- a/Classes/Domain/Repository/AbstractRawDataCapableRepository.php
+++ b/Classes/Domain/Repository/AbstractRawDataCapableRepository.php
@@ -8,7 +8,6 @@ use OliverKlee\Seminars\Domain\Model\RawDataInterface;
 use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Extbase\DomainObject\DomainObjectInterface;
-use TYPO3\CMS\Extbase\Object\ObjectManagerInterface;
 use TYPO3\CMS\Extbase\Persistence\Repository;
 
 /**
@@ -19,10 +18,8 @@ abstract class AbstractRawDataCapableRepository extends Repository
 {
     protected ConnectionPool $connectionPool;
 
-    public function __construct(ObjectManagerInterface $objectManager, ConnectionPool $connectionPool)
+    public function injectConnectionPool(ConnectionPool $connectionPool): void
     {
-        parent::__construct($objectManager);
-
         $this->connectionPool = $connectionPool;
     }
 

--- a/Classes/Domain/Repository/Event/EventRepository.php
+++ b/Classes/Domain/Repository/Event/EventRepository.php
@@ -11,10 +11,8 @@ use OliverKlee\Seminars\Domain\Model\Event\NullEventTopic;
 use OliverKlee\Seminars\Domain\Repository\AbstractRawDataCapableRepository;
 use TYPO3\CMS\Core\Context\Context;
 use TYPO3\CMS\Core\Database\Connection;
-use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\DataHandling\DataHandler;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\CMS\Extbase\Object\ObjectManagerInterface;
 use TYPO3\CMS\Extbase\Persistence\Generic\Qom\ConstraintInterface;
 use TYPO3\CMS\Extbase\Persistence\Generic\QuerySettingsInterface;
 use TYPO3\CMS\Extbase\Persistence\Generic\Typo3QuerySettings;
@@ -40,10 +38,8 @@ class EventRepository extends AbstractRawDataCapableRepository
 
     private Context $context;
 
-    public function __construct(ObjectManagerInterface $objectManager, ConnectionPool $connectionPool, Context $context)
+    public function injectContext(Context $context): void
     {
-        parent::__construct($objectManager, $connectionPool);
-
         $this->context = $context;
     }
 

--- a/rector.php
+++ b/rector.php
@@ -103,4 +103,7 @@ return RectorConfig::configure()
         ExtEmConfRector::ADDITIONAL_VALUES_TO_BE_REMOVED => [],
     ])
     ->withSkip([
+        InjectMethodToConstructorInjectionRector::class => [
+            'Classes/Domain/Repository/*',
+        ],
     ]);


### PR DESCRIPTION
Using constructor DI in the repositories breaks
compatibility with TYPO3 12LTS as the Extbase
`ObjectManagerInterface` and `ObjectManager` are not available in TYPO3 12LTS anymore.

So, as long as we keep compatible with TYPO3 11LTS (where all Extbase `Repository` classes get an
`ObjectManagerInterface` as constructor parameter), we need to keep using `inject*()` methods for DI in the Extbase repositories.

(We can keep using constructor DI for `PageRepository`, which does not extend the Extbase `Repository`.)

Also configure Rector to skip the DI transformation for the repositories.

This partially reverts commit
49351a5dda4b55327725a5554865ff27fed9edc7.