### PR TITLE
[TASK] Rename `Event.downloadsPossibleByDate`

### DIFF
--- a/Classes/Domain/Model/Event/EventDateInterface.php
+++ b/Classes/Domain/Model/Event/EventDateInterface.php
@@ -41,7 +41,7 @@ interface EventDateInterface extends EventInterface
 
     public function getBillingStart(): ?\DateTime;
 
-    public function isDownloadsPossibleByDate(): bool;
+    public function isDownloadPossibleByDate(): bool;
 
     public function isRegistrationRequired(): bool;
 

--- a/Classes/Domain/Model/Event/EventDateTrait.php
+++ b/Classes/Domain/Model/Event/EventDateTrait.php
@@ -257,7 +257,7 @@ trait EventDateTrait
         $this->downloadStartDate = $startDate;
     }
 
-    public function isDownloadsPossibleByDate(): bool
+    public function isDownloadPossibleByDate(): bool
     {
         $downloadStartDate = $this->getDownloadStartDate();
         if (!($downloadStartDate instanceof \DateTimeInterface)) {

--- a/Resources/Private/Partials/MyRegistrations/Show.html
+++ b/Resources/Private/Partials/MyRegistrations/Show.html
@@ -74,7 +74,7 @@
 
     <oelib:isFieldEnabled fieldName="downloads">
         <f:if
-            condition="{event.downloadsForAttendees} && {event.downloadsPossibleByDate} && {registration.regularRegistration}">
+            condition="{event.downloadsForAttendees} && {event.downloadPossibleByDate} && {registration.regularRegistration}">
             <h3>
                 <f:translate key="plugin.myRegistrations.show.heading.downloads"/>
             </h3>

--- a/Tests/Unit/Domain/Model/Event/EventDateTest.php
+++ b/Tests/Unit/Domain/Model/Event/EventDateTest.php
@@ -1674,33 +1674,33 @@ final class EventDateTest extends UnitTestCase
     /**
      * @test
      */
-    public function isDownloadsPossibleByDateForNoDownloadStartDateReturnsTrue(): void
+    public function isDownloadPossibleByDateForNoDownloadStartDateReturnsTrue(): void
     {
-        self::assertTrue($this->subject->isDownloadsPossibleByDate());
+        self::assertTrue($this->subject->isDownloadPossibleByDate());
     }
 
     /**
      * @test
      */
-    public function isDownloadsPossibleByDateForDownloadStartInPastReturnsTrue(): void
+    public function isDownloadPossibleByDateForDownloadStartInPastReturnsTrue(): void
     {
         $context = GeneralUtility::makeInstance(Context::class);
         $context->setAspect('date', new DateTimeAspect(new \DateTimeImmutable('now')));
         $this->subject->setDownloadStartDate(new \DateTime('now -1 day'));
 
-        self::assertTrue($this->subject->isDownloadsPossibleByDate());
+        self::assertTrue($this->subject->isDownloadPossibleByDate());
     }
 
     /**
      * @test
      */
-    public function isDownloadsPossibleByDateForDownloadStartInFutureReturnsFalse(): void
+    public function isDownloadPossibleByDateForDownloadStartInFutureReturnsFalse(): void
     {
         $context = GeneralUtility::makeInstance(Context::class);
         $context->setAspect('date', new DateTimeAspect(new \DateTimeImmutable('now')));
         $this->subject->setDownloadStartDate(new \DateTime('now +1 day'));
 
-        self::assertFalse($this->subject->isDownloadsPossibleByDate());
+        self::assertFalse($this->subject->isDownloadPossibleByDate());
     }
 
     /**

--- a/Tests/Unit/Domain/Model/Event/SingleEventTest.php
+++ b/Tests/Unit/Domain/Model/Event/SingleEventTest.php
@@ -1796,33 +1796,33 @@ final class SingleEventTest extends UnitTestCase
     /**
      * @test
      */
-    public function isDownloadsPossibleByDateForNoDownloadStartDateReturnsTrue(): void
+    public function isDownloadPossibleByDateForNoDownloadStartDateReturnsTrue(): void
     {
-        self::assertTrue($this->subject->isDownloadsPossibleByDate());
+        self::assertTrue($this->subject->isDownloadPossibleByDate());
     }
 
     /**
      * @test
      */
-    public function isDownloadsPossibleByDateForDownloadStartInPastReturnsTrue(): void
+    public function isDownloadPossibleByDateForDownloadStartInPastReturnsTrue(): void
     {
         $context = GeneralUtility::makeInstance(Context::class);
         $context->setAspect('date', new DateTimeAspect(new \DateTimeImmutable('now')));
         $this->subject->setDownloadStartDate(new \DateTime('now -1 day'));
 
-        self::assertTrue($this->subject->isDownloadsPossibleByDate());
+        self::assertTrue($this->subject->isDownloadPossibleByDate());
     }
 
     /**
      * @test
      */
-    public function isDownloadsPossibleByDateForDownloadStartInFutureReturnsFalse(): void
+    public function isDownloadPossibleByDateForDownloadStartInFutureReturnsFalse(): void
     {
         $context = GeneralUtility::makeInstance(Context::class);
         $context->setAspect('date', new DateTimeAspect(new \DateTimeImmutable('now')));
         $this->subject->setDownloadStartDate(new \DateTime('now +1 day'));
 
-        self::assertFalse($this->subject->isDownloadsPossibleByDate());
+        self::assertFalse($this->subject->isDownloadPossibleByDate());
     }
 
     /**


### PR DESCRIPTION
Using the singular form `.downloadPossibleByDate` sounds better.