### PR TITLE
[TASK] Run tests with TYPO3 11LTS only up to PHP 8.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,11 +161,8 @@ jobs:
           - typo3-version: "^11.5"
             php-version: "8.3"
             composer-dependencies: lowest
-#          - typo3-version: "^11.5"
-#            php-version: "8.4"
-#            composer-dependencies: lowest
           - typo3-version: "^11.5"
-            php-version: "8.4"
+            php-version: "8.3"
             composer-dependencies: highest
   functional-tests:
     name: Functional tests
@@ -239,10 +236,10 @@ jobs:
             php-version: "7.4"
             composer-dependencies: highest
           - typo3-version: "^11.5"
-            php-version: "8.4"
+            php-version: "8.3"
             composer-dependencies: lowest
           - typo3-version: "^11.5"
-            php-version: "8.4"
+            php-version: "8.3"
             composer-dependencies: highest
   legacy-functional-tests:
     name: Legacy functional tests
@@ -316,10 +313,10 @@ jobs:
             php-version: "7.4"
             composer-dependencies: highest
           - typo3-version: "^11.5"
-            php-version: "8.4"
+            php-version: "8.3"
             composer-dependencies: lowest
           - typo3-version: "^11.5"
-            php-version: "8.4"
+            php-version: "8.3"
             composer-dependencies: highest
   shellcheck:
     name: Check shell scripts


### PR DESCRIPTION
TYPO3 11LTS/ELTS officially only claims compatibility up to PHP 8.3:

https://get.typo3.org/version/11

With PHP 8.4, we still get lots of warnings about implicitly nullable types in 3rd-party dependencies. So lower the max PHP version for the 11LTS tests from 8.4 to 8.3.

Fixes #4788