### PR TITLE
[BUGFIX] Avoid deprecated `ExpressionBuilder` methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -225,6 +225,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- Avoid deprecated `ExpressionBuilder` methods (#4874)
 - Fix TCA migrations in TYPO3 12LTS (#4865, #4867, #4868, #4870, #4872, #4873)
 - Fix a bogus label in the FE editor flexforms (#4846, #4847)
 - Drop nonsensical `NULL` from `ext_tables.sql` (#4834)

--- a/Classes/BagBuilder/EventBagBuilder.php
+++ b/Classes/BagBuilder/EventBagBuilder.php
@@ -1008,7 +1008,7 @@ class EventBagBuilder extends AbstractBagBuilder
                     'minimum_age',
                     $queryBuilder->createNamedParameter($age, Connection::PARAM_INT),
                 ),
-                $queryBuilder->expr()->orX(
+                $queryBuilder->expr()->or(
                     $queryBuilder->expr()->eq(
                         'maximum_age',
                         $queryBuilder->createNamedParameter(0, Connection::PARAM_INT),
@@ -1029,7 +1029,7 @@ class EventBagBuilder extends AbstractBagBuilder
             ->select('uid')
             ->from($table)
             ->where(
-                $queryBuilder->expr()->orX(
+                $queryBuilder->expr()->or(
                     $queryBuilder->expr()->eq(
                         'object_type',
                         $queryBuilder->createNamedParameter(EventInterface::TYPE_SINGLE_EVENT, Connection::PARAM_INT),

--- a/Classes/Mapper/EventMapper.php
+++ b/Classes/Mapper/EventMapper.php
@@ -43,7 +43,7 @@ class EventMapper extends AbstractDataMapper
             ->select('*')
             ->from($this->getTableName())
             ->where(
-                $queryBuilder->expr()->andX(
+                $queryBuilder->expr()->and(
                     $queryBuilder->expr()->eq(
                         'cancelled',
                         $queryBuilder->createNamedParameter(EventInterface::STATUS_PLANNED, Connection::PARAM_INT),


### PR DESCRIPTION
https://docs.typo3.org/permalink/changelog:deprecation-97354