### PR TITLE
[CLEANUP] Avoid using the deprecated `Time` class

### DIFF
--- a/Classes/BagBuilder/EventBagBuilder.php
+++ b/Classes/BagBuilder/EventBagBuilder.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace OliverKlee\Seminars\BagBuilder;
 
-use OliverKlee\Oelib\Interfaces\Time;
 use OliverKlee\Seminars\Bag\EventBag;
 use OliverKlee\Seminars\Domain\Model\Event\EventInterface;
 use OliverKlee\Seminars\OldModel\LegacyEvent;
@@ -43,6 +42,8 @@ class EventBagBuilder extends AbstractBagBuilder
         'all',
         'today',
     ];
+
+    private const SECONDS_PER_DAY = 86400;
 
     /**
      * @var array<string, list<non-empty-string>> a list of field names of m:n associations in which we can search,
@@ -429,8 +430,8 @@ class EventBagBuilder extends AbstractBagBuilder
         }
 
         $endDate = $event->getEndDateAsTimestamp();
-        $midnightBeforeEndDate = $endDate - ($endDate % Time::SECONDS_PER_DAY);
-        $secondMidnightAfterEndDate = $midnightBeforeEndDate + 2 * Time::SECONDS_PER_DAY;
+        $midnightBeforeEndDate = $endDate - ($endDate % self::SECONDS_PER_DAY);
+        $secondMidnightAfterEndDate = $midnightBeforeEndDate + 2 * self::SECONDS_PER_DAY;
 
         $this->whereClauseParts['next_day'] = 'begin_date>=' . $endDate .
             ' AND begin_date<' . $secondMidnightAfterEndDate;
@@ -556,7 +557,7 @@ class EventBagBuilder extends AbstractBagBuilder
     public function limitToDaysBeforeBeginDate(int $days): void
     {
         $nowPlusDays = GeneralUtility::makeInstance(Context::class)->getPropertyFromAspect('date', 'timestamp')
-            + $days * Time::SECONDS_PER_DAY;
+            + $days * self::SECONDS_PER_DAY;
 
         $this->whereClauseParts['days_before_begin_date'] = 'tx_seminars_seminars.begin_date < ' . $nowPlusDays;
     }

--- a/Classes/OldModel/LegacyEvent.php
+++ b/Classes/OldModel/LegacyEvent.php
@@ -6,7 +6,6 @@ namespace OliverKlee\Seminars\OldModel;
 
 use OliverKlee\Oelib\Configuration\ConfigurationRegistry;
 use OliverKlee\Oelib\DataStructures\Collection;
-use OliverKlee\Oelib\Interfaces\Time;
 use OliverKlee\Oelib\Mapper\MapperRegistry;
 use OliverKlee\Oelib\ViewHelpers\PriceViewHelper;
 use OliverKlee\Seminars\Bag\EventBag;
@@ -36,6 +35,8 @@ use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
  */
 class LegacyEvent extends AbstractTimeSpan
 {
+    private const SECONDS_PER_DAY = 86400;
+
     /**
      * @var string the name of the SQL table this class corresponds to
      */
@@ -2951,7 +2952,7 @@ class LegacyEvent extends AbstractTimeSpan
         $deadline = $beginDate;
         /** @var LegacySpeaker $speaker */
         foreach ($this->getSpeakerBag() as $speaker) {
-            $speakerDeadline = $beginDate - ($speaker->getCancelationPeriodInDays() * Time::SECONDS_PER_DAY);
+            $speakerDeadline = $beginDate - ($speaker->getCancelationPeriodInDays() * self::SECONDS_PER_DAY);
             $deadline = \max(0, \min($speakerDeadline, $deadline));
         }
 

--- a/Tests/LegacyFunctional/BagBuilder/EventBagBuilderTest.php
+++ b/Tests/LegacyFunctional/BagBuilder/EventBagBuilderTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace OliverKlee\Seminars\Tests\LegacyFunctional\BagBuilder;
 
-use OliverKlee\Oelib\Interfaces\Time;
 use OliverKlee\Oelib\Testing\TestingFramework;
 use OliverKlee\Seminars\Bag\AbstractBag;
 use OliverKlee\Seminars\Bag\EventBag;
@@ -21,6 +20,9 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
  */
 final class EventBagBuilderTest extends FunctionalTestCase
 {
+    private const SECONDS_PER_DAY = 86400;
+    private const SECONDS_PER_WEEK = 604800;
+
     protected array $testExtensionsToLoad = [
         'oliverklee/feuserextrafields',
         'oliverklee/oelib',
@@ -521,9 +523,9 @@ final class EventBagBuilderTest extends FunctionalTestCase
             'tx_seminars_seminars',
             [
                 'begin_date' => (int)GeneralUtility::makeInstance(Context::class)
-                        ->getPropertyFromAspect('date', 'timestamp') - Time::SECONDS_PER_WEEK,
+                        ->getPropertyFromAspect('date', 'timestamp') - self::SECONDS_PER_WEEK,
                 'end_date' => (int)GeneralUtility::makeInstance(Context::class)
-                        ->getPropertyFromAspect('date', 'timestamp') - Time::SECONDS_PER_DAY,
+                        ->getPropertyFromAspect('date', 'timestamp') - self::SECONDS_PER_DAY,
             ],
         );
 
@@ -545,7 +547,7 @@ final class EventBagBuilderTest extends FunctionalTestCase
             'tx_seminars_seminars',
             [
                 'begin_date' => (int)GeneralUtility::makeInstance(Context::class)
-                        ->getPropertyFromAspect('date', 'timestamp') - Time::SECONDS_PER_WEEK,
+                        ->getPropertyFromAspect('date', 'timestamp') - self::SECONDS_PER_WEEK,
                 'end_date' => 0,
             ],
         );
@@ -568,9 +570,9 @@ final class EventBagBuilderTest extends FunctionalTestCase
             'tx_seminars_seminars',
             [
                 'begin_date' => (int)GeneralUtility::makeInstance(Context::class)
-                        ->getPropertyFromAspect('date', 'timestamp') - Time::SECONDS_PER_DAY,
+                        ->getPropertyFromAspect('date', 'timestamp') - self::SECONDS_PER_DAY,
                 'end_date' => (int)GeneralUtility::makeInstance(Context::class)
-                        ->getPropertyFromAspect('date', 'timestamp') + Time::SECONDS_PER_DAY,
+                        ->getPropertyFromAspect('date', 'timestamp') + self::SECONDS_PER_DAY,
             ],
         );
 
@@ -591,9 +593,9 @@ final class EventBagBuilderTest extends FunctionalTestCase
             'tx_seminars_seminars',
             [
                 'begin_date' => (int)GeneralUtility::makeInstance(Context::class)
-                        ->getPropertyFromAspect('date', 'timestamp') + Time::SECONDS_PER_DAY,
+                        ->getPropertyFromAspect('date', 'timestamp') + self::SECONDS_PER_DAY,
                 'end_date' => (int)GeneralUtility::makeInstance(Context::class)
-                        ->getPropertyFromAspect('date', 'timestamp') + Time::SECONDS_PER_WEEK,
+                        ->getPropertyFromAspect('date', 'timestamp') + self::SECONDS_PER_WEEK,
             ],
         );
 
@@ -614,7 +616,7 @@ final class EventBagBuilderTest extends FunctionalTestCase
             'tx_seminars_seminars',
             [
                 'begin_date' => (int)GeneralUtility::makeInstance(Context::class)
-                        ->getPropertyFromAspect('date', 'timestamp') + Time::SECONDS_PER_DAY,
+                        ->getPropertyFromAspect('date', 'timestamp') + self::SECONDS_PER_DAY,
                 'end_date' => 0,
             ],
         );
@@ -663,9 +665,9 @@ final class EventBagBuilderTest extends FunctionalTestCase
             'tx_seminars_seminars',
             [
                 'begin_date' => (int)GeneralUtility::makeInstance(Context::class)
-                        ->getPropertyFromAspect('date', 'timestamp') - Time::SECONDS_PER_WEEK,
+                        ->getPropertyFromAspect('date', 'timestamp') - self::SECONDS_PER_WEEK,
                 'end_date' => (int)GeneralUtility::makeInstance(Context::class)
-                        ->getPropertyFromAspect('date', 'timestamp') - Time::SECONDS_PER_DAY,
+                        ->getPropertyFromAspect('date', 'timestamp') - self::SECONDS_PER_DAY,
             ],
         );
 
@@ -687,7 +689,7 @@ final class EventBagBuilderTest extends FunctionalTestCase
             'tx_seminars_seminars',
             [
                 'begin_date' => (int)GeneralUtility::makeInstance(Context::class)
-                        ->getPropertyFromAspect('date', 'timestamp') - Time::SECONDS_PER_WEEK,
+                        ->getPropertyFromAspect('date', 'timestamp') - self::SECONDS_PER_WEEK,
                 'end_date' => 0,
             ],
         );
@@ -710,9 +712,9 @@ final class EventBagBuilderTest extends FunctionalTestCase
             'tx_seminars_seminars',
             [
                 'begin_date' => (int)GeneralUtility::makeInstance(Context::class)
-                        ->getPropertyFromAspect('date', 'timestamp') - Time::SECONDS_PER_DAY,
+                        ->getPropertyFromAspect('date', 'timestamp') - self::SECONDS_PER_DAY,
                 'end_date' => (int)GeneralUtility::makeInstance(Context::class)
-                        ->getPropertyFromAspect('date', 'timestamp') + Time::SECONDS_PER_DAY,
+                        ->getPropertyFromAspect('date', 'timestamp') + self::SECONDS_PER_DAY,
             ],
         );
 
@@ -734,9 +736,9 @@ final class EventBagBuilderTest extends FunctionalTestCase
             'tx_seminars_seminars',
             [
                 'begin_date' => (int)GeneralUtility::makeInstance(Context::class)
-                        ->getPropertyFromAspect('date', 'timestamp') + Time::SECONDS_PER_DAY,
+                        ->getPropertyFromAspect('date', 'timestamp') + self::SECONDS_PER_DAY,
                 'end_date' => (int)GeneralUtility::makeInstance(Context::class)
-                        ->getPropertyFromAspect('date', 'timestamp') + Time::SECONDS_PER_WEEK,
+                        ->getPropertyFromAspect('date', 'timestamp') + self::SECONDS_PER_WEEK,
             ],
         );
 
@@ -757,7 +759,7 @@ final class EventBagBuilderTest extends FunctionalTestCase
             'tx_seminars_seminars',
             [
                 'begin_date' => (int)GeneralUtility::makeInstance(Context::class)
-                        ->getPropertyFromAspect('date', 'timestamp') + Time::SECONDS_PER_DAY,
+                        ->getPropertyFromAspect('date', 'timestamp') + self::SECONDS_PER_DAY,
                 'end_date' => 0,
             ],
         );
@@ -806,9 +808,9 @@ final class EventBagBuilderTest extends FunctionalTestCase
             'tx_seminars_seminars',
             [
                 'begin_date' => (int)GeneralUtility::makeInstance(Context::class)
-                        ->getPropertyFromAspect('date', 'timestamp') - Time::SECONDS_PER_WEEK,
+                        ->getPropertyFromAspect('date', 'timestamp') - self::SECONDS_PER_WEEK,
                 'end_date' => (int)GeneralUtility::makeInstance(Context::class)
-                        ->getPropertyFromAspect('date', 'timestamp') - Time::SECONDS_PER_DAY,
+                        ->getPropertyFromAspect('date', 'timestamp') - self::SECONDS_PER_DAY,
             ],
         );
 
@@ -829,7 +831,7 @@ final class EventBagBuilderTest extends FunctionalTestCase
             'tx_seminars_seminars',
             [
                 'begin_date' => (int)GeneralUtility::makeInstance(Context::class)
-                        ->getPropertyFromAspect('date', 'timestamp') - Time::SECONDS_PER_WEEK,
+                        ->getPropertyFromAspect('date', 'timestamp') - self::SECONDS_PER_WEEK,
                 'end_date' => 0,
             ],
         );
@@ -851,9 +853,9 @@ final class EventBagBuilderTest extends FunctionalTestCase
             'tx_seminars_seminars',
             [
                 'begin_date' => (int)GeneralUtility::makeInstance(Context::class)
-                        ->getPropertyFromAspect('date', 'timestamp') - Time::SECONDS_PER_DAY,
+                        ->getPropertyFromAspect('date', 'timestamp') - self::SECONDS_PER_DAY,
                 'end_date' => (int)GeneralUtility::makeInstance(Context::class)
-                        ->getPropertyFromAspect('date', 'timestamp') + Time::SECONDS_PER_DAY,
+                        ->getPropertyFromAspect('date', 'timestamp') + self::SECONDS_PER_DAY,
             ],
         );
 
@@ -875,9 +877,9 @@ final class EventBagBuilderTest extends FunctionalTestCase
             'tx_seminars_seminars',
             [
                 'begin_date' => (int)GeneralUtility::makeInstance(Context::class)
-                        ->getPropertyFromAspect('date', 'timestamp') + Time::SECONDS_PER_DAY,
+                        ->getPropertyFromAspect('date', 'timestamp') + self::SECONDS_PER_DAY,
                 'end_date' => (int)GeneralUtility::makeInstance(Context::class)
-                        ->getPropertyFromAspect('date', 'timestamp') + Time::SECONDS_PER_WEEK,
+                        ->getPropertyFromAspect('date', 'timestamp') + self::SECONDS_PER_WEEK,
             ],
         );
 
@@ -898,7 +900,7 @@ final class EventBagBuilderTest extends FunctionalTestCase
             'tx_seminars_seminars',
             [
                 'begin_date' => (int)GeneralUtility::makeInstance(Context::class)
-                        ->getPropertyFromAspect('date', 'timestamp') + Time::SECONDS_PER_DAY,
+                        ->getPropertyFromAspect('date', 'timestamp') + self::SECONDS_PER_DAY,
                 'end_date' => 0,
             ],
         );
@@ -947,9 +949,9 @@ final class EventBagBuilderTest extends FunctionalTestCase
             'tx_seminars_seminars',
             [
                 'begin_date' => (int)GeneralUtility::makeInstance(Context::class)
-                        ->getPropertyFromAspect('date', 'timestamp') - Time::SECONDS_PER_WEEK,
+                        ->getPropertyFromAspect('date', 'timestamp') - self::SECONDS_PER_WEEK,
                 'end_date' => (int)GeneralUtility::makeInstance(Context::class)
-                        ->getPropertyFromAspect('date', 'timestamp') - Time::SECONDS_PER_DAY,
+                        ->getPropertyFromAspect('date', 'timestamp') - self::SECONDS_PER_DAY,
             ],
         );
 
@@ -970,7 +972,7 @@ final class EventBagBuilderTest extends FunctionalTestCase
             'tx_seminars_seminars',
             [
                 'begin_date' => (int)GeneralUtility::makeInstance(Context::class)
-                        ->getPropertyFromAspect('date', 'timestamp') - Time::SECONDS_PER_WEEK,
+                        ->getPropertyFromAspect('date', 'timestamp') - self::SECONDS_PER_WEEK,
                 'end_date' => 0,
             ],
         );
@@ -992,9 +994,9 @@ final class EventBagBuilderTest extends FunctionalTestCase
             'tx_seminars_seminars',
             [
                 'begin_date' => (int)GeneralUtility::makeInstance(Context::class)
-                        ->getPropertyFromAspect('date', 'timestamp') - Time::SECONDS_PER_DAY,
+                        ->getPropertyFromAspect('date', 'timestamp') - self::SECONDS_PER_DAY,
                 'end_date' => (int)GeneralUtility::makeInstance(Context::class)
-                        ->getPropertyFromAspect('date', 'timestamp') + Time::SECONDS_PER_DAY,
+                        ->getPropertyFromAspect('date', 'timestamp') + self::SECONDS_PER_DAY,
             ],
         );
 
@@ -1016,9 +1018,9 @@ final class EventBagBuilderTest extends FunctionalTestCase
             'tx_seminars_seminars',
             [
                 'begin_date' => (int)GeneralUtility::makeInstance(Context::class)
-                        ->getPropertyFromAspect('date', 'timestamp') + Time::SECONDS_PER_DAY,
+                        ->getPropertyFromAspect('date', 'timestamp') + self::SECONDS_PER_DAY,
                 'end_date' => (int)GeneralUtility::makeInstance(Context::class)
-                        ->getPropertyFromAspect('date', 'timestamp') + Time::SECONDS_PER_WEEK,
+                        ->getPropertyFromAspect('date', 'timestamp') + self::SECONDS_PER_WEEK,
             ],
         );
 
@@ -1040,7 +1042,7 @@ final class EventBagBuilderTest extends FunctionalTestCase
             'tx_seminars_seminars',
             [
                 'begin_date' => (int)GeneralUtility::makeInstance(Context::class)
-                        ->getPropertyFromAspect('date', 'timestamp') + Time::SECONDS_PER_DAY,
+                        ->getPropertyFromAspect('date', 'timestamp') + self::SECONDS_PER_DAY,
                 'end_date' => 0,
             ],
         );
@@ -1091,9 +1093,9 @@ final class EventBagBuilderTest extends FunctionalTestCase
             'tx_seminars_seminars',
             [
                 'begin_date' => (int)GeneralUtility::makeInstance(Context::class)
-                        ->getPropertyFromAspect('date', 'timestamp') - Time::SECONDS_PER_WEEK,
+                        ->getPropertyFromAspect('date', 'timestamp') - self::SECONDS_PER_WEEK,
                 'end_date' => (int)GeneralUtility::makeInstance(Context::class)
-                        ->getPropertyFromAspect('date', 'timestamp') - Time::SECONDS_PER_DAY,
+                        ->getPropertyFromAspect('date', 'timestamp') - self::SECONDS_PER_DAY,
             ],
         );
 
@@ -1114,7 +1116,7 @@ final class EventBagBuilderTest extends FunctionalTestCase
             'tx_seminars_seminars',
             [
                 'begin_date' => (int)GeneralUtility::makeInstance(Context::class)
-                        ->getPropertyFromAspect('date', 'timestamp') - Time::SECONDS_PER_WEEK,
+                        ->getPropertyFromAspect('date', 'timestamp') - self::SECONDS_PER_WEEK,
                 'end_date' => 0,
             ],
         );
@@ -1136,9 +1138,9 @@ final class EventBagBuilderTest extends FunctionalTestCase
             'tx_seminars_seminars',
             [
                 'begin_date' => (int)GeneralUtility::makeInstance(Context::class)
-                        ->getPropertyFromAspect('date', 'timestamp') - Time::SECONDS_PER_DAY,
+                        ->getPropertyFromAspect('date', 'timestamp') - self::SECONDS_PER_DAY,
                 'end_date' => (int)GeneralUtility::makeInstance(Context::class)
-                        ->getPropertyFromAspect('date', 'timestamp') + Time::SECONDS_PER_DAY,
+                        ->getPropertyFromAspect('date', 'timestamp') + self::SECONDS_PER_DAY,
             ],
         );
 
@@ -1159,9 +1161,9 @@ final class EventBagBuilderTest extends FunctionalTestCase
             'tx_seminars_seminars',
             [
                 'begin_date' => (int)GeneralUtility::makeInstance(Context::class)
-                        ->getPropertyFromAspect('date', 'timestamp') + Time::SECONDS_PER_DAY,
+                        ->getPropertyFromAspect('date', 'timestamp') + self::SECONDS_PER_DAY,
                 'end_date' => (int)GeneralUtility::makeInstance(Context::class)
-                        ->getPropertyFromAspect('date', 'timestamp') + Time::SECONDS_PER_WEEK,
+                        ->getPropertyFromAspect('date', 'timestamp') + self::SECONDS_PER_WEEK,
             ],
         );
 
@@ -1183,7 +1185,7 @@ final class EventBagBuilderTest extends FunctionalTestCase
             'tx_seminars_seminars',
             [
                 'begin_date' => (int)GeneralUtility::makeInstance(Context::class)
-                        ->getPropertyFromAspect('date', 'timestamp') + Time::SECONDS_PER_DAY,
+                        ->getPropertyFromAspect('date', 'timestamp') + self::SECONDS_PER_DAY,
                 'end_date' => 0,
             ],
         );
@@ -1234,9 +1236,9 @@ final class EventBagBuilderTest extends FunctionalTestCase
             'tx_seminars_seminars',
             [
                 'begin_date' => (int)GeneralUtility::makeInstance(Context::class)
-                        ->getPropertyFromAspect('date', 'timestamp') - Time::SECONDS_PER_WEEK,
+                        ->getPropertyFromAspect('date', 'timestamp') - self::SECONDS_PER_WEEK,
                 'end_date' => (int)GeneralUtility::makeInstance(Context::class)
-                        ->getPropertyFromAspect('date', 'timestamp') - Time::SECONDS_PER_DAY,
+                        ->getPropertyFromAspect('date', 'timestamp') - self::SECONDS_PER_DAY,
             ],
         );
 
@@ -1257,7 +1259,7 @@ final class EventBagBuilderTest extends FunctionalTestCase
             'tx_seminars_seminars',
             [
                 'begin_date' => (int)GeneralUtility::makeInstance(Context::class)
-                        ->getPropertyFromAspect('date', 'timestamp') - Time::SECONDS_PER_WEEK,
+                        ->getPropertyFromAspect('date', 'timestamp') - self::SECONDS_PER_WEEK,
                 'end_date' => 0,
             ],
         );
@@ -1279,9 +1281,9 @@ final class EventBagBuilderTest extends FunctionalTestCase
             'tx_seminars_seminars',
             [
                 'begin_date' => (int)GeneralUtility::makeInstance(Context::class)
-                        ->getPropertyFromAspect('date', 'timestamp') - Time::SECONDS_PER_DAY,
+                        ->getPropertyFromAspect('date', 'timestamp') - self::SECONDS_PER_DAY,
                 'end_date' => (int)GeneralUtility::makeInstance(Context::class)
-                        ->getPropertyFromAspect('date', 'timestamp') + Time::SECONDS_PER_DAY,
+                        ->getPropertyFromAspect('date', 'timestamp') + self::SECONDS_PER_DAY,
             ],
         );
 
@@ -1302,9 +1304,9 @@ final class EventBagBuilderTest extends FunctionalTestCase
             'tx_seminars_seminars',
             [
                 'begin_date' => (int)GeneralUtility::makeInstance(Context::class)
-                        ->getPropertyFromAspect('date', 'timestamp') + Time::SECONDS_PER_DAY,
+                        ->getPropertyFromAspect('date', 'timestamp') + self::SECONDS_PER_DAY,
                 'end_date' => (int)GeneralUtility::makeInstance(Context::class)
-                        ->getPropertyFromAspect('date', 'timestamp') + Time::SECONDS_PER_WEEK,
+                        ->getPropertyFromAspect('date', 'timestamp') + self::SECONDS_PER_WEEK,
             ],
         );
 
@@ -1326,7 +1328,7 @@ final class EventBagBuilderTest extends FunctionalTestCase
             'tx_seminars_seminars',
             [
                 'begin_date' => (int)GeneralUtility::makeInstance(Context::class)
-                        ->getPropertyFromAspect('date', 'timestamp') + Time::SECONDS_PER_DAY,
+                        ->getPropertyFromAspect('date', 'timestamp') + self::SECONDS_PER_DAY,
                 'end_date' => 0,
             ],
         );
@@ -1377,9 +1379,9 @@ final class EventBagBuilderTest extends FunctionalTestCase
             'tx_seminars_seminars',
             [
                 'begin_date' => (int)GeneralUtility::makeInstance(Context::class)
-                        ->getPropertyFromAspect('date', 'timestamp') - Time::SECONDS_PER_WEEK,
+                        ->getPropertyFromAspect('date', 'timestamp') - self::SECONDS_PER_WEEK,
                 'end_date' => (int)GeneralUtility::makeInstance(Context::class)
-                        ->getPropertyFromAspect('date', 'timestamp') - Time::SECONDS_PER_DAY,
+                        ->getPropertyFromAspect('date', 'timestamp') - self::SECONDS_PER_DAY,
                 'deadline_registration' => 0,
             ],
         );
@@ -1401,7 +1403,7 @@ final class EventBagBuilderTest extends FunctionalTestCase
             'tx_seminars_seminars',
             [
                 'begin_date' => (int)GeneralUtility::makeInstance(Context::class)
-                        ->getPropertyFromAspect('date', 'timestamp') - Time::SECONDS_PER_WEEK,
+                        ->getPropertyFromAspect('date', 'timestamp') - self::SECONDS_PER_WEEK,
                 'end_date' => 0,
                 'deadline_registration' => 0,
             ],
@@ -1424,9 +1426,9 @@ final class EventBagBuilderTest extends FunctionalTestCase
             'tx_seminars_seminars',
             [
                 'begin_date' => (int)GeneralUtility::makeInstance(Context::class)
-                        ->getPropertyFromAspect('date', 'timestamp') - Time::SECONDS_PER_DAY,
+                        ->getPropertyFromAspect('date', 'timestamp') - self::SECONDS_PER_DAY,
                 'end_date' => (int)GeneralUtility::makeInstance(Context::class)
-                        ->getPropertyFromAspect('date', 'timestamp') + Time::SECONDS_PER_DAY,
+                        ->getPropertyFromAspect('date', 'timestamp') + self::SECONDS_PER_DAY,
                 'deadline_registration' => 0,
             ],
         );
@@ -1448,9 +1450,9 @@ final class EventBagBuilderTest extends FunctionalTestCase
             'tx_seminars_seminars',
             [
                 'begin_date' => (int)GeneralUtility::makeInstance(Context::class)
-                        ->getPropertyFromAspect('date', 'timestamp') + Time::SECONDS_PER_DAY,
+                        ->getPropertyFromAspect('date', 'timestamp') + self::SECONDS_PER_DAY,
                 'end_date' => (int)GeneralUtility::makeInstance(Context::class)
-                        ->getPropertyFromAspect('date', 'timestamp') + Time::SECONDS_PER_WEEK,
+                        ->getPropertyFromAspect('date', 'timestamp') + self::SECONDS_PER_WEEK,
                 'deadline_registration' => 0,
             ],
         );
@@ -1473,11 +1475,11 @@ final class EventBagBuilderTest extends FunctionalTestCase
             'tx_seminars_seminars',
             [
                 'begin_date' => (int)GeneralUtility::makeInstance(Context::class)
-                        ->getPropertyFromAspect('date', 'timestamp') + 2 * Time::SECONDS_PER_DAY,
+                        ->getPropertyFromAspect('date', 'timestamp') + 2 * self::SECONDS_PER_DAY,
                 'end_date' => (int)GeneralUtility::makeInstance(Context::class)
-                        ->getPropertyFromAspect('date', 'timestamp') + Time::SECONDS_PER_WEEK,
+                        ->getPropertyFromAspect('date', 'timestamp') + self::SECONDS_PER_WEEK,
                 'deadline_registration' => (int)GeneralUtility::makeInstance(Context::class)
-                        ->getPropertyFromAspect('date', 'timestamp') + Time::SECONDS_PER_DAY,
+                        ->getPropertyFromAspect('date', 'timestamp') + self::SECONDS_PER_DAY,
             ],
         );
 
@@ -1499,11 +1501,11 @@ final class EventBagBuilderTest extends FunctionalTestCase
             'tx_seminars_seminars',
             [
                 'begin_date' => (int)GeneralUtility::makeInstance(Context::class)
-                        ->getPropertyFromAspect('date', 'timestamp') + Time::SECONDS_PER_DAY,
+                        ->getPropertyFromAspect('date', 'timestamp') + self::SECONDS_PER_DAY,
                 'end_date' => (int)GeneralUtility::makeInstance(Context::class)
-                        ->getPropertyFromAspect('date', 'timestamp') + Time::SECONDS_PER_WEEK,
+                        ->getPropertyFromAspect('date', 'timestamp') + self::SECONDS_PER_WEEK,
                 'deadline_registration' => (int)GeneralUtility::makeInstance(Context::class)
-                        ->getPropertyFromAspect('date', 'timestamp') - Time::SECONDS_PER_DAY,
+                        ->getPropertyFromAspect('date', 'timestamp') - self::SECONDS_PER_DAY,
             ],
         );
 
@@ -1524,7 +1526,7 @@ final class EventBagBuilderTest extends FunctionalTestCase
             'tx_seminars_seminars',
             [
                 'begin_date' => (int)GeneralUtility::makeInstance(Context::class)
-                        ->getPropertyFromAspect('date', 'timestamp') + Time::SECONDS_PER_DAY,
+                        ->getPropertyFromAspect('date', 'timestamp') + self::SECONDS_PER_DAY,
                 'end_date' => 0,
                 'deadline_registration' => 0,
             ],
@@ -1600,7 +1602,7 @@ final class EventBagBuilderTest extends FunctionalTestCase
             'tx_seminars_seminars',
             [
                 'begin_date' => (int)GeneralUtility::makeInstance(Context::class)
-                        ->getPropertyFromAspect('date', 'timestamp') + Time::SECONDS_PER_DAY,
+                        ->getPropertyFromAspect('date', 'timestamp') + self::SECONDS_PER_DAY,
                 'end_date' => 0,
             ],
         );
@@ -1624,7 +1626,7 @@ final class EventBagBuilderTest extends FunctionalTestCase
                 'begin_date' => (int)GeneralUtility::makeInstance(Context::class)
                     ->getPropertyFromAspect('date', 'timestamp'),
                 'end_date' => (int)GeneralUtility::makeInstance(Context::class)
-                        ->getPropertyFromAspect('date', 'timestamp') + Time::SECONDS_PER_DAY,
+                        ->getPropertyFromAspect('date', 'timestamp') + self::SECONDS_PER_DAY,
             ],
         );
 
@@ -1646,7 +1648,7 @@ final class EventBagBuilderTest extends FunctionalTestCase
             'tx_seminars_seminars',
             [
                 'begin_date' => (int)GeneralUtility::makeInstance(Context::class)
-                        ->getPropertyFromAspect('date', 'timestamp') - Time::SECONDS_PER_DAY,
+                        ->getPropertyFromAspect('date', 'timestamp') - self::SECONDS_PER_DAY,
                 'end_date' => (int)GeneralUtility::makeInstance(Context::class)
                     ->getPropertyFromAspect('date', 'timestamp'),
             ],
@@ -1670,9 +1672,9 @@ final class EventBagBuilderTest extends FunctionalTestCase
             'tx_seminars_seminars',
             [
                 'begin_date' => (int)GeneralUtility::makeInstance(Context::class)
-                        ->getPropertyFromAspect('date', 'timestamp') - Time::SECONDS_PER_DAY,
+                        ->getPropertyFromAspect('date', 'timestamp') - self::SECONDS_PER_DAY,
                 'end_date' => (int)GeneralUtility::makeInstance(Context::class)
-                        ->getPropertyFromAspect('date', 'timestamp') + Time::SECONDS_PER_DAY,
+                        ->getPropertyFromAspect('date', 'timestamp') + self::SECONDS_PER_DAY,
             ],
         );
 
@@ -1694,9 +1696,9 @@ final class EventBagBuilderTest extends FunctionalTestCase
             'tx_seminars_seminars',
             [
                 'begin_date' => (int)GeneralUtility::makeInstance(Context::class)
-                        ->getPropertyFromAspect('date', 'timestamp') - Time::SECONDS_PER_WEEK,
+                        ->getPropertyFromAspect('date', 'timestamp') - self::SECONDS_PER_WEEK,
                 'end_date' => (int)GeneralUtility::makeInstance(Context::class)
-                        ->getPropertyFromAspect('date', 'timestamp') - Time::SECONDS_PER_DAY,
+                        ->getPropertyFromAspect('date', 'timestamp') - self::SECONDS_PER_DAY,
             ],
         );
 
@@ -1717,9 +1719,9 @@ final class EventBagBuilderTest extends FunctionalTestCase
             'tx_seminars_seminars',
             [
                 'begin_date' => (int)GeneralUtility::makeInstance(Context::class)
-                        ->getPropertyFromAspect('date', 'timestamp') + Time::SECONDS_PER_DAY,
+                        ->getPropertyFromAspect('date', 'timestamp') + self::SECONDS_PER_DAY,
                 'end_date' => (int)GeneralUtility::makeInstance(Context::class)
-                        ->getPropertyFromAspect('date', 'timestamp') + Time::SECONDS_PER_WEEK,
+                        ->getPropertyFromAspect('date', 'timestamp') + self::SECONDS_PER_WEEK,
             ],
         );
 
@@ -1767,9 +1769,9 @@ final class EventBagBuilderTest extends FunctionalTestCase
             'tx_seminars_seminars',
             [
                 'begin_date' => (int)GeneralUtility::makeInstance(Context::class)
-                        ->getPropertyFromAspect('date', 'timestamp') - Time::SECONDS_PER_WEEK,
+                        ->getPropertyFromAspect('date', 'timestamp') - self::SECONDS_PER_WEEK,
                 'end_date' => (int)GeneralUtility::makeInstance(Context::class)
-                        ->getPropertyFromAspect('date', 'timestamp') - Time::SECONDS_PER_DAY,
+                        ->getPropertyFromAspect('date', 'timestamp') - self::SECONDS_PER_DAY,
             ],
         );
 
@@ -1791,7 +1793,7 @@ final class EventBagBuilderTest extends FunctionalTestCase
             'tx_seminars_seminars',
             [
                 'begin_date' => (int)GeneralUtility::makeInstance(Context::class)
-                        ->getPropertyFromAspect('date', 'timestamp') - Time::SECONDS_PER_WEEK,
+                        ->getPropertyFromAspect('date', 'timestamp') - self::SECONDS_PER_WEEK,
                 'end_date' => 0,
             ],
         );
@@ -1814,9 +1816,9 @@ final class EventBagBuilderTest extends FunctionalTestCase
             'tx_seminars_seminars',
             [
                 'begin_date' => (int)GeneralUtility::makeInstance(Context::class)
-                        ->getPropertyFromAspect('date', 'timestamp') - Time::SECONDS_PER_DAY,
+                        ->getPropertyFromAspect('date', 'timestamp') - self::SECONDS_PER_DAY,
                 'end_date' => (int)GeneralUtility::makeInstance(Context::class)
-                        ->getPropertyFromAspect('date', 'timestamp') + Time::SECONDS_PER_DAY,
+                        ->getPropertyFromAspect('date', 'timestamp') + self::SECONDS_PER_DAY,
             ],
         );
 
@@ -1838,9 +1840,9 @@ final class EventBagBuilderTest extends FunctionalTestCase
             'tx_seminars_seminars',
             [
                 'begin_date' => (int)GeneralUtility::makeInstance(Context::class)
-                        ->getPropertyFromAspect('date', 'timestamp') + Time::SECONDS_PER_DAY,
+                        ->getPropertyFromAspect('date', 'timestamp') + self::SECONDS_PER_DAY,
                 'end_date' => (int)GeneralUtility::makeInstance(Context::class)
-                        ->getPropertyFromAspect('date', 'timestamp') + Time::SECONDS_PER_WEEK,
+                        ->getPropertyFromAspect('date', 'timestamp') + self::SECONDS_PER_WEEK,
             ],
         );
 
@@ -1862,7 +1864,7 @@ final class EventBagBuilderTest extends FunctionalTestCase
             'tx_seminars_seminars',
             [
                 'begin_date' => (int)GeneralUtility::makeInstance(Context::class)
-                        ->getPropertyFromAspect('date', 'timestamp') + Time::SECONDS_PER_DAY,
+                        ->getPropertyFromAspect('date', 'timestamp') + self::SECONDS_PER_DAY,
                 'end_date' => 0,
             ],
         );
@@ -2903,13 +2905,13 @@ final class EventBagBuilderTest extends FunctionalTestCase
     {
         $eventUid1 = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
-            ['begin_date' => Time::SECONDS_PER_DAY, 'end_date' => Time::SECONDS_PER_DAY + 60 * 60],
+            ['begin_date' => self::SECONDS_PER_DAY, 'end_date' => self::SECONDS_PER_DAY + 60 * 60],
         );
         $eventUid2 = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
             [
-                'begin_date' => 2 * Time::SECONDS_PER_DAY,
-                'end_date' => 60 * 60 + 2 * Time::SECONDS_PER_DAY,
+                'begin_date' => 2 * self::SECONDS_PER_DAY,
+                'end_date' => 60 * 60 + 2 * self::SECONDS_PER_DAY,
             ],
         );
         $event = new LegacyEvent($eventUid1);
@@ -2933,7 +2935,7 @@ final class EventBagBuilderTest extends FunctionalTestCase
     {
         $eventUid = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
-            ['begin_date' => Time::SECONDS_PER_DAY, 'end_date' => Time::SECONDS_PER_DAY + 60 * 60],
+            ['begin_date' => self::SECONDS_PER_DAY, 'end_date' => self::SECONDS_PER_DAY + 60 * 60],
         );
         $this->testingFramework->createRecord(
             'tx_seminars_seminars',
@@ -2958,13 +2960,13 @@ final class EventBagBuilderTest extends FunctionalTestCase
     {
         $eventUid = $this->testingFramework->createRecord(
             'tx_seminars_seminars',
-            ['begin_date' => Time::SECONDS_PER_DAY, 'end_date' => Time::SECONDS_PER_DAY + 60 * 60],
+            ['begin_date' => self::SECONDS_PER_DAY, 'end_date' => self::SECONDS_PER_DAY + 60 * 60],
         );
         $this->testingFramework->createRecord(
             'tx_seminars_seminars',
             [
-                'begin_date' => 3 * Time::SECONDS_PER_DAY,
-                'end_date' => 60 * 60 + 3 * Time::SECONDS_PER_DAY,
+                'begin_date' => 3 * self::SECONDS_PER_DAY,
+                'end_date' => 60 * 60 + 3 * self::SECONDS_PER_DAY,
             ],
         );
         $event = new LegacyEvent($eventUid);
@@ -4956,7 +4958,7 @@ final class EventBagBuilderTest extends FunctionalTestCase
             'tx_seminars_seminars',
             [
                 'begin_date' => (int)GeneralUtility::makeInstance(Context::class)
-                        ->getPropertyFromAspect('date', 'timestamp') + Time::SECONDS_PER_DAY,
+                        ->getPropertyFromAspect('date', 'timestamp') + self::SECONDS_PER_DAY,
             ],
         );
 
@@ -4978,7 +4980,7 @@ final class EventBagBuilderTest extends FunctionalTestCase
             'tx_seminars_seminars',
             [
                 'begin_date' => (int)GeneralUtility::makeInstance(Context::class)
-                        ->getPropertyFromAspect('date', 'timestamp') - Time::SECONDS_PER_DAY,
+                        ->getPropertyFromAspect('date', 'timestamp') - self::SECONDS_PER_DAY,
             ],
         );
 
@@ -5000,7 +5002,7 @@ final class EventBagBuilderTest extends FunctionalTestCase
             'tx_seminars_seminars',
             [
                 'begin_date' => (int)GeneralUtility::makeInstance(Context::class)
-                        ->getPropertyFromAspect('date', 'timestamp') + (2 * Time::SECONDS_PER_DAY),
+                        ->getPropertyFromAspect('date', 'timestamp') + (2 * self::SECONDS_PER_DAY),
             ],
         );
 
@@ -5022,7 +5024,7 @@ final class EventBagBuilderTest extends FunctionalTestCase
             'tx_seminars_seminars',
             [
                 'begin_date' => (int)GeneralUtility::makeInstance(Context::class)
-                        ->getPropertyFromAspect('date', 'timestamp') - (2 * Time::SECONDS_PER_DAY),
+                        ->getPropertyFromAspect('date', 'timestamp') - (2 * self::SECONDS_PER_DAY),
             ],
         );
 

--- a/Tests/LegacyFunctional/BagBuilder/RegistrationBagBuilderTest.php
+++ b/Tests/LegacyFunctional/BagBuilder/RegistrationBagBuilderTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace OliverKlee\Seminars\Tests\LegacyFunctional\BagBuilder;
 
-use OliverKlee\Oelib\Interfaces\Time;
 use OliverKlee\Oelib\Mapper\MapperRegistry;
 use OliverKlee\Oelib\Testing\TestingFramework;
 use OliverKlee\Seminars\Bag\RegistrationBag;
@@ -22,6 +21,8 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
  */
 final class RegistrationBagBuilderTest extends FunctionalTestCase
 {
+    private const SECONDS_PER_DAY = 86400;
+
     protected array $testExtensionsToLoad = [
         'oliverklee/feuserextrafields',
         'oliverklee/oelib',
@@ -75,7 +76,7 @@ final class RegistrationBagBuilderTest extends FunctionalTestCase
                 'crdate' => GeneralUtility::makeInstance(Context::class)->getPropertyFromAspect(
                     'date',
                     'timestamp',
-                ) + Time::SECONDS_PER_DAY,
+                ) + self::SECONDS_PER_DAY,
             ],
         );
         $this->testingFramework->createRecord(

--- a/Tests/LegacyFunctional/Email/SalutationTest.php
+++ b/Tests/LegacyFunctional/Email/SalutationTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace OliverKlee\Seminars\Tests\LegacyFunctional\Email;
 
 use OliverKlee\Oelib\Configuration\ConfigurationRegistry;
-use OliverKlee\Oelib\Interfaces\Time;
 use OliverKlee\Oelib\Mapper\MapperRegistry;
 use OliverKlee\Oelib\Testing\TestingFramework;
 use OliverKlee\Seminars\Email\Salutation;
@@ -26,6 +25,7 @@ final class SalutationTest extends FunctionalTestCase
 
     private const DATE_FORMAT = 'Y-m-d';
     private const TIME_FORMAT = 'H:i';
+    private const SECONDS_PER_DAY = 86400;
 
     protected array $testExtensionsToLoad = [
         'oliverklee/feuserextrafields',
@@ -291,13 +291,13 @@ final class SalutationTest extends FunctionalTestCase
             'tx_seminars_seminars',
             [
                 'begin_date' => $this->now,
-                'end_date' => $this->now + Time::SECONDS_PER_DAY,
+                'end_date' => $this->now + self::SECONDS_PER_DAY,
             ],
         );
         $event = new TestingLegacyEvent($eventUid);
 
         self::assertStringContainsString(
-            \date(self::DATE_FORMAT, $this->now) . '-' . \date(self::DATE_FORMAT, $this->now + Time::SECONDS_PER_DAY),
+            \date(self::DATE_FORMAT, $this->now) . '-' . \date(self::DATE_FORMAT, $this->now + self::SECONDS_PER_DAY),
             $this->subject->createIntroduction('%s', $event),
         );
     }

--- a/Tests/LegacyFunctional/FrontEnd/DefaultControllerTest.php
+++ b/Tests/LegacyFunctional/FrontEnd/DefaultControllerTest.php
@@ -6,7 +6,6 @@ namespace OliverKlee\Seminars\Tests\LegacyFunctional\FrontEnd;
 
 use OliverKlee\Oelib\Configuration\ConfigurationRegistry;
 use OliverKlee\Oelib\Configuration\DummyConfiguration;
-use OliverKlee\Oelib\Interfaces\Time;
 use OliverKlee\Oelib\Mapper\MapperRegistry;
 use OliverKlee\Oelib\Testing\TestingFramework;
 use OliverKlee\Seminars\Domain\Model\Event\EventInterface;
@@ -38,6 +37,9 @@ final class DefaultControllerTest extends FunctionalTestCase
     private const CONFIGURATION = [
         'currency' => 'EUR',
     ];
+
+    private const SECONDS_PER_DAY = 86400;
+    private const SECONDS_PER_WEEK = 604800;
 
     protected array $testExtensionsToLoad = [
         'sjbr/static-info-tables',
@@ -554,11 +556,11 @@ final class DefaultControllerTest extends FunctionalTestCase
                 'begin_date' => GeneralUtility::makeInstance(Context::class)->getPropertyFromAspect(
                     'date',
                     'timestamp',
-                ) + Time::SECONDS_PER_WEEK,
+                ) + self::SECONDS_PER_WEEK,
                 'end_date' => GeneralUtility::makeInstance(Context::class)->getPropertyFromAspect(
                     'date',
                     'timestamp',
-                ) + Time::SECONDS_PER_WEEK + Time::SECONDS_PER_DAY,
+                ) + self::SECONDS_PER_WEEK + self::SECONDS_PER_DAY,
             ],
         );
         $this->testingFramework->createRecord(
@@ -571,11 +573,11 @@ final class DefaultControllerTest extends FunctionalTestCase
                 'begin_date' => GeneralUtility::makeInstance(Context::class)->getPropertyFromAspect(
                     'date',
                     'timestamp',
-                ) + Time::SECONDS_PER_WEEK + 2 * Time::SECONDS_PER_DAY,
+                ) + self::SECONDS_PER_WEEK + 2 * self::SECONDS_PER_DAY,
                 'end_date' => GeneralUtility::makeInstance(Context::class)->getPropertyFromAspect(
                     'date',
                     'timestamp',
-                ) + Time::SECONDS_PER_WEEK + 3 * Time::SECONDS_PER_DAY,
+                ) + self::SECONDS_PER_WEEK + 3 * self::SECONDS_PER_DAY,
             ],
         );
 
@@ -618,11 +620,11 @@ final class DefaultControllerTest extends FunctionalTestCase
                 'begin_date' => GeneralUtility::makeInstance(Context::class)->getPropertyFromAspect(
                     'date',
                     'timestamp',
-                ) + Time::SECONDS_PER_WEEK,
+                ) + self::SECONDS_PER_WEEK,
                 'end_date' => GeneralUtility::makeInstance(Context::class)->getPropertyFromAspect(
                     'date',
                     'timestamp',
-                ) + Time::SECONDS_PER_WEEK + Time::SECONDS_PER_DAY,
+                ) + self::SECONDS_PER_WEEK + self::SECONDS_PER_DAY,
             ],
         );
         $singleEventUid = $this->testingFramework->createRecord(
@@ -635,11 +637,11 @@ final class DefaultControllerTest extends FunctionalTestCase
                 'begin_date' => GeneralUtility::makeInstance(Context::class)->getPropertyFromAspect(
                     'date',
                     'timestamp',
-                ) + Time::SECONDS_PER_WEEK + 2 * Time::SECONDS_PER_DAY,
+                ) + self::SECONDS_PER_WEEK + 2 * self::SECONDS_PER_DAY,
                 'end_date' => GeneralUtility::makeInstance(Context::class)->getPropertyFromAspect(
                     'date',
                     'timestamp',
-                ) + Time::SECONDS_PER_WEEK + 3 * Time::SECONDS_PER_DAY,
+                ) + self::SECONDS_PER_WEEK + 3 * self::SECONDS_PER_DAY,
             ],
         );
 
@@ -680,11 +682,11 @@ final class DefaultControllerTest extends FunctionalTestCase
                 'begin_date' => GeneralUtility::makeInstance(Context::class)->getPropertyFromAspect(
                     'date',
                     'timestamp',
-                ) + Time::SECONDS_PER_WEEK,
+                ) + self::SECONDS_PER_WEEK,
                 'end_date' => GeneralUtility::makeInstance(Context::class)->getPropertyFromAspect(
                     'date',
                     'timestamp',
-                ) + Time::SECONDS_PER_WEEK + Time::SECONDS_PER_DAY,
+                ) + self::SECONDS_PER_WEEK + self::SECONDS_PER_DAY,
             ],
         );
         $this->testingFramework->createRecord(
@@ -697,11 +699,11 @@ final class DefaultControllerTest extends FunctionalTestCase
                 'begin_date' => GeneralUtility::makeInstance(Context::class)->getPropertyFromAspect(
                     'date',
                     'timestamp',
-                ) + Time::SECONDS_PER_WEEK + 2 * Time::SECONDS_PER_DAY,
+                ) + self::SECONDS_PER_WEEK + 2 * self::SECONDS_PER_DAY,
                 'end_date' => GeneralUtility::makeInstance(Context::class)->getPropertyFromAspect(
                     'date',
                     'timestamp',
-                ) + Time::SECONDS_PER_WEEK + 3 * Time::SECONDS_PER_DAY,
+                ) + self::SECONDS_PER_WEEK + 3 * self::SECONDS_PER_DAY,
                 'needs_registration' => 1,
                 'attendees_max' => 5,
                 'offline_attendees' => 5,
@@ -745,11 +747,11 @@ final class DefaultControllerTest extends FunctionalTestCase
                 'begin_date' => GeneralUtility::makeInstance(Context::class)->getPropertyFromAspect(
                     'date',
                     'timestamp',
-                ) + Time::SECONDS_PER_WEEK,
+                ) + self::SECONDS_PER_WEEK,
                 'end_date' => GeneralUtility::makeInstance(Context::class)->getPropertyFromAspect(
                     'date',
                     'timestamp',
-                ) + Time::SECONDS_PER_WEEK + Time::SECONDS_PER_DAY,
+                ) + self::SECONDS_PER_WEEK + self::SECONDS_PER_DAY,
             ],
         );
         $dateUid2 = $this->testingFramework->createRecord(
@@ -762,11 +764,11 @@ final class DefaultControllerTest extends FunctionalTestCase
                 'begin_date' => GeneralUtility::makeInstance(Context::class)->getPropertyFromAspect(
                     'date',
                     'timestamp',
-                ) + Time::SECONDS_PER_WEEK + 2 * Time::SECONDS_PER_DAY,
+                ) + self::SECONDS_PER_WEEK + 2 * self::SECONDS_PER_DAY,
                 'end_date' => GeneralUtility::makeInstance(Context::class)->getPropertyFromAspect(
                     'date',
                     'timestamp',
-                ) + Time::SECONDS_PER_WEEK + 3 * Time::SECONDS_PER_DAY,
+                ) + self::SECONDS_PER_WEEK + 3 * self::SECONDS_PER_DAY,
                 'needs_registration' => 1,
                 'attendees_max' => 5,
                 'offline_attendees' => 5,
@@ -3446,7 +3448,7 @@ final class DefaultControllerTest extends FunctionalTestCase
             [
                 'pid' => $this->systemFolderPid,
                 'title' => 'Event with category',
-                'end_date' => Time::SECONDS_PER_WEEK,
+                'end_date' => self::SECONDS_PER_WEEK,
                 // the number of categories
                 'categories' => 1,
             ],

--- a/Tests/LegacyFunctional/OldModel/LegacyEventTest.php
+++ b/Tests/LegacyFunctional/OldModel/LegacyEventTest.php
@@ -6,7 +6,6 @@ namespace OliverKlee\Seminars\Tests\LegacyFunctional\OldModel;
 
 use OliverKlee\Oelib\Configuration\ConfigurationRegistry;
 use OliverKlee\Oelib\Configuration\DummyConfiguration;
-use OliverKlee\Oelib\Interfaces\Time;
 use OliverKlee\Oelib\Testing\TestingFramework;
 use OliverKlee\Seminars\Bag\EventBag;
 use OliverKlee\Seminars\Bag\OrganizerBag;
@@ -31,6 +30,9 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
 final class LegacyEventTest extends FunctionalTestCase
 {
     use LanguageHelper;
+
+    private const SECONDS_PER_DAY = 86400;
+    private const SECONDS_PER_WEEK = 604800;
 
     protected array $testExtensionsToLoad = [
         'sjbr/static-info-tables',
@@ -69,7 +71,7 @@ final class LegacyEventTest extends FunctionalTestCase
         $context->setAspect('date', new DateTimeAspect(new \DateTimeImmutable('2018-04-26 12:42:23')));
         $this->now = (int)$context->getPropertyFromAspect('date', 'timestamp');
 
-        $this->unregistrationDeadline = ($this->now + Time::SECONDS_PER_WEEK);
+        $this->unregistrationDeadline = ($this->now + self::SECONDS_PER_WEEK);
 
         $this->testingFramework = new TestingFramework();
         $this->connectionPool = GeneralUtility::makeInstance(ConnectionPool::class);
@@ -1741,7 +1743,7 @@ final class LegacyEventTest extends FunctionalTestCase
     public function isUnregistrationPossibleWithoutUnregistrationDeadlineReturnsTrue(): void
     {
         $this->subject->setUnregistrationDeadline(0);
-        $this->subject->setBeginDate($this->now + Time::SECONDS_PER_WEEK);
+        $this->subject->setBeginDate($this->now + self::SECONDS_PER_WEEK);
 
         self::assertTrue($this->subject->isUnregistrationPossible());
     }
@@ -1762,8 +1764,8 @@ final class LegacyEventTest extends FunctionalTestCase
      */
     public function isUnregistrationPossibleWithFutureEventDeadlineReturnsTrue(): void
     {
-        $this->subject->setUnregistrationDeadline($this->now + Time::SECONDS_PER_DAY);
-        $this->subject->setBeginDate($this->now + Time::SECONDS_PER_WEEK);
+        $this->subject->setUnregistrationDeadline($this->now + self::SECONDS_PER_DAY);
+        $this->subject->setBeginDate($this->now + self::SECONDS_PER_WEEK);
 
         self::assertTrue($this->subject->isUnregistrationPossible());
     }
@@ -1773,8 +1775,8 @@ final class LegacyEventTest extends FunctionalTestCase
      */
     public function isUnregistrationPossibleWithPastEventDeadlineReturnsFalse(): void
     {
-        $this->subject->setUnregistrationDeadline($this->now - Time::SECONDS_PER_DAY);
-        $this->subject->setBeginDate($this->now + Time::SECONDS_PER_WEEK);
+        $this->subject->setUnregistrationDeadline($this->now - self::SECONDS_PER_DAY);
+        $this->subject->setBeginDate($this->now + self::SECONDS_PER_WEEK);
 
         self::assertFalse($this->subject->isUnregistrationPossible());
     }
@@ -1784,7 +1786,7 @@ final class LegacyEventTest extends FunctionalTestCase
      */
     public function isUnregistrationPossibleWithoutBeginDateAndWithFutureEventDeadlineReturnsTrue(): void
     {
-        $this->subject->setUnregistrationDeadline($this->now + Time::SECONDS_PER_DAY);
+        $this->subject->setUnregistrationDeadline($this->now + self::SECONDS_PER_DAY);
         $this->subject->setBeginDate(0);
 
         self::assertTrue($this->subject->isUnregistrationPossible());
@@ -1795,7 +1797,7 @@ final class LegacyEventTest extends FunctionalTestCase
      */
     public function isUnregistrationPossibleWithoutBeginDateAndWithPastEventDeadlineReturnsFalse(): void
     {
-        $this->subject->setUnregistrationDeadline($this->now - Time::SECONDS_PER_DAY);
+        $this->subject->setUnregistrationDeadline($this->now - self::SECONDS_PER_DAY);
         $this->subject->setBeginDate(0);
 
         self::assertFalse($this->subject->isUnregistrationPossible());
@@ -1806,8 +1808,8 @@ final class LegacyEventTest extends FunctionalTestCase
      */
     public function isUnregistrationPossibleWithUnregistrationDeadlineInFutureReturnsTrue(): void
     {
-        $this->subject->setUnregistrationDeadline($this->now + Time::SECONDS_PER_DAY);
-        $this->subject->setBeginDate($this->now + Time::SECONDS_PER_WEEK);
+        $this->subject->setUnregistrationDeadline($this->now + self::SECONDS_PER_DAY);
+        $this->subject->setBeginDate($this->now + self::SECONDS_PER_WEEK);
 
         self::assertTrue($this->subject->isUnregistrationPossible());
     }
@@ -1817,8 +1819,8 @@ final class LegacyEventTest extends FunctionalTestCase
      */
     public function isUnregistrationPossibleWithUnregistrationDeadlineInPastReturnsFalse(): void
     {
-        $this->subject->setUnregistrationDeadline($this->now - Time::SECONDS_PER_DAY);
-        $this->subject->setBeginDate($this->now + Time::SECONDS_PER_DAY);
+        $this->subject->setUnregistrationDeadline($this->now - self::SECONDS_PER_DAY);
+        $this->subject->setBeginDate($this->now + self::SECONDS_PER_DAY);
 
         self::assertFalse($this->subject->isUnregistrationPossible());
     }
@@ -1828,7 +1830,7 @@ final class LegacyEventTest extends FunctionalTestCase
      */
     public function isUnregistrationPossibleWithoutBeginDateAndWithUnregistrationDeadlineInFutureReturnsTrue(): void
     {
-        $this->subject->setUnregistrationDeadline($this->now + Time::SECONDS_PER_DAY);
+        $this->subject->setUnregistrationDeadline($this->now + self::SECONDS_PER_DAY);
         $this->subject->setBeginDate(0);
 
         self::assertTrue($this->subject->isUnregistrationPossible());
@@ -1840,7 +1842,7 @@ final class LegacyEventTest extends FunctionalTestCase
     public function isUnregistrationPossibleWithoutBeginDateAndWithUnregistrationDeadlineInPastReturnsFalse(): void
     {
         $this->subject->setBeginDate(0);
-        $this->subject->setUnregistrationDeadline($this->now - Time::SECONDS_PER_DAY);
+        $this->subject->setUnregistrationDeadline($this->now - self::SECONDS_PER_DAY);
 
         self::assertFalse($this->subject->isUnregistrationPossible());
     }
@@ -1850,8 +1852,8 @@ final class LegacyEventTest extends FunctionalTestCase
      */
     public function isUnregistrationPossibleWithPastEventUnregistrationDeadlineReturnsFalse(): void
     {
-        $this->subject->setBeginDate($this->now + 2 * Time::SECONDS_PER_DAY);
-        $this->subject->setUnregistrationDeadline($this->now - Time::SECONDS_PER_DAY);
+        $this->subject->setBeginDate($this->now + 2 * self::SECONDS_PER_DAY);
+        $this->subject->setUnregistrationDeadline($this->now - self::SECONDS_PER_DAY);
 
         self::assertFalse($this->subject->isUnregistrationPossible());
     }
@@ -1862,8 +1864,8 @@ final class LegacyEventTest extends FunctionalTestCase
     public function isUnregistrationPossibleForNeedsRegistrationFalseReturnsFalse(): void
     {
         $this->subject->setNeedsRegistration(false);
-        $this->subject->setUnregistrationDeadline($this->now + Time::SECONDS_PER_DAY);
-        $this->subject->setBeginDate($this->now + Time::SECONDS_PER_WEEK);
+        $this->subject->setUnregistrationDeadline($this->now + self::SECONDS_PER_DAY);
+        $this->subject->setBeginDate($this->now + self::SECONDS_PER_WEEK);
 
         self::assertFalse($this->subject->isUnregistrationPossible());
     }
@@ -1873,9 +1875,9 @@ final class LegacyEventTest extends FunctionalTestCase
      */
     public function isUnregistrationPossibleForStartedEventWithUnregistrationDeadlineInFutureReturnsTrue(): void
     {
-        $this->subject->setBeginDate($this->now - Time::SECONDS_PER_DAY);
-        $this->subject->setEndDate($this->now + Time::SECONDS_PER_DAY);
-        $this->subject->setUnregistrationDeadline($this->now + Time::SECONDS_PER_WEEK);
+        $this->subject->setBeginDate($this->now - self::SECONDS_PER_DAY);
+        $this->subject->setEndDate($this->now + self::SECONDS_PER_DAY);
+        $this->subject->setUnregistrationDeadline($this->now + self::SECONDS_PER_WEEK);
 
         self::assertTrue($this->subject->isUnregistrationPossible());
     }
@@ -1885,9 +1887,9 @@ final class LegacyEventTest extends FunctionalTestCase
      */
     public function isUnregistrationPossibleForPastEventWithUnregistrationDeadlineInFutureReturnsTrue(): void
     {
-        $this->subject->setBeginDate($this->now - Time::SECONDS_PER_WEEK);
-        $this->subject->setEndDate($this->now - Time::SECONDS_PER_DAY);
-        $this->subject->setUnregistrationDeadline($this->now + Time::SECONDS_PER_WEEK);
+        $this->subject->setBeginDate($this->now - self::SECONDS_PER_WEEK);
+        $this->subject->setEndDate($this->now - self::SECONDS_PER_DAY);
+        $this->subject->setUnregistrationDeadline($this->now + self::SECONDS_PER_WEEK);
 
         self::assertTrue($this->subject->isUnregistrationPossible());
     }
@@ -1910,7 +1912,7 @@ final class LegacyEventTest extends FunctionalTestCase
      */
     public function getEffectiveUnregistrationDeadlineForDeadlineSetAndNoBeginDateReturnsDeadline(): void
     {
-        $deadline = $this->now + Time::SECONDS_PER_WEEK;
+        $deadline = $this->now + self::SECONDS_PER_WEEK;
         $this->subject->setBeginDate(0);
         $this->subject->setUnregistrationDeadline($deadline);
 
@@ -1922,8 +1924,8 @@ final class LegacyEventTest extends FunctionalTestCase
      */
     public function getEffectiveUnregistrationDeadlineForDeadlineSetReturnsDeadline(): void
     {
-        $this->subject->setBeginDate($this->now + Time::SECONDS_PER_WEEK);
-        $deadline = $this->now + Time::SECONDS_PER_DAY;
+        $this->subject->setBeginDate($this->now + self::SECONDS_PER_WEEK);
+        $deadline = $this->now + self::SECONDS_PER_DAY;
         $this->subject->setUnregistrationDeadline($deadline);
 
         self::assertSame($deadline, $this->subject->getEffectiveUnregistrationDeadline());
@@ -1934,7 +1936,7 @@ final class LegacyEventTest extends FunctionalTestCase
      */
     public function getEffectiveUnregistrationDeadlineBeginDateSetAndNoDeadlineReturnsBeginDate(): void
     {
-        $start = $this->now + Time::SECONDS_PER_WEEK;
+        $start = $this->now + self::SECONDS_PER_WEEK;
         $this->subject->setBeginDate($start);
         $this->subject->setUnregistrationDeadline(0);
 
@@ -1975,8 +1977,8 @@ final class LegacyEventTest extends FunctionalTestCase
         $this->subject->setAttendancesMax(1);
         $this->subject->setRegistrationQueue(true);
         $this->subject->setNumberOfAttendances(1);
-        $this->subject->setUnregistrationDeadline($this->now + (6 * Time::SECONDS_PER_DAY));
-        $this->subject->setBeginDate($this->now + Time::SECONDS_PER_WEEK);
+        $this->subject->setUnregistrationDeadline($this->now + (6 * self::SECONDS_PER_DAY));
+        $this->subject->setBeginDate($this->now + self::SECONDS_PER_WEEK);
 
         self::assertTrue($this->subject->isUnregistrationPossible());
     }
@@ -5078,7 +5080,7 @@ final class LegacyEventTest extends FunctionalTestCase
         $this->addSpeakerRelation(['cancelation_period' => 1]);
 
         self::assertSame(
-            $this->now - Time::SECONDS_PER_DAY,
+            $this->now - self::SECONDS_PER_DAY,
             $this->subject->getCancelationDeadline(),
         );
     }
@@ -5093,7 +5095,7 @@ final class LegacyEventTest extends FunctionalTestCase
         $this->addSpeakerRelation(['cancelation_period' => 42]);
 
         self::assertSame(
-            $this->now - (42 * Time::SECONDS_PER_DAY),
+            $this->now - (42 * self::SECONDS_PER_DAY),
             $this->subject->getCancelationDeadline(),
         );
     }
@@ -5317,7 +5319,7 @@ final class LegacyEventTest extends FunctionalTestCase
     public function getEventDataForEventWithDateUsesHyphenAsDateSeparator(): void
     {
         $this->subject->setBeginDate($this->now);
-        $this->subject->setEndDate($this->now + Time::SECONDS_PER_DAY);
+        $this->subject->setEndDate($this->now + self::SECONDS_PER_DAY);
 
         self::assertStringContainsString(
             '-',

--- a/Tests/LegacyFunctional/SchedulerTasks/MailNotifierTest.php
+++ b/Tests/LegacyFunctional/SchedulerTasks/MailNotifierTest.php
@@ -6,7 +6,6 @@ namespace OliverKlee\Seminars\Tests\LegacyFunctional\SchedulerTasks;
 
 use OliverKlee\Oelib\Configuration\ConfigurationRegistry;
 use OliverKlee\Oelib\DataStructures\Collection;
-use OliverKlee\Oelib\Interfaces\Time;
 use OliverKlee\Oelib\Mapper\MapperRegistry;
 use OliverKlee\Oelib\Testing\TestingFramework;
 use OliverKlee\Seminars\Domain\Model\Event\EventInterface;
@@ -34,6 +33,8 @@ final class MailNotifierTest extends FunctionalTestCase
     use BackEndTestsTrait;
     use EmailTrait;
     use MakeInstanceTrait;
+
+    private const SECONDS_PER_DAY = 86400;
 
     protected array $coreExtensionsToLoad = ['typo3/cms-scheduler'];
 
@@ -264,7 +265,7 @@ final class MailNotifierTest extends FunctionalTestCase
     {
         $this->createSeminarWithOrganizer(
             [
-                'begin_date' => $this->now + Time::SECONDS_PER_DAY,
+                'begin_date' => $this->now + self::SECONDS_PER_DAY,
                 'cancelled' => EventInterface::STATUS_CONFIRMED,
             ],
         );
@@ -286,7 +287,7 @@ final class MailNotifierTest extends FunctionalTestCase
 
         $this->createSeminarWithOrganizer(
             [
-                'begin_date' => $this->now + Time::SECONDS_PER_DAY,
+                'begin_date' => $this->now + self::SECONDS_PER_DAY,
                 'cancelled' => EventInterface::STATUS_CONFIRMED,
             ],
         );
@@ -310,7 +311,7 @@ final class MailNotifierTest extends FunctionalTestCase
 
         $this->createSeminarWithOrganizer(
             [
-                'begin_date' => $this->now + Time::SECONDS_PER_DAY,
+                'begin_date' => $this->now + self::SECONDS_PER_DAY,
                 'cancelled' => EventInterface::STATUS_CONFIRMED,
             ],
         );
@@ -333,13 +334,13 @@ final class MailNotifierTest extends FunctionalTestCase
     {
         $this->createSeminarWithOrganizer(
             [
-                'begin_date' => $this->now + Time::SECONDS_PER_DAY,
+                'begin_date' => $this->now + self::SECONDS_PER_DAY,
                 'cancelled' => EventInterface::STATUS_CONFIRMED,
             ],
         );
         $this->createSeminarWithOrganizer(
             [
-                'begin_date' => $this->now + Time::SECONDS_PER_DAY,
+                'begin_date' => $this->now + self::SECONDS_PER_DAY,
                 'cancelled' => EventInterface::STATUS_CONFIRMED,
             ],
         );
@@ -358,7 +359,7 @@ final class MailNotifierTest extends FunctionalTestCase
     {
         $eventUid = $this->createSeminarWithOrganizer(
             [
-                'begin_date' => $this->now + Time::SECONDS_PER_DAY,
+                'begin_date' => $this->now + self::SECONDS_PER_DAY,
                 'cancelled' => EventInterface::STATUS_CONFIRMED,
             ],
         );
@@ -383,7 +384,7 @@ final class MailNotifierTest extends FunctionalTestCase
     {
         $this->createSeminarWithOrganizer(
             [
-                'begin_date' => $this->now + Time::SECONDS_PER_DAY,
+                'begin_date' => $this->now + self::SECONDS_PER_DAY,
                 'cancelled' => EventInterface::STATUS_CONFIRMED,
             ],
         );
@@ -407,7 +408,7 @@ final class MailNotifierTest extends FunctionalTestCase
     ): void {
         $this->createSeminarWithOrganizer(
             [
-                'begin_date' => $this->now + Time::SECONDS_PER_DAY,
+                'begin_date' => $this->now + self::SECONDS_PER_DAY,
                 'cancelled' => EventInterface::STATUS_CONFIRMED,
                 'event_takes_place_reminder_sent' => 1,
             ],
@@ -426,7 +427,7 @@ final class MailNotifierTest extends FunctionalTestCase
     {
         $this->createSeminarWithOrganizer(
             [
-                'begin_date' => $this->now - Time::SECONDS_PER_DAY,
+                'begin_date' => $this->now - self::SECONDS_PER_DAY,
                 'cancelled' => EventInterface::STATUS_CONFIRMED,
             ],
         );
@@ -444,7 +445,7 @@ final class MailNotifierTest extends FunctionalTestCase
     ): void {
         $this->createSeminarWithOrganizer(
             [
-                'begin_date' => $this->now + (3 * Time::SECONDS_PER_DAY),
+                'begin_date' => $this->now + (3 * self::SECONDS_PER_DAY),
                 'cancelled' => EventInterface::STATUS_CONFIRMED,
             ],
         );
@@ -462,7 +463,7 @@ final class MailNotifierTest extends FunctionalTestCase
     {
         $this->createSeminarWithOrganizer(
             [
-                'begin_date' => $this->now + Time::SECONDS_PER_DAY,
+                'begin_date' => $this->now + self::SECONDS_PER_DAY,
                 'cancelled' => EventInterface::STATUS_CONFIRMED,
             ],
         );
@@ -481,7 +482,7 @@ final class MailNotifierTest extends FunctionalTestCase
     {
         $this->createSeminarWithOrganizer(
             [
-                'begin_date' => $this->now + Time::SECONDS_PER_DAY,
+                'begin_date' => $this->now + self::SECONDS_PER_DAY,
                 'cancelled' => EventInterface::STATUS_CANCELED,
             ],
         );
@@ -499,7 +500,7 @@ final class MailNotifierTest extends FunctionalTestCase
     {
         $this->createSeminarWithOrganizer(
             [
-                'begin_date' => $this->now + Time::SECONDS_PER_DAY,
+                'begin_date' => $this->now + self::SECONDS_PER_DAY,
                 'cancelled' => EventInterface::STATUS_PLANNED,
             ],
         );
@@ -520,7 +521,7 @@ final class MailNotifierTest extends FunctionalTestCase
         $this->addSpeaker(
             $this->createSeminarWithOrganizer(
                 [
-                    'begin_date' => $this->now + Time::SECONDS_PER_DAY,
+                    'begin_date' => $this->now + self::SECONDS_PER_DAY,
                     'cancelled' => EventInterface::STATUS_PLANNED,
                 ],
             ),
@@ -544,7 +545,7 @@ final class MailNotifierTest extends FunctionalTestCase
         $this->addSpeaker(
             $this->createSeminarWithOrganizer(
                 [
-                    'begin_date' => $this->now + Time::SECONDS_PER_DAY,
+                    'begin_date' => $this->now + self::SECONDS_PER_DAY,
                     'cancelled' => EventInterface::STATUS_PLANNED,
                 ],
             ),
@@ -570,7 +571,7 @@ final class MailNotifierTest extends FunctionalTestCase
         $this->addSpeaker(
             $this->createSeminarWithOrganizer(
                 [
-                    'begin_date' => $this->now + Time::SECONDS_PER_DAY,
+                    'begin_date' => $this->now + self::SECONDS_PER_DAY,
                     'cancelled' => EventInterface::STATUS_PLANNED,
                 ],
             ),
@@ -594,7 +595,7 @@ final class MailNotifierTest extends FunctionalTestCase
         $this->addSpeaker(
             $this->createSeminarWithOrganizer(
                 [
-                    'begin_date' => $this->now + Time::SECONDS_PER_DAY,
+                    'begin_date' => $this->now + self::SECONDS_PER_DAY,
                     'cancelled' => EventInterface::STATUS_PLANNED,
                 ],
             ),
@@ -602,7 +603,7 @@ final class MailNotifierTest extends FunctionalTestCase
         $this->addSpeaker(
             $this->createSeminarWithOrganizer(
                 [
-                    'begin_date' => $this->now + Time::SECONDS_PER_DAY,
+                    'begin_date' => $this->now + self::SECONDS_PER_DAY,
                     'cancelled' => EventInterface::STATUS_PLANNED,
                 ],
             ),
@@ -622,7 +623,7 @@ final class MailNotifierTest extends FunctionalTestCase
     ): void {
         $eventUid = $this->createSeminarWithOrganizer(
             [
-                'begin_date' => $this->now + Time::SECONDS_PER_DAY,
+                'begin_date' => $this->now + self::SECONDS_PER_DAY,
                 'cancelled' => EventInterface::STATUS_PLANNED,
             ],
         );
@@ -657,7 +658,7 @@ final class MailNotifierTest extends FunctionalTestCase
         $this->addSpeaker(
             $this->createSeminarWithOrganizer(
                 [
-                    'begin_date' => $this->now + Time::SECONDS_PER_DAY,
+                    'begin_date' => $this->now + self::SECONDS_PER_DAY,
                     'cancelled' => EventInterface::STATUS_PLANNED,
                 ],
             ),
@@ -683,7 +684,7 @@ final class MailNotifierTest extends FunctionalTestCase
         $this->addSpeaker(
             $this->createSeminarWithOrganizer(
                 [
-                    'begin_date' => $this->now + Time::SECONDS_PER_DAY,
+                    'begin_date' => $this->now + self::SECONDS_PER_DAY,
                     'cancelled' => EventInterface::STATUS_PLANNED,
                     'cancelation_deadline_reminder_sent' => 1,
                 ],
@@ -704,7 +705,7 @@ final class MailNotifierTest extends FunctionalTestCase
         $this->addSpeaker(
             $this->createSeminarWithOrganizer(
                 [
-                    'begin_date' => $this->now - Time::SECONDS_PER_DAY,
+                    'begin_date' => $this->now - self::SECONDS_PER_DAY,
                     'cancelled' => EventInterface::STATUS_PLANNED,
                 ],
             ),
@@ -724,7 +725,7 @@ final class MailNotifierTest extends FunctionalTestCase
         $this->addSpeaker(
             $this->createSeminarWithOrganizer(
                 [
-                    'begin_date' => $this->now + (3 * Time::SECONDS_PER_DAY),
+                    'begin_date' => $this->now + (3 * self::SECONDS_PER_DAY),
                     'cancelled' => EventInterface::STATUS_PLANNED,
                 ],
             ),
@@ -744,7 +745,7 @@ final class MailNotifierTest extends FunctionalTestCase
         $this->addSpeaker(
             $this->createSeminarWithOrganizer(
                 [
-                    'begin_date' => $this->now + Time::SECONDS_PER_DAY,
+                    'begin_date' => $this->now + self::SECONDS_PER_DAY,
                     'cancelled' => EventInterface::STATUS_PLANNED,
                 ],
             ),
@@ -765,7 +766,7 @@ final class MailNotifierTest extends FunctionalTestCase
         $this->addSpeaker(
             $this->createSeminarWithOrganizer(
                 [
-                    'begin_date' => $this->now + Time::SECONDS_PER_DAY,
+                    'begin_date' => $this->now + self::SECONDS_PER_DAY,
                     'cancelled' => EventInterface::STATUS_CANCELED,
                 ],
             ),
@@ -785,7 +786,7 @@ final class MailNotifierTest extends FunctionalTestCase
         $this->addSpeaker(
             $this->createSeminarWithOrganizer(
                 [
-                    'begin_date' => $this->now + Time::SECONDS_PER_DAY,
+                    'begin_date' => $this->now + self::SECONDS_PER_DAY,
                     'cancelled' => EventInterface::STATUS_CONFIRMED,
                 ],
             ),
@@ -810,7 +811,7 @@ final class MailNotifierTest extends FunctionalTestCase
     {
         $this->createSeminarWithOrganizer(
             [
-                'begin_date' => $this->now + Time::SECONDS_PER_DAY,
+                'begin_date' => $this->now + self::SECONDS_PER_DAY,
                 'cancelled' => EventInterface::STATUS_CONFIRMED,
             ],
         );
@@ -830,7 +831,7 @@ final class MailNotifierTest extends FunctionalTestCase
     {
         $this->createSeminarWithOrganizer(
             [
-                'begin_date' => $this->now + Time::SECONDS_PER_DAY,
+                'begin_date' => $this->now + self::SECONDS_PER_DAY,
                 'cancelled' => EventInterface::STATUS_CONFIRMED,
             ],
         );
@@ -855,7 +856,7 @@ final class MailNotifierTest extends FunctionalTestCase
     ): void {
         $eventUid = $this->createSeminarWithOrganizer(
             [
-                'begin_date' => $this->now + Time::SECONDS_PER_DAY,
+                'begin_date' => $this->now + self::SECONDS_PER_DAY,
                 'cancelled' => EventInterface::STATUS_CONFIRMED,
             ],
         );
@@ -887,7 +888,7 @@ final class MailNotifierTest extends FunctionalTestCase
     {
         $eventUid = $this->createSeminarWithOrganizer(
             [
-                'begin_date' => $this->now + Time::SECONDS_PER_DAY,
+                'begin_date' => $this->now + self::SECONDS_PER_DAY,
                 'cancelled' => EventInterface::STATUS_CONFIRMED,
             ],
         );
@@ -917,7 +918,7 @@ final class MailNotifierTest extends FunctionalTestCase
     {
         $this->createSeminarWithOrganizer(
             [
-                'begin_date' => $this->now + Time::SECONDS_PER_DAY,
+                'begin_date' => $this->now + self::SECONDS_PER_DAY,
                 'cancelled' => EventInterface::STATUS_CONFIRMED,
             ],
         );
@@ -940,7 +941,7 @@ final class MailNotifierTest extends FunctionalTestCase
     ): void {
         $eventUid = $this->createSeminarWithOrganizer(
             [
-                'begin_date' => $this->now + Time::SECONDS_PER_DAY,
+                'begin_date' => $this->now + self::SECONDS_PER_DAY,
                 'cancelled' => EventInterface::STATUS_CONFIRMED,
             ],
         );
@@ -974,7 +975,7 @@ final class MailNotifierTest extends FunctionalTestCase
 
         $this->createSeminarWithOrganizer(
             [
-                'begin_date' => $this->now + Time::SECONDS_PER_DAY,
+                'begin_date' => $this->now + self::SECONDS_PER_DAY,
                 'cancelled' => EventInterface::STATUS_CONFIRMED,
             ],
         );
@@ -999,7 +1000,7 @@ final class MailNotifierTest extends FunctionalTestCase
 
         $eventUid = $this->createSeminarWithOrganizer(
             [
-                'begin_date' => $this->now + Time::SECONDS_PER_DAY,
+                'begin_date' => $this->now + self::SECONDS_PER_DAY,
                 'cancelled' => EventInterface::STATUS_CONFIRMED,
             ],
         );
@@ -1032,7 +1033,7 @@ final class MailNotifierTest extends FunctionalTestCase
         $this->configuration->setAsBoolean('addRegistrationCsvToOrganizerReminderMail', false);
         $eventUid = $this->createSeminarWithOrganizer(
             [
-                'begin_date' => $this->now + Time::SECONDS_PER_DAY,
+                'begin_date' => $this->now + self::SECONDS_PER_DAY,
                 'cancelled' => EventInterface::STATUS_CONFIRMED,
             ],
         );
@@ -1064,7 +1065,7 @@ final class MailNotifierTest extends FunctionalTestCase
         $this->configuration->setAsBoolean('addRegistrationCsvToOrganizerReminderMail', true);
         $eventUid = $this->createSeminarWithOrganizer(
             [
-                'begin_date' => $this->now + Time::SECONDS_PER_DAY,
+                'begin_date' => $this->now + self::SECONDS_PER_DAY,
                 'cancelled' => EventInterface::STATUS_CONFIRMED,
             ],
         );
@@ -1098,7 +1099,7 @@ final class MailNotifierTest extends FunctionalTestCase
 
         $eventUid = $this->createSeminarWithOrganizer(
             [
-                'begin_date' => $this->now + Time::SECONDS_PER_DAY,
+                'begin_date' => $this->now + self::SECONDS_PER_DAY,
                 'cancelled' => EventInterface::STATUS_CONFIRMED,
             ],
         );
@@ -1132,7 +1133,7 @@ final class MailNotifierTest extends FunctionalTestCase
 
         $eventUid = $this->createSeminarWithOrganizer(
             [
-                'begin_date' => $this->now + Time::SECONDS_PER_DAY,
+                'begin_date' => $this->now + self::SECONDS_PER_DAY,
                 'cancelled' => EventInterface::STATUS_CONFIRMED,
             ],
         );
@@ -1175,7 +1176,7 @@ final class MailNotifierTest extends FunctionalTestCase
     {
         $this->createSeminarWithOrganizer(
             [
-                'begin_date' => $this->now + Time::SECONDS_PER_DAY,
+                'begin_date' => $this->now + self::SECONDS_PER_DAY,
                 'cancelled' => EventInterface::STATUS_CONFIRMED,
                 'title' => 'test event',
             ],
@@ -1199,7 +1200,7 @@ final class MailNotifierTest extends FunctionalTestCase
     {
         $this->createSeminarWithOrganizer(
             [
-                'begin_date' => $this->now + Time::SECONDS_PER_DAY,
+                'begin_date' => $this->now + self::SECONDS_PER_DAY,
                 'cancelled' => EventInterface::STATUS_CONFIRMED,
             ],
         );
@@ -1224,7 +1225,7 @@ final class MailNotifierTest extends FunctionalTestCase
     {
         $this->createSeminarWithOrganizer(
             [
-                'begin_date' => $this->now + Time::SECONDS_PER_DAY,
+                'begin_date' => $this->now + self::SECONDS_PER_DAY,
                 'cancelled' => EventInterface::STATUS_CONFIRMED,
             ],
         );
@@ -1244,7 +1245,7 @@ final class MailNotifierTest extends FunctionalTestCase
     {
         $this->createSeminarWithOrganizer(
             [
-                'begin_date' => $this->now + Time::SECONDS_PER_DAY,
+                'begin_date' => $this->now + self::SECONDS_PER_DAY,
                 'cancelled' => EventInterface::STATUS_CONFIRMED,
                 'title' => 'test event',
             ],
@@ -1265,7 +1266,7 @@ final class MailNotifierTest extends FunctionalTestCase
     {
         $uid = $this->createSeminarWithOrganizer(
             [
-                'begin_date' => $this->now + Time::SECONDS_PER_DAY,
+                'begin_date' => $this->now + self::SECONDS_PER_DAY,
                 'cancelled' => EventInterface::STATUS_CONFIRMED,
             ],
         );
@@ -1285,7 +1286,7 @@ final class MailNotifierTest extends FunctionalTestCase
     {
         $this->createSeminarWithOrganizer(
             [
-                'begin_date' => $this->now + Time::SECONDS_PER_DAY,
+                'begin_date' => $this->now + self::SECONDS_PER_DAY,
                 'cancelled' => EventInterface::STATUS_CONFIRMED,
             ],
         );
@@ -1306,7 +1307,7 @@ final class MailNotifierTest extends FunctionalTestCase
         $this->addSpeaker(
             $this->createSeminarWithOrganizer(
                 [
-                    'begin_date' => $this->now + Time::SECONDS_PER_DAY,
+                    'begin_date' => $this->now + self::SECONDS_PER_DAY,
                     'cancelled' => EventInterface::STATUS_PLANNED,
                 ],
             ),
@@ -1318,7 +1319,7 @@ final class MailNotifierTest extends FunctionalTestCase
         $this->subject->sendCancellationDeadlineReminders();
 
         self::assertStringContainsString(
-            \date('Y-m-d', $this->now + Time::SECONDS_PER_DAY),
+            \date('Y-m-d', $this->now + self::SECONDS_PER_DAY),
             $this->email->getTextBody(),
         );
     }
@@ -1330,7 +1331,7 @@ final class MailNotifierTest extends FunctionalTestCase
     {
         $this->createSeminarWithOrganizer(
             [
-                'begin_date' => $this->now + Time::SECONDS_PER_DAY,
+                'begin_date' => $this->now + self::SECONDS_PER_DAY,
                 'cancelled' => EventInterface::STATUS_CONFIRMED,
             ],
         );
@@ -1350,7 +1351,7 @@ final class MailNotifierTest extends FunctionalTestCase
     {
         $eventUid = $this->createSeminarWithOrganizer(
             [
-                'begin_date' => $this->now + Time::SECONDS_PER_DAY,
+                'begin_date' => $this->now + self::SECONDS_PER_DAY,
                 'cancelled' => EventInterface::STATUS_CONFIRMED,
             ],
         );

--- a/Tests/LegacyFunctional/Service/RegistrationManagerTest.php
+++ b/Tests/LegacyFunctional/Service/RegistrationManagerTest.php
@@ -6,7 +6,6 @@ namespace OliverKlee\Seminars\Tests\LegacyFunctional\Service;
 
 use OliverKlee\Oelib\Configuration\ConfigurationRegistry;
 use OliverKlee\Oelib\Configuration\DummyConfiguration;
-use OliverKlee\Oelib\Interfaces\Time;
 use OliverKlee\Oelib\Mapper\MapperRegistry;
 use OliverKlee\Oelib\Testing\TestingFramework;
 use OliverKlee\Seminars\Domain\Model\Event\EventInterface;
@@ -38,6 +37,8 @@ final class RegistrationManagerTest extends FunctionalTestCase
     use LanguageHelper;
     use EmailTrait;
     use MakeInstanceTrait;
+
+    private const SECONDS_PER_DAY = 86400;
 
     protected array $testExtensionsToLoad = [
         'oliverklee/feuserextrafields',
@@ -943,7 +944,7 @@ final class RegistrationManagerTest extends FunctionalTestCase
             'tx_seminars_seminars',
             $this->seminarUid,
             [
-                'deadline_unregistration' => $this->now + Time::SECONDS_PER_DAY,
+                'deadline_unregistration' => $this->now + self::SECONDS_PER_DAY,
             ],
         );
 
@@ -968,7 +969,7 @@ final class RegistrationManagerTest extends FunctionalTestCase
         $this->testingFramework->changeRecord(
             'tx_seminars_seminars',
             $this->seminarUid,
-            ['deadline_unregistration' => $this->now - Time::SECONDS_PER_DAY],
+            ['deadline_unregistration' => $this->now - self::SECONDS_PER_DAY],
         );
 
         $subject->notifyAttendee($registration);
@@ -994,7 +995,7 @@ final class RegistrationManagerTest extends FunctionalTestCase
         $this->testingFramework->changeRecord(
             'tx_seminars_seminars',
             $this->seminarUid,
-            ['deadline_unregistration' => $this->now + Time::SECONDS_PER_DAY],
+            ['deadline_unregistration' => $this->now + self::SECONDS_PER_DAY],
         );
 
         $subject->notifyAttendee($registration);
@@ -1020,7 +1021,7 @@ final class RegistrationManagerTest extends FunctionalTestCase
             'tx_seminars_seminars',
             $this->seminarUid,
             [
-                'deadline_unregistration' => $this->now + Time::SECONDS_PER_DAY,
+                'deadline_unregistration' => $this->now + self::SECONDS_PER_DAY,
                 'queue_size' => 1,
             ],
         );
@@ -1056,7 +1057,7 @@ final class RegistrationManagerTest extends FunctionalTestCase
             'tx_seminars_seminars',
             $this->seminarUid,
             [
-                'deadline_unregistration' => $this->now + Time::SECONDS_PER_DAY,
+                'deadline_unregistration' => $this->now + self::SECONDS_PER_DAY,
                 'queue_size' => 1,
             ],
         );


### PR DESCRIPTION
Fixes #4902

