### PR TITLE
[BUGFIX] Avoid deprecated `->getTypoLink()` in `LegacySpeaker`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -228,7 +228,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
-- Avoid the deprecated `->getTypoLink()` (#4895, #4903, #4904, #4905)
+- Avoid the deprecated `->getTypoLink()` (#4895, #4903, #4904, #4905, #4906)
 - Avoid accessing the deprecated flash message severity constants (#4878, #4884)
 - Avoid calling the deprecated `LanguageServer->getLL` (#4876, #4877)
 - Avoid deprecated `ExpressionBuilder` methods (#4874)

--- a/Classes/OldModel/LegacySpeaker.php
+++ b/Classes/OldModel/LegacySpeaker.php
@@ -183,8 +183,7 @@ class LegacySpeaker extends AbstractModel
      * Creates a link to this speaker's homepage, with the title as link text.
      *
      * @return string this speaker's title wrapped in a link tag, or if the
-     *                speaker has no homepage just the speaker name, will not
-     *                be empty
+     *                speaker has no homepage just the speaker name
      */
     public function getLinkedTitle(): string
     {
@@ -192,7 +191,7 @@ class LegacySpeaker extends AbstractModel
         $frontEndController = $GLOBALS['TSFE'] ?? null;
         $contentObject = $frontEndController instanceof TypoScriptFrontendController ? $frontEndController->cObj : null;
         if ($contentObject instanceof ContentObjectRenderer && $this->hasHomepage()) {
-            $result = $contentObject->getTypoLink($encodedTitle, $this->getHomepage());
+            $result = $contentObject->typoLink($encodedTitle, ['parameter' => $this->getHomepage()]);
         } else {
             $result = $encodedTitle;
         }


### PR DESCRIPTION
We basically copy the relevant parts from `getTypoLink()` and call `typoLink` instead.

https://docs.typo3.org/permalink/changelog:deprecation-96641-2

Part of #4879