### PR TITLE
[TASK] Avoid using the deprecated `ConfigurationProxy` in tests

### DIFF
--- a/Tests/Functional/FrontEnd/CategoryListTest.php
+++ b/Tests/Functional/FrontEnd/CategoryListTest.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace OliverKlee\Seminars\Tests\Functional\FrontEnd;
 
-use OliverKlee\Oelib\Configuration\ConfigurationProxy;
-use OliverKlee\Oelib\Configuration\DummyConfiguration;
 use OliverKlee\Oelib\Testing\TestingFramework;
 use OliverKlee\Seminars\FrontEnd\CategoryList;
 use OliverKlee\Seminars\Tests\Support\LanguageHelper;
@@ -37,10 +35,6 @@ final class CategoryListTest extends FunctionalTestCase
 
         $this->testingFramework = new TestingFramework('tx_seminars');
         $this->testingFramework->createFakeFrontEnd($this->testingFramework->createFrontEndPage());
-
-        $extensionConfiguration = new DummyConfiguration();
-        $extensionConfiguration->setAsBoolean('enableConfigCheck', false);
-        ConfigurationProxy::setInstance('seminars', $extensionConfiguration);
 
         $this->subject = new CategoryList(
             [

--- a/Tests/Functional/FrontEnd/DefaultController/ListViewTest.php
+++ b/Tests/Functional/FrontEnd/DefaultController/ListViewTest.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace OliverKlee\Seminars\Tests\Functional\FrontEnd\DefaultController;
 
-use OliverKlee\Oelib\Configuration\ConfigurationProxy;
-use OliverKlee\Oelib\Configuration\DummyConfiguration;
 use OliverKlee\Oelib\Testing\TestingFramework;
 use OliverKlee\Seminars\Tests\Functional\FrontEnd\Fixtures\TestingDefaultController;
 use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
@@ -30,10 +28,6 @@ final class ListViewTest extends FunctionalTestCase
         parent::setUp();
 
         $this->testingFramework = new TestingFramework('tx_seminars');
-
-        $extensionConfiguration = new DummyConfiguration();
-        $extensionConfiguration->setAsBoolean('enableConfigCheck', false);
-        ConfigurationProxy::setInstance('seminars', $extensionConfiguration);
     }
 
     private function buildSubjectForListView(string $fixtureFileName): TestingDefaultController

--- a/Tests/Functional/FrontEnd/DefaultController/SingleViewTest.php
+++ b/Tests/Functional/FrontEnd/DefaultController/SingleViewTest.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace OliverKlee\Seminars\Tests\Functional\FrontEnd\DefaultController;
 
-use OliverKlee\Oelib\Configuration\ConfigurationProxy;
-use OliverKlee\Oelib\Configuration\DummyConfiguration;
 use OliverKlee\Oelib\Testing\TestingFramework;
 use OliverKlee\Seminars\Seo\SingleViewPageTitleProvider;
 use OliverKlee\Seminars\Tests\Functional\FrontEnd\Fixtures\TestingDefaultController;
@@ -33,10 +31,6 @@ final class SingleViewTest extends FunctionalTestCase
     protected function setUp(): void
     {
         parent::setUp();
-
-        $extensionConfiguration = new DummyConfiguration();
-        $extensionConfiguration->setAsBoolean('enableConfigCheck', false);
-        ConfigurationProxy::setInstance('seminars', $extensionConfiguration);
 
         $this->testingFramework = new TestingFramework('tx_seminars');
         $this->buildSubjectForSingleView();

--- a/Tests/Functional/Templating/TemplateHelperTest.php
+++ b/Tests/Functional/Templating/TemplateHelperTest.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace OliverKlee\Seminars\Tests\Functional\Templating;
 
-use OliverKlee\Oelib\Configuration\ConfigurationProxy;
-use OliverKlee\Oelib\Configuration\DummyConfiguration;
 use OliverKlee\Oelib\Exception\NotFoundException;
 use OliverKlee\Seminars\Tests\Unit\Templating\Fixtures\TestingTemplateHelper;
 use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
@@ -35,16 +33,7 @@ final class TemplateHelperTest extends FunctionalTestCase
         $frontEndControllerMock->cObj = $this->createMock(ContentObjectRenderer::class);
         $GLOBALS['TSFE'] = $frontEndControllerMock;
 
-        $configuration = new DummyConfiguration(['enableConfigCheck' => true]);
-        ConfigurationProxy::setInstance('seminars', $configuration);
-
         $this->subject = new TestingTemplateHelper([]);
-    }
-
-    protected function tearDown(): void
-    {
-        ConfigurationProxy::purgeInstances();
-        parent::tearDown();
     }
 
     ///////////////////////////////

--- a/Tests/LegacyFunctional/FrontEnd/DefaultControllerTest.php
+++ b/Tests/LegacyFunctional/FrontEnd/DefaultControllerTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace OliverKlee\Seminars\Tests\LegacyFunctional\FrontEnd;
 
-use OliverKlee\Oelib\Configuration\ConfigurationProxy;
 use OliverKlee\Oelib\Configuration\ConfigurationRegistry;
 use OliverKlee\Oelib\Configuration\DummyConfiguration;
 use OliverKlee\Oelib\Interfaces\Time;
@@ -87,10 +86,6 @@ final class DefaultControllerTest extends FunctionalTestCase
 
     private ConnectionPool $connectionPool;
 
-    private DummyConfiguration $sharedConfiguration;
-
-    private DummyConfiguration $extensionConfiguration;
-
     private DummyConfiguration $pluginConfiguration;
 
     /**
@@ -115,11 +110,7 @@ final class DefaultControllerTest extends FunctionalTestCase
 
         $this->getLanguageService();
 
-        $this->extensionConfiguration = new DummyConfiguration();
-        $this->extensionConfiguration->setAsBoolean('enableConfigCheck', false);
-        ConfigurationProxy::setInstance('seminars', $this->extensionConfiguration);
-        $this->sharedConfiguration = new DummyConfiguration(self::CONFIGURATION);
-        ConfigurationRegistry::getInstance()->set('plugin.tx_seminars', $this->sharedConfiguration);
+        ConfigurationRegistry::getInstance()->set('plugin.tx_seminars', new DummyConfiguration(self::CONFIGURATION));
         $this->pluginConfiguration = new DummyConfiguration(self::CONFIGURATION);
         ConfigurationRegistry::getInstance()->set('plugin.tx_seminars_pi1', $this->pluginConfiguration);
 
@@ -172,7 +163,6 @@ final class DefaultControllerTest extends FunctionalTestCase
         $this->testingFramework->cleanUpWithoutDatabase();
 
         ConfigurationRegistry::purgeInstance();
-        ConfigurationProxy::purgeInstances();
 
         $GLOBALS['TYPO3_CONF_VARS']['EXTCONF'] = $this->extConfBackup;
 
@@ -3112,21 +3102,6 @@ final class DefaultControllerTest extends FunctionalTestCase
         self::assertTrue(
             strpos($output, 'Event B') < strpos($output, 'Event A'),
         );
-    }
-
-    /**
-     * @test
-     *
-     * @doesNotPerformAssertions
-     */
-    public function listViewSortedByCategoryWithoutStaticTemplateAndEnabledConfigurationCheckDoesNotCrash(): void
-    {
-        $this->extensionConfiguration->setAsBoolean('enableConfigCheck', true);
-
-        $subject = new TestingDefaultController();
-        $subject->init(['sortListViewByCategory' => 1]);
-
-        $subject->main('', []);
     }
 
     /**

--- a/Tests/Unit/Templating/TemplateHelperTest.php
+++ b/Tests/Unit/Templating/TemplateHelperTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace OliverKlee\Seminars\Tests\Unit\Templating;
 
-use OliverKlee\Oelib\Configuration\ConfigurationProxy;
 use OliverKlee\Oelib\Templating\Template;
 use OliverKlee\Seminars\Tests\Unit\Templating\Fixtures\TestingContentObjectRenderer;
 use OliverKlee\Seminars\Tests\Unit\Templating\Fixtures\TestingTemplateHelper;
@@ -38,7 +37,6 @@ final class TemplateHelperTest extends UnitTestCase
 
     protected function tearDown(): void
     {
-        ConfigurationProxy::purgeInstances();
         GeneralUtility::purgeInstances();
 
         unset($GLOBALS['TSFE']);


### PR DESCRIPTION
Part of #4068