### PR TITLE
[TASK] Avoid unnecessary mocking in a test

### DIFF
--- a/Build/phpstan/phpstan-baseline.neon
+++ b/Build/phpstan/phpstan-baseline.neon
@@ -3306,6 +3306,11 @@ parameters:
 			path: ../../Tests/Unit/Service/RegistrationProcessorTest.php
 
 		-
+			message: "#^OliverKlee\\\\Seminars\\\\Tests\\\\Unit\\\\Templating\\\\Fixtures\\\\TestingContentObjectRenderer\\:\\:__construct\\(\\) does not call parent constructor from TYPO3\\\\CMS\\\\Frontend\\\\ContentObject\\\\ContentObjectRenderer\\.$#"
+			count: 1
+			path: ../../Tests/Unit/Templating/Fixtures/TestingContentObjectRenderer.php
+
+		-
 			message: "#^OliverKlee\\\\Seminars\\\\Tests\\\\Unit\\\\Templating\\\\Fixtures\\\\TestingTemplateHelper\\:\\:__construct\\(\\) does not call parent constructor from OliverKlee\\\\Seminars\\\\Templating\\\\TemplateHelper\\.$#"
 			count: 1
 			path: ../../Tests/Unit/Templating/Fixtures/TestingTemplateHelper.php

--- a/Tests/Unit/Templating/Fixtures/TestingContentObjectRenderer.php
+++ b/Tests/Unit/Templating/Fixtures/TestingContentObjectRenderer.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+namespace OliverKlee\Seminars\Tests\Unit\Templating\Fixtures;
+
+use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
+
+final class TestingContentObjectRenderer extends ContentObjectRenderer
+{
+    public function __construct()
+    {
+    }
+}

--- a/Tests/Unit/Templating/TemplateHelperTest.php
+++ b/Tests/Unit/Templating/TemplateHelperTest.php
@@ -6,6 +6,7 @@ namespace OliverKlee\Seminars\Tests\Unit\Templating;
 
 use OliverKlee\Oelib\Configuration\ConfigurationProxy;
 use OliverKlee\Oelib\Templating\Template;
+use OliverKlee\Seminars\Tests\Unit\Templating\Fixtures\TestingContentObjectRenderer;
 use OliverKlee\Seminars\Tests\Unit\Templating\Fixtures\TestingTemplateHelper;
 use TYPO3\CMS\Core\Cache\Backend\NullBackend;
 use TYPO3\CMS\Core\Cache\CacheManager;
@@ -29,7 +30,7 @@ final class TemplateHelperTest extends UnitTestCase
         $cacheManager->setCacheConfigurations(['l10n' => ['backend' => NullBackend::class]]);
 
         $frontEndControllerMock = $this->createMock(TypoScriptFrontendController::class);
-        $frontEndControllerMock->cObj = $this->createMock(ContentObjectRenderer::class);
+        $frontEndControllerMock->cObj = new TestingContentObjectRenderer();
         $GLOBALS['TSFE'] = $frontEndControllerMock;
 
         $this->subject = new TestingTemplateHelper([]);
@@ -39,6 +40,8 @@ final class TemplateHelperTest extends UnitTestCase
     {
         ConfigurationProxy::purgeInstances();
         GeneralUtility::purgeInstances();
+
+        unset($GLOBALS['TSFE']);
 
         parent::tearDown();
     }
@@ -131,8 +134,6 @@ final class TemplateHelperTest extends UnitTestCase
 
     /**
      * @test
-     *
-     * @doesNotPerformAssertions
      */
     public function processTemplateWithoutTemplateFileDoesNotThrowException(): void
     {


### PR DESCRIPTION
Mocking `ContentObjectRenderer` poses some problems, and using the real thing does so as well:

- A mock does not implement `__sleep()`, which triggers some warnings.

- The real thing depends on the PSR-11 container present, which is not the case in the unit tests.