### PR TITLE
[BUGFIX] Avoid using the `ConfigurationRegistry` in unit tests

### DIFF
--- a/Tests/Unit/Csv/CsvResponseTest.php
+++ b/Tests/Unit/Csv/CsvResponseTest.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace OliverKlee\Seminars\Tests\Unit\Csv;
 
-use OliverKlee\Oelib\Configuration\ConfigurationRegistry;
-use OliverKlee\Oelib\Configuration\DummyConfiguration;
 use OliverKlee\Seminars\Csv\CsvResponse;
 use Psr\Http\Message\ResponseInterface;
 use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
@@ -15,23 +13,6 @@ use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
  */
 final class CsvResponseTest extends UnitTestCase
 {
-    private DummyConfiguration $configuration;
-
-    protected function setUp(): void
-    {
-        parent::setUp();
-
-        $this->configuration = new DummyConfiguration();
-        ConfigurationRegistry::getInstance()->set('plugin.tx_seminars', $this->configuration);
-    }
-
-    protected function tearDown(): void
-    {
-        ConfigurationRegistry::purgeInstance();
-
-        parent::tearDown();
-    }
-
     /**
      * @test
      */

--- a/Tests/Unit/Model/EventTest.php
+++ b/Tests/Unit/Model/EventTest.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace OliverKlee\Seminars\Tests\Unit\Model;
 
-use OliverKlee\Oelib\Configuration\ConfigurationRegistry;
-use OliverKlee\Oelib\Configuration\DummyConfiguration;
 use OliverKlee\Oelib\DataStructures\Collection;
 use OliverKlee\Seminars\Domain\Model\Event\EventInterface;
 use OliverKlee\Seminars\Model\Category;
@@ -29,8 +27,6 @@ final class EventTest extends UnitTestCase
 
     private Event $subject;
 
-    private DummyConfiguration $configuration;
-
     protected int $now = 1424751343;
 
     protected function setUp(): void
@@ -40,17 +36,7 @@ final class EventTest extends UnitTestCase
         GeneralUtility::makeInstance(Context::class)
             ->setAspect('date', new DateTimeAspect(new \DateTimeImmutable('2018-04-26 12:42:23')));
 
-        $configurationRegistry = ConfigurationRegistry::getInstance();
-        $this->configuration = new DummyConfiguration();
-        $configurationRegistry->set('plugin.tx_seminars', $this->configuration);
-
         $this->subject = new Event();
-    }
-
-    protected function tearDown(): void
-    {
-        ConfigurationRegistry::purgeInstance();
-        parent::tearDown();
     }
 
     ///////////////////////////////////


### PR DESCRIPTION
Fixes #4992