### PR TITLE
[BUGFIX] Avoid the deprecated message severity constants even more

### DIFF
--- a/Build/phpstan/phpstan-baseline.neon
+++ b/Build/phpstan/phpstan-baseline.neon
@@ -1411,6 +1411,11 @@ parameters:
 			path: ../../Classes/SchedulerTasks/MailNotifier.php
 
 		-
+			message: "#^Access to constant ERROR on an unknown class TYPO3\\\\CMS\\\\Core\\\\Type\\\\ContextualFeedbackSeverity\\.$#"
+			count: 1
+			path: ../../Classes/SchedulerTasks/MailNotifierConfiguration.php
+
+		-
 			message: "#^Method OliverKlee\\\\Seminars\\\\SchedulerTasks\\\\MailNotifierConfiguration\\:\\:getLanguageService\\(\\) should return TYPO3\\\\CMS\\\\Core\\\\Localization\\\\LanguageService but returns mixed\\.$#"
 			count: 1
 			path: ../../Classes/SchedulerTasks/MailNotifierConfiguration.php

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -226,7 +226,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
-- Avoid accessing the deprecated flash message severity constants (#4878)
+- Avoid accessing the deprecated flash message severity constants (#4878, #4884)
 - Avoid calling the deprecated `LanguageServer->getLL` (#4876, #4877)
 - Avoid deprecated `ExpressionBuilder` methods (#4874)
 - Fix TCA migrations in TYPO3 12LTS (#4865, #4867, #4868, #4870, #4872, #4873)

--- a/Classes/BackEnd/EmailService.php
+++ b/Classes/BackEnd/EmailService.php
@@ -14,6 +14,7 @@ use OliverKlee\Seminars\Domain\Model\Organizer;
 use OliverKlee\Seminars\Domain\Repository\Registration\RegistrationRepository;
 use OliverKlee\Seminars\Email\EmailBuilder;
 use TYPO3\CMS\Core\Information\Typo3Version;
+use TYPO3\CMS\Core\Messaging\AbstractMessage;
 use TYPO3\CMS\Core\Messaging\FlashMessage;
 use TYPO3\CMS\Core\Messaging\FlashMessageService;
 use TYPO3\CMS\Core\SingletonInterface;
@@ -69,16 +70,13 @@ class EmailService implements SingletonInterface
         if ((new Typo3Version())->getMajorVersion() >= 12) {
             $severity = ContextualFeedbackSeverity::OK;
         } else {
-            $severity = FlashMessage::OK;
+            $severity = AbstractMessage::OK;
         }
-        $message = GeneralUtility::makeInstance(
-            FlashMessage::class,
-            LocalizationUtility::translate('message_emailToAttendeesSent', 'seminars'),
-            '',
-            $severity,
-            true,
-        );
-        $this->addFlashMessage($message);
+
+        $message = LocalizationUtility::translate('message_emailToAttendeesSent', 'seminars');
+        \assert(\is_string($message));
+        $flashMessage = GeneralUtility::makeInstance(FlashMessage::class, $message, '', $severity, true);
+        $this->addFlashMessage($flashMessage);
     }
 
     /**

--- a/Classes/SchedulerTasks/MailNotifierConfiguration.php
+++ b/Classes/SchedulerTasks/MailNotifierConfiguration.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace OliverKlee\Seminars\SchedulerTasks;
 
 use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Information\Typo3Version;
 use TYPO3\CMS\Core\Localization\LanguageService;
 use TYPO3\CMS\Core\Messaging\AbstractMessage;
+use TYPO3\CMS\Core\Type\ContextualFeedbackSeverity;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Scheduler\AbstractAdditionalFieldProvider;
 use TYPO3\CMS\Scheduler\Controller\SchedulerModuleController;
@@ -65,8 +67,13 @@ class MailNotifierConfiguration extends AbstractAdditionalFieldProvider
             return true;
         }
 
+        if ((new Typo3Version())->getMajorVersion() >= 12) {
+            $severity = ContextualFeedbackSeverity::ERROR;
+        } else {
+            $severity = AbstractMessage::ERROR;
+        }
         $message = $this->getLanguageService()->sL(self::LABEL_PREFIX . 'schedulerTasks.errors.page-uid');
-        $this->addMessage($message, AbstractMessage::ERROR);
+        $this->addMessage($message, $severity);
 
         return false;
     }

--- a/Tests/Functional/SchedulerTasks/MailNotifierConfigurationTest.php
+++ b/Tests/Functional/SchedulerTasks/MailNotifierConfigurationTest.php
@@ -9,7 +9,7 @@ use OliverKlee\Seminars\SchedulerTasks\MailNotifierConfiguration;
 use PHPUnit\Framework\MockObject\MockObject;
 use TYPO3\CMS\Core\Information\Typo3Version;
 use TYPO3\CMS\Core\Localization\LanguageServiceFactory;
-use TYPO3\CMS\Core\Messaging\FlashMessage;
+use TYPO3\CMS\Core\Messaging\AbstractMessage;
 use TYPO3\CMS\Core\Messaging\FlashMessageQueue;
 use TYPO3\CMS\Core\Messaging\FlashMessageService;
 use TYPO3\CMS\Core\Type\ContextualFeedbackSeverity;
@@ -151,7 +151,7 @@ final class MailNotifierConfigurationTest extends FunctionalTestCase
         if ((new Typo3Version())->getMajorVersion() >= 12) {
             $severity = ContextualFeedbackSeverity::ERROR;
         } else {
-            $severity = FlashMessage::ERROR;
+            $severity = AbstractMessage::ERROR;
         }
         self::assertCount(1, $this->getFlashMessageQueue()->getAllMessages($severity));
     }
@@ -180,7 +180,7 @@ final class MailNotifierConfigurationTest extends FunctionalTestCase
         if ((new Typo3Version())->getMajorVersion() >= 12) {
             $severity = ContextualFeedbackSeverity::ERROR;
         } else {
-            $severity = FlashMessage::ERROR;
+            $severity = AbstractMessage::ERROR;
         }
         self::assertCount(1, $this->getFlashMessageQueue()->getAllMessages($severity));
     }


### PR DESCRIPTION
Also avoid accessing the constants using a subclass.