### PR TITLE
[TASK] Avoid using the `CacheNullifyer` in the tests

### DIFF
--- a/Tests/Functional/Service/EmailServiceTest.php
+++ b/Tests/Functional/Service/EmailServiceTest.php
@@ -7,7 +7,6 @@ namespace OliverKlee\Seminars\Tests\Functional\Service;
 use OliverKlee\Oelib\Configuration\ConfigurationRegistry;
 use OliverKlee\Oelib\Configuration\DummyConfiguration;
 use OliverKlee\Oelib\DataStructures\Collection;
-use OliverKlee\Oelib\Testing\CacheNullifyer;
 use OliverKlee\Seminars\Model\Event;
 use OliverKlee\Seminars\Model\FrontEndUser;
 use OliverKlee\Seminars\Model\Organizer;
@@ -44,8 +43,6 @@ final class EmailServiceTest extends FunctionalTestCase
     protected function setUp(): void
     {
         parent::setUp();
-
-        (new CacheNullifyer())->setAllCoreCaches();
 
         $languageService = GeneralUtility::makeInstance(LanguageServiceFactory::class)->create('default');
         $GLOBALS['LANG'] = $languageService;

--- a/Tests/LegacyFunctional/SchedulerTasks/MailNotifierTest.php
+++ b/Tests/LegacyFunctional/SchedulerTasks/MailNotifierTest.php
@@ -8,7 +8,6 @@ use OliverKlee\Oelib\Configuration\ConfigurationRegistry;
 use OliverKlee\Oelib\DataStructures\Collection;
 use OliverKlee\Oelib\Interfaces\Time;
 use OliverKlee\Oelib\Mapper\MapperRegistry;
-use OliverKlee\Oelib\Testing\CacheNullifyer;
 use OliverKlee\Oelib\Testing\TestingFramework;
 use OliverKlee\Seminars\Domain\Model\Event\EventInterface;
 use OliverKlee\Seminars\Mapper\EventMapper;
@@ -69,7 +68,6 @@ final class MailNotifierTest extends FunctionalTestCase
 
         $this->importCSVDataSet(__DIR__ . '/Fixtures/BackEndUser.csv');
 
-        (new CacheNullifyer())->setAllCoreCaches();
         $this->unifyTestingEnvironment();
 
         $this->configuration->setAsInteger('sendEventTakesPlaceReminderDaysBeforeBeginDate', 2);

--- a/Tests/LegacyFunctional/Service/EmailServiceTest.php
+++ b/Tests/LegacyFunctional/Service/EmailServiceTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace OliverKlee\Seminars\Tests\LegacyFunctional\Service;
 
 use OliverKlee\Oelib\DataStructures\Collection;
-use OliverKlee\Oelib\Testing\CacheNullifyer;
 use OliverKlee\Oelib\Testing\TestingFramework;
 use OliverKlee\Seminars\Model\Event;
 use OliverKlee\Seminars\Model\FrontEndUser;
@@ -47,8 +46,6 @@ final class EmailServiceTest extends FunctionalTestCase
     protected function setUp(): void
     {
         parent::setUp();
-
-        (new CacheNullifyer())->setAllCoreCaches();
 
         $this->unifyTestingEnvironment();
 


### PR DESCRIPTION
With the TYPO3 testing framework, this is not needed anymore.