### PR TITLE
[BUGFIX] Avoid empty table datasets in a functional test

### DIFF
--- a/Tests/Functional/UpgradeWizards/Fixtures/RemoveDuplicateEventVenueRelationsUpgradeWizard/NoRelations.csv
+++ b/Tests/Functional/UpgradeWizards/Fixtures/RemoveDuplicateEventVenueRelationsUpgradeWizard/NoRelations.csv
@@ -5,6 +5,3 @@
 "tx_seminars_sites"
 ,"uid"
 ,1
-
-"tx_seminars_seminars_place_mm"
-,"uid_local","uid_foreign"


### PR DESCRIPTION
Table datasets in CSV DB fixtures must not be empty.