### PR TITLE
[BUGFIX] Avoid deprecated `->getTypoLink()` in registration list

### DIFF
--- a/Build/phpstan/phpstan-baseline.neon
+++ b/Build/phpstan/phpstan-baseline.neon
@@ -1026,11 +1026,6 @@ parameters:
 			path: ../../Classes/FrontEnd/DefaultController.php
 
 		-
-			message: "#^Cannot call method getTypoLink\\(\\) on TYPO3\\\\CMS\\\\Frontend\\\\ContentObject\\\\ContentObjectRenderer\\|null\\.$#"
-			count: 1
-			path: ../../Classes/FrontEnd/RegistrationsList.php
-
-		-
 			message: "#^Method OliverKlee\\\\Seminars\\\\FrontEnd\\\\RegistrationsList\\:\\:__construct\\(\\) has parameter \\$configuration with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: ../../Classes/FrontEnd/RegistrationsList.php

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -228,7 +228,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
-- Avoid the deprecated `->getTypoLink()` (#4895, #4903)
+- Avoid the deprecated `->getTypoLink()` (#4895, #4903, #4904)
 - Avoid accessing the deprecated flash message severity constants (#4878, #4884)
 - Avoid calling the deprecated `LanguageServer->getLL` (#4876, #4877)
 - Avoid deprecated `ExpressionBuilder` methods (#4874)

--- a/Classes/FrontEnd/RegistrationsList.php
+++ b/Classes/FrontEnd/RegistrationsList.php
@@ -105,9 +105,13 @@ class RegistrationsList extends AbstractView
             $this->setMarker('registrations_list_view_content', '');
         }
 
+        \assert($this->cObj instanceof ContentObjectRenderer);
         $this->setMarker(
             'backlink',
-            $this->cObj->getTypoLink($this->translate('label_back'), (string)$this->getConfValueInteger('listPID')),
+            $this->cObj->typoLink(
+                $this->translate('label_back'),
+                ['parameter' => (string)$this->getConfValueInteger('listPID')],
+            ),
         );
 
         return $this->getSubpart('REGISTRATIONS_LIST_VIEW');


### PR DESCRIPTION
We basically copy the relevant parts from `getTypoLink()` and call `typoLink` instead.

https://docs.typo3.org/permalink/changelog:deprecation-96641-2

Part of #4879