### PR TITLE
[BUGFIX] Avoid deprecated `->getTypoLink()` in `DefaultController`

### DIFF
--- a/Build/phpstan/phpstan-baseline.neon
+++ b/Build/phpstan/phpstan-baseline.neon
@@ -681,11 +681,6 @@ parameters:
 			path: ../../Classes/FrontEnd/DefaultController.php
 
 		-
-			message: "#^Cannot call method getTypoLink\\(\\) on TYPO3\\\\CMS\\\\Frontend\\\\ContentObject\\\\ContentObjectRenderer\\|null\\.$#"
-			count: 2
-			path: ../../Classes/FrontEnd/DefaultController.php
-
-		-
 			message: "#^Cannot call method getUid\\(\\) on OliverKlee\\\\Seminars\\\\Model\\\\FrontEndUser\\|null\\.$#"
 			count: 1
 			path: ../../Classes/FrontEnd/DefaultController.php

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -227,7 +227,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
-- Avoid the deprecated `->getTypoLink()` (#4895)
+- Avoid the deprecated `->getTypoLink()` (#4895, #4903)
 - Avoid accessing the deprecated flash message severity constants (#4878, #4884)
 - Avoid calling the deprecated `LanguageServer->getLL` (#4876, #4877)
 - Avoid deprecated `ExpressionBuilder` methods (#4874)

--- a/Classes/FrontEnd/DefaultController.php
+++ b/Classes/FrontEnd/DefaultController.php
@@ -40,6 +40,7 @@ use OliverKlee\Seminars\ViewHelpers\RichTextViewHelper;
 use TYPO3\CMS\Core\Context\Context;
 use TYPO3\CMS\Core\Resource\FileReference;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Core\Utility\HttpUtility;
 use TYPO3\CMS\Core\Utility\MathUtility;
 use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
 
@@ -385,10 +386,16 @@ class DefaultController extends TemplateHelper
         }
 
         if ($targetPageId) {
-            $result = $this->cObj->getTypoLink(
+            \assert($this->cObj instanceof ContentObjectRenderer);
+            $result = $this->cObj->typoLink(
                 $this->translate('label_listRegistrationsLink'),
-                (string)$targetPageId,
-                ['tx_seminars_pi1[seminar]' => $this->seminar->getUid()],
+                [
+                    'parameter' => (string)$targetPageId,
+                    'additionalParams' => HttpUtility::buildQueryString(
+                        ['tx_seminars_pi1[seminar]' => $this->seminar->getUid()],
+                        '&',
+                    ),
+                ],
             );
         }
 
@@ -2140,7 +2147,8 @@ class DefaultController extends TemplateHelper
         foreach ($this->seminar->getOrganizerBag() as $organizer) {
             $encodedName = \htmlspecialchars($organizer->getName(), ENT_QUOTES | ENT_HTML5);
             if ($organizer->hasHomepage()) {
-                $organizerHtml = $this->cObj->getTypoLink($encodedName, $organizer->getHomepage());
+                \assert($this->cObj instanceof ContentObjectRenderer);
+                $organizerHtml = $this->cObj->typoLink($encodedName, ['parameter' => $organizer->getHomepage()]);
             } else {
                 $organizerHtml = $encodedName;
             }


### PR DESCRIPTION
We basically copy the relevant parts from `getTypoLink()` and call `typoLink` instead.

https://docs.typo3.org/permalink/changelog:deprecation-96641-2

Part of #4879