### PR TITLE
[BUGFIX] Always provide `timeframeInList` in tests

### DIFF
--- a/Tests/Functional/FrontEnd/CategoryListTest.php
+++ b/Tests/Functional/FrontEnd/CategoryListTest.php
@@ -46,6 +46,7 @@ final class CategoryListTest extends FunctionalTestCase
             [
                 'isStaticTemplateLoaded' => 1,
                 'templateFile' => 'EXT:seminars/Resources/Private/Templates/FrontEnd/FrontEnd.html',
+                'timeframeInList' => 'currentAndUpcoming',
             ],
             $this->getFrontEndController()->cObj,
         );

--- a/Tests/Functional/FrontEnd/DefaultController/ListViewTest.php
+++ b/Tests/Functional/FrontEnd/DefaultController/ListViewTest.php
@@ -59,6 +59,7 @@ final class ListViewTest extends FunctionalTestCase
                     'results_at_a_time' => 999,
                     'maxPages' => 5,
                 ],
+                'timeframeInList' => 'currentAndUpcoming',
                 'linkToSingleView' => 'always',
             ],
         );

--- a/Tests/Functional/OldModel/LegacyEventTest.php
+++ b/Tests/Functional/OldModel/LegacyEventTest.php
@@ -70,7 +70,13 @@ final class LegacyEventTest extends FunctionalTestCase
         $this->testingFramework->createFakeFrontEnd(1);
 
         $plugin = new DefaultController();
-        $plugin->main('', ['templateFile' => 'EXT:seminars/Resources/Private/Templates/FrontEnd/FrontEnd.html']);
+        $plugin->main(
+            '',
+            [
+                'templateFile' => 'EXT:seminars/Resources/Private/Templates/FrontEnd/FrontEnd.html',
+                'timeframeInList' => 'currentAndUpcoming',
+            ]
+        );
 
         return $plugin;
     }

--- a/Tests/LegacyFunctional/FrontEnd/CategoryListTest.php
+++ b/Tests/LegacyFunctional/FrontEnd/CategoryListTest.php
@@ -54,6 +54,7 @@ final class CategoryListTest extends FunctionalTestCase
                 'pages' => $this->systemFolderPid,
                 'pidList' => $this->systemFolderPid,
                 'recursive' => 1,
+                'timeframeInList' => 'currentAndUpcoming',
             ],
             $this->getFrontEndController()->cObj,
         );

--- a/Tests/LegacyFunctional/FrontEnd/DefaultControllerTest.php
+++ b/Tests/LegacyFunctional/FrontEnd/DefaultControllerTest.php
@@ -152,6 +152,7 @@ final class DefaultControllerTest extends FunctionalTestCase
                     'results_at_a_time' => 999,
                     'maxPages' => 5,
                 ],
+                'timeframeInList' => 'currentAndUpcoming',
                 'linkToSingleView' => 'always',
             ],
         );
@@ -5598,6 +5599,7 @@ final class DefaultControllerTest extends FunctionalTestCase
 
         $subject->init(
             [
+                'timeframeInList' => 'currentAndUpcoming',
                 'registrationsListPID' => $listPid,
                 'registrationsVipListPID' => $vipListPid,
             ],
@@ -5639,6 +5641,7 @@ final class DefaultControllerTest extends FunctionalTestCase
 
         $subject->init(
             [
+                'timeframeInList' => 'currentAndUpcoming',
                 'registrationsListPID' => $listPid,
                 'registrationsVipListPID' => $vipListPid,
             ],
@@ -5680,6 +5683,7 @@ final class DefaultControllerTest extends FunctionalTestCase
 
         $subject->init(
             [
+                'timeframeInList' => 'currentAndUpcoming',
                 'registrationsListPID' => $listPid,
                 'registrationsVipListPID' => $vipListPid,
             ],


### PR DESCRIPTION
For legacy event list view, this value is not allowed to be empty.

Also stop swallowing exceptions about invalid values, which allows the integrator to fix their setup.