### PR TITLE
[BUGFIX] Avoid deprecated `->getTypoLink()` in `LegacyEvent`

### DIFF
--- a/Build/phpstan/phpstan-baseline.neon
+++ b/Build/phpstan/phpstan-baseline.neon
@@ -1256,11 +1256,6 @@ parameters:
 			path: ../../Classes/OldModel/LegacyEvent.php
 
 		-
-			message: "#^Cannot call method getTypoLink\\(\\) on TYPO3\\\\CMS\\\\Frontend\\\\ContentObject\\\\ContentObjectRenderer\\|null\\.$#"
-			count: 1
-			path: ../../Classes/OldModel/LegacyEvent.php
-
-		-
 			message: "#^Cannot call method getUid\\(\\) on OliverKlee\\\\Seminars\\\\OldModel\\\\LegacyCategory\\|null\\.$#"
 			count: 1
 			path: ../../Classes/OldModel/LegacyEvent.php
@@ -1357,11 +1352,6 @@ parameters:
 
 		-
 			message: "#^Property OliverKlee\\\\Seminars\\\\OldModel\\\\LegacyEvent\\:\\:\\$registrations \\(array\\<array\\<string, int\\|string\\>\\>\\) does not accept array\\<int, array\\<string, mixed\\>\\>\\.$#"
-			count: 1
-			path: ../../Classes/OldModel/LegacyEvent.php
-
-		-
-			message: "#^Right side of && is always true\\.$#"
 			count: 1
 			path: ../../Classes/OldModel/LegacyEvent.php
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -228,7 +228,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
-- Avoid the deprecated `->getTypoLink()` (#4895, #4903, #4904)
+- Avoid the deprecated `->getTypoLink()` (#4895, #4903, #4904, #4905)
 - Avoid accessing the deprecated flash message severity constants (#4878, #4884)
 - Avoid calling the deprecated `LanguageServer->getLL` (#4876, #4877)
 - Avoid deprecated `ExpressionBuilder` methods (#4874)

--- a/Classes/OldModel/LegacyEvent.php
+++ b/Classes/OldModel/LegacyEvent.php
@@ -229,12 +229,12 @@ class LegacyEvent extends AbstractTimeSpan
         }
 
         $result = '';
-        $contentObjectRenderer = $plugin->getContentObjectRenderer();
+        $contentObject = $plugin->getContentObjectRenderer();
         foreach ($this->getPlacesAsArray() as $place) {
             $encodedPlaceTitle = \htmlspecialchars((string)$place['title'], ENT_QUOTES | ENT_HTML5);
             $homepage = (string)($place['homepage'] ?? '');
-            if ($contentObjectRenderer instanceof ContentObjectRenderer && $homepage !== '') {
-                $placeTitleHtml = $contentObjectRenderer->typoLink($encodedPlaceTitle, ['parameter' => $homepage]);
+            if ($contentObject instanceof ContentObjectRenderer && $homepage !== '') {
+                $placeTitleHtml = $contentObject->typoLink($encodedPlaceTitle, ['parameter' => $homepage]);
             } else {
                 $placeTitleHtml = $encodedPlaceTitle;
             }

--- a/Classes/OldModel/LegacyEvent.php
+++ b/Classes/OldModel/LegacyEvent.php
@@ -229,11 +229,12 @@ class LegacyEvent extends AbstractTimeSpan
         }
 
         $result = '';
+        $contentObjectRenderer = $plugin->getContentObjectRenderer();
         foreach ($this->getPlacesAsArray() as $place) {
             $encodedPlaceTitle = \htmlspecialchars((string)$place['title'], ENT_QUOTES | ENT_HTML5);
             $homepage = (string)($place['homepage'] ?? '');
-            if ($homepage !== '') {
-                $placeTitleHtml = $plugin->getContentObjectRenderer()->getTypoLink($encodedPlaceTitle, $homepage);
+            if ($contentObjectRenderer instanceof ContentObjectRenderer && $homepage !== '') {
+                $placeTitleHtml = $contentObjectRenderer->typoLink($encodedPlaceTitle, ['parameter' => $homepage]);
             } else {
                 $placeTitleHtml = $encodedPlaceTitle;
             }
@@ -556,7 +557,7 @@ class LegacyEvent extends AbstractTimeSpan
             $encodedTitle = \htmlspecialchars($speaker->getTitle(), ENT_QUOTES | ENT_HTML5);
 
             if ($contentObject instanceof ContentObjectRenderer && $speaker->hasHomepage()) {
-                $result[] = $contentObject->getTypoLink($encodedTitle, $speaker->getHomepage());
+                $result[] = $contentObject->typoLink($encodedTitle, ['parameter' => $speaker->getHomepage()]);
             } else {
                 $result[] = $encodedTitle;
             }
@@ -1450,8 +1451,8 @@ class LegacyEvent extends AbstractTimeSpan
 
         $frontEndController = $GLOBALS['TSFE'] ?? null;
         $contentObject = $frontEndController instanceof TypoScriptFrontendController ? $frontEndController->cObj : null;
-        if ($contentObject instanceof ContentObjectRenderer && $organizer->hasHomepage()) {
-            $html = $contentObject->getTypoLink($encodedName, $organizer->getHomepage());
+        if ($contentObject instanceof ContentObjectRenderer) {
+            $html = $contentObject->typoLink($encodedName, ['parameter' => $organizer->getHomepage()]);
         } else {
             $html = $encodedName;
         }


### PR DESCRIPTION
We basically copy the relevant parts from `getTypoLink()` and call `typoLink` instead.

https://docs.typo3.org/permalink/changelog:deprecation-96641-2

Part of #4879