### PR TITLE
[BUGFIX] Avoid deprecated `->getTypoLink()` in category list

### DIFF
--- a/Build/phpstan/phpstan-baseline.neon
+++ b/Build/phpstan/phpstan-baseline.neon
@@ -411,11 +411,6 @@ parameters:
 			path: ../../Classes/FrontEnd/AbstractView.php
 
 		-
-			message: "#^Cannot call method getTypoLink\\(\\) on TYPO3\\\\CMS\\\\Frontend\\\\ContentObject\\\\ContentObjectRenderer\\|null\\.$#"
-			count: 1
-			path: ../../Classes/FrontEnd/CategoryList.php
-
-		-
 			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
 			count: 1
 			path: ../../Classes/FrontEnd/CategoryList.php

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -226,6 +226,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- Avoid the deprecated `->getTypoLink()` (#4895)
 - Avoid accessing the deprecated flash message severity constants (#4878, #4884)
 - Avoid calling the deprecated `LanguageServer->getLL` (#4876, #4877)
 - Avoid deprecated `ExpressionBuilder` methods (#4874)

--- a/Classes/FrontEnd/CategoryList.php
+++ b/Classes/FrontEnd/CategoryList.php
@@ -8,6 +8,8 @@ use OliverKlee\Seminars\BagBuilder\CategoryBagBuilder;
 use OliverKlee\Seminars\BagBuilder\EventBagBuilder;
 use OliverKlee\Seminars\OldModel\LegacyCategory;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Core\Utility\HttpUtility;
+use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
 
 /**
  * This class creates a category list.
@@ -85,11 +87,14 @@ class CategoryList extends AbstractView
         if ($title === '') {
             throw new \InvalidArgumentException('$title must not be empty.', 1333293044);
         }
+        \assert($this->cObj instanceof ContentObjectRenderer);
 
-        return $this->cObj->getTypoLink(
+        return $this->cObj->typoLink(
             $title,
-            (string)$this->getConfValueInteger('listPID'),
-            ['tx_seminars_pi1[category]' => $categoryUid],
+            [
+                'parameter' => (string)$this->getConfValueInteger('listPID'),
+                'additionalParams' => HttpUtility::buildQueryString(['tx_seminars_pi1[category]' => $categoryUid], '&'),
+            ],
         );
     }
 


### PR DESCRIPTION
We basically copy the relevant parts from `getTypoLink()` and call `typoLink` instead.

https://docs.typo3.org/permalink/changelog:deprecation-96641-2

Part of #4879