### PR TITLE
[TASK] Show 0 vacancies for fully-booked events in the FE editor

### DIFF
--- a/Resources/Private/Partials/FrontEndEditor/Vacancies.html
+++ b/Resources/Private/Partials/FrontEndEditor/Vacancies.html
@@ -6,10 +6,6 @@
             <f:then>
                 <f:translate key="plugin.{viewName}.events.property.vacancies.unlimited"/>
             </f:then>
-            <f:else if="{statistics.fullyBooked}">
-                <f:translate key="plugin.{viewName}.events.property.vacancies.fullyBooked"/>
-                🔴
-            </f:else>
             <f:else>
                 {statistics.vacancies}
             </f:else>

--- a/Tests/Functional/Controller/Fixtures/FrontEndEditorController/indexAction/FullyBookedSingleEvent.csv
+++ b/Tests/Functional/Controller/Fixtures/FrontEndEditorController/indexAction/FullyBookedSingleEvent.csv
@@ -1,0 +1,3 @@
+"tx_seminars_seminars"
+,"uid","pid","object_type","title","owner_feuser","attendees_max","offline_attendees"
+,1,2,0,"event with owner",1,9,9

--- a/Tests/Functional/Controller/FrontEndEditorControllerTest.php
+++ b/Tests/Functional/Controller/FrontEndEditorControllerTest.php
@@ -417,6 +417,21 @@ final class FrontEndEditorControllerTest extends FunctionalTestCase
     /**
      * @test
      */
+    public function indexActionForFullyBookedEventRendersZeroVacancies(): void
+    {
+        $this->importCSVDataSet(self::FIXTURES_PATH . '/indexAction/FullyBookedSingleEvent.csv');
+
+        $request = (new InternalRequest())->withPageId(self::PAGE_UID);
+        $requestContext = (new InternalRequestContext())->withFrontendUserId(1);
+        $response = $this->executeFrontendSubRequest($request, $requestContext);
+        $body = (string)$response->getBody();
+
+        self::assertMatchesRegularExpression('#<td[^>]*>\\s*0\\s*</td>#', $body);
+    }
+
+    /**
+     * @test
+     */
     public function indexActionWithSingleEventHasEditSingleEventLink(): void
     {
         $this->importCSVDataSet(self::FIXTURES_PATH . '/indexAction/SingleEventWithOwner.csv');


### PR DESCRIPTION
The red dot only for fully-booked events does not fit with the overall businesslike styling of the FE editor.

Fixes #4885