### PR TITLE
[BUGFIX] Avoid deprecated `->getTypoLink()` in `RegistrationManager`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -228,7 +228,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
-- Avoid the deprecated `->getTypoLink()` (#4895, #4903, #4904, #4905, #4906)
+- Avoid the deprecated `->getTypoLink()`
+  (#4895, #4903, #4904, #4905, #4906, #4907)
 - Avoid accessing the deprecated flash message severity constants (#4878, #4884)
 - Avoid calling the deprecated `LanguageServer->getLL` (#4876, #4877)
 - Avoid deprecated `ExpressionBuilder` methods (#4874)

--- a/Classes/Service/RegistrationManager.php
+++ b/Classes/Service/RegistrationManager.php
@@ -32,6 +32,7 @@ use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\SingletonInterface;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Core\Utility\HttpUtility;
 use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
 use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
 
@@ -158,10 +159,15 @@ class RegistrationManager implements SingletonInterface
      */
     public function getLinkToRegistrationPage(DefaultController $plugin, LegacyEvent $event): string
     {
-        return $this->getContentObjectRendererFromPlugin($plugin)->getTypoLink(
+        return $this->getContentObjectRendererFromPlugin($plugin)->typoLink(
             $this->getRegistrationLabel($event),
-            (string)$plugin->getConfValueInteger('registerPID'),
-            ['tx_seminars_eventregistration[event]' => $event->getUid()],
+            [
+                'parameter' => (string)$plugin->getConfValueInteger('registerPID'),
+                'additionalParams' => HttpUtility::buildQueryString(
+                    ['tx_seminars_eventregistration[event]' => $event->getUid()],
+                    '&',
+                ),
+            ],
         );
     }
 
@@ -207,14 +213,19 @@ class RegistrationManager implements SingletonInterface
      */
     public function getLinkToUnregistrationPage(TemplateHelper $plugin, LegacyRegistration $registration): string
     {
-        return $this->getContentObjectRendererFromPlugin($plugin)->getTypoLink(
+        return $this->getContentObjectRendererFromPlugin($plugin)->typoLink(
             $this->translate('label_onlineUnregistration'),
-            (string)$plugin->getConfValueInteger('registerPID'),
             [
-                'tx_seminars_eventregistration' => [
-                    'controller' => 'EventUnregistration',
-                    'registration' => $registration->getUid(),
-                ],
+                'parameter' => (string)$plugin->getConfValueInteger('registerPID'),
+                'additionalParams' => HttpUtility::buildQueryString(
+                    [
+                        'tx_seminars_eventregistration' => [
+                            'controller' => 'EventUnregistration',
+                            'registration' => $registration->getUid(),
+                        ],
+                    ],
+                    '&',
+                ),
             ],
         );
     }


### PR DESCRIPTION
We basically copy the relevant parts from `getTypoLink()` and call `typoLink` instead.

https://docs.typo3.org/permalink/changelog:deprecation-96641-2

Part of #4879