### PR TITLE
[BUGFIX] Properly clean up after functional tests

### DIFF
--- a/Tests/Functional/Csv/CsvDownloaderTest.php
+++ b/Tests/Functional/Csv/CsvDownloaderTest.php
@@ -38,6 +38,13 @@ final class CsvDownloaderTest extends FunctionalTestCase
         $this->subject = new CsvDownloader();
     }
 
+    protected function tearDown(): void
+    {
+        ConfigurationRegistry::purgeInstance();
+
+        parent::tearDown();
+    }
+
     private function setUpExtensionConfiguration(): void
     {
         $configurationRegistry = ConfigurationRegistry::getInstance();

--- a/Tests/Functional/Csv/DownloadRegistrationListViewTest.php
+++ b/Tests/Functional/Csv/DownloadRegistrationListViewTest.php
@@ -37,6 +37,13 @@ final class DownloadRegistrationListViewTest extends FunctionalTestCase
         $this->subject = new DownloadRegistrationListView();
     }
 
+    protected function tearDown(): void
+    {
+        ConfigurationRegistry::purgeInstance();
+
+        parent::tearDown();
+    }
+
     /**
      * @test
      */

--- a/Tests/Functional/Domain/Repository/Event/EventRepositoryTest.php
+++ b/Tests/Functional/Domain/Repository/Event/EventRepositoryTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace OliverKlee\Seminars\Tests\Functional\Domain\Repository\Event;
 
+use OliverKlee\Oelib\Configuration\ConfigurationRegistry;
 use OliverKlee\Seminars\Domain\Model\AccommodationOption;
 use OliverKlee\Seminars\Domain\Model\Category;
 use OliverKlee\Seminars\Domain\Model\Event\EventDate;
@@ -57,6 +58,13 @@ final class EventRepositoryTest extends FunctionalTestCase
         parent::setUp();
 
         $this->subject = $this->get(EventRepository::class);
+    }
+
+    protected function tearDown(): void
+    {
+        ConfigurationRegistry::purgeInstance();
+
+        parent::tearDown();
     }
 
     private function initializeBackEndUser(): void

--- a/Tests/Functional/Domain/Repository/Registration/RegistrationRepositoryTest.php
+++ b/Tests/Functional/Domain/Repository/Registration/RegistrationRepositoryTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace OliverKlee\Seminars\Tests\Functional\Domain\Repository\Registration;
 
+use OliverKlee\Oelib\Configuration\ConfigurationRegistry;
 use OliverKlee\Seminars\Domain\Model\AccommodationOption;
 use OliverKlee\Seminars\Domain\Model\Event\EventDate;
 use OliverKlee\Seminars\Domain\Model\Event\SingleEvent;
@@ -54,6 +55,13 @@ final class RegistrationRepositoryTest extends FunctionalTestCase
         $this->subject = $this->get(RegistrationRepository::class);
         $this->eventRepository = $this->get(EventRepository::class);
         $this->persistenceManager = $this->get(PersistenceManager::class);
+    }
+
+    protected function tearDown(): void
+    {
+        ConfigurationRegistry::purgeInstance();
+
+        parent::tearDown();
     }
 
     private function initializeBackEndUser(): void

--- a/Tests/Functional/Hooks/DataHandlerHookTest.php
+++ b/Tests/Functional/Hooks/DataHandlerHookTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace OliverKlee\Seminars\Tests\Functional\Hooks;
 
+use OliverKlee\Oelib\Configuration\ConfigurationRegistry;
 use OliverKlee\Seminars\Hooks\DataHandlerHook;
 use OliverKlee\Seminars\Hooks\Interfaces\DataSanitization;
 use OliverKlee\Seminars\Tests\Support\BackEndTestsTrait;
@@ -38,6 +39,13 @@ final class DataHandlerHookTest extends FunctionalTestCase
         $this->dataHandler = new DataHandler();
 
         $this->subject = $this->get(DataHandlerHook::class);
+    }
+
+    protected function tearDown(): void
+    {
+        ConfigurationRegistry::purgeInstance();
+
+        parent::tearDown();
     }
 
     private function initializeBackEndUser(): void

--- a/Tests/Functional/SchedulerTasks/MailNotifierTest.php
+++ b/Tests/Functional/SchedulerTasks/MailNotifierTest.php
@@ -6,6 +6,7 @@ namespace OliverKlee\Seminars\Tests\Functional\SchedulerTasks;
 
 use OliverKlee\Oelib\Configuration\ConfigurationRegistry;
 use OliverKlee\Oelib\Configuration\DummyConfiguration;
+use OliverKlee\Oelib\Configuration\PageFinder;
 use OliverKlee\Oelib\Mapper\MapperRegistry;
 use OliverKlee\Seminars\SchedulerTasks\MailNotifier;
 use OliverKlee\Seminars\SchedulerTasks\RegistrationDigest;
@@ -56,6 +57,7 @@ final class MailNotifierTest extends FunctionalTestCase
     {
         ConfigurationRegistry::purgeInstance();
         MapperRegistry::purgeInstance();
+        PageFinder::purgeInstance();
         GeneralUtility::resetSingletonInstances([]);
 
         parent::tearDown();

--- a/Tests/Functional/Service/EmailServiceTest.php
+++ b/Tests/Functional/Service/EmailServiceTest.php
@@ -82,6 +82,13 @@ final class EmailServiceTest extends FunctionalTestCase
         $this->subject = new EmailService();
     }
 
+    protected function tearDown(): void
+    {
+        ConfigurationRegistry::purgeInstance();
+
+        parent::tearDown();
+    }
+
     /**
      * @test
      */

--- a/Tests/Functional/Service/RegistrationManagerTest.php
+++ b/Tests/Functional/Service/RegistrationManagerTest.php
@@ -110,6 +110,7 @@ final class RegistrationManagerTest extends FunctionalTestCase
         $this->testingFramework->cleanUpWithoutDatabase();
 
         ConfigurationRegistry::purgeInstance();
+        MapperRegistry::purgeInstance();
         // Purge the FIFO buffer of mocks
         GeneralUtility::makeInstance(MailMessage::class);
         GeneralUtility::makeInstance(MailMessage::class);

--- a/Tests/Functional/ViewHelpers/DateRangeViewHelperTest.php
+++ b/Tests/Functional/ViewHelpers/DateRangeViewHelperTest.php
@@ -46,6 +46,13 @@ final class DateRangeViewHelperTest extends FunctionalTestCase
         $this->subject = new DateRangeViewHelper();
     }
 
+    protected function tearDown(): void
+    {
+        ConfigurationRegistry::purgeInstance();
+
+        parent::tearDown();
+    }
+
     /**
      * @test
      */

--- a/Tests/LegacyFunctional/BagBuilder/RegistrationBagBuilderTest.php
+++ b/Tests/LegacyFunctional/BagBuilder/RegistrationBagBuilderTest.php
@@ -47,6 +47,7 @@ final class RegistrationBagBuilderTest extends FunctionalTestCase
 
     protected function tearDown(): void
     {
+        MapperRegistry::purgeInstance();
         $this->testingFramework->cleanUpWithoutDatabase();
 
         parent::tearDown();

--- a/Tests/LegacyFunctional/Csv/AbstractRegistrationListViewTest.php
+++ b/Tests/LegacyFunctional/Csv/AbstractRegistrationListViewTest.php
@@ -6,6 +6,7 @@ namespace OliverKlee\Seminars\Tests\LegacyUnit\Csv;
 
 use OliverKlee\Oelib\Configuration\ConfigurationRegistry;
 use OliverKlee\Oelib\Configuration\DummyConfiguration;
+use OliverKlee\Oelib\Mapper\MapperRegistry;
 use OliverKlee\Oelib\Testing\TestingFramework;
 use OliverKlee\Seminars\Csv\AbstractRegistrationListView;
 use OliverKlee\Seminars\Hooks\Interfaces\RegistrationListCsv;
@@ -118,7 +119,8 @@ final class AbstractRegistrationListViewTest extends FunctionalTestCase
     {
         $this->purgeMockedInstances();
         $GLOBALS['TYPO3_CONF_VARS']['EXTCONF'] = $this->extConfBackup;
-
+        ConfigurationRegistry::purgeInstance();
+        MapperRegistry::purgeInstance();
         $this->testingFramework->cleanUpWithoutDatabase();
 
         parent::tearDown();

--- a/Tests/LegacyFunctional/Csv/CsvDownloaderTest.php
+++ b/Tests/LegacyFunctional/Csv/CsvDownloaderTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace OliverKlee\Seminars\Tests\LegacyUnit\Csv;
 
+use OliverKlee\Oelib\Configuration\ConfigurationRegistry;
 use OliverKlee\Oelib\Testing\TestingFramework;
 use OliverKlee\Seminars\Csv\CsvDownloader;
 use OliverKlee\Seminars\Tests\Support\BackEndTestsTrait;
@@ -65,6 +66,7 @@ final class CsvDownloaderTest extends FunctionalTestCase
 
     protected function tearDown(): void
     {
+        ConfigurationRegistry::purgeInstance();
         $this->testingFramework->cleanUpWithoutDatabase();
         $this->restoreOriginalEnvironment();
 

--- a/Tests/LegacyFunctional/Csv/EmailRegistrationListViewTest.php
+++ b/Tests/LegacyFunctional/Csv/EmailRegistrationListViewTest.php
@@ -73,6 +73,7 @@ final class EmailRegistrationListViewTest extends FunctionalTestCase
 
     protected function tearDown(): void
     {
+        ConfigurationRegistry::purgeInstance();
         $this->testingFramework->cleanUpWithoutDatabase();
 
         parent::tearDown();

--- a/Tests/LegacyFunctional/Email/SalutationTest.php
+++ b/Tests/LegacyFunctional/Email/SalutationTest.php
@@ -54,6 +54,7 @@ final class SalutationTest extends FunctionalTestCase
         $this->restoreOriginalEnvironment();
 
         ConfigurationRegistry::purgeInstance();
+        MapperRegistry::purgeInstance();
         $this->testingFramework->cleanUpWithoutDatabase();
 
         parent::tearDown();

--- a/Tests/LegacyFunctional/FrontEnd/DefaultControllerTest.php
+++ b/Tests/LegacyFunctional/FrontEnd/DefaultControllerTest.php
@@ -165,7 +165,7 @@ final class DefaultControllerTest extends FunctionalTestCase
     protected function tearDown(): void
     {
         $this->testingFramework->cleanUpWithoutDatabase();
-
+        MapperRegistry::purgeInstance();
         ConfigurationRegistry::purgeInstance();
 
         $GLOBALS['TYPO3_CONF_VARS']['EXTCONF'] = $this->extConfBackup;

--- a/Tests/LegacyFunctional/FrontEnd/RequirementsListTest.php
+++ b/Tests/LegacyFunctional/FrontEnd/RequirementsListTest.php
@@ -70,7 +70,6 @@ final class RequirementsListTest extends FunctionalTestCase
     protected function tearDown(): void
     {
         $this->testingFramework->cleanUpWithoutDatabase();
-
         ConfigurationRegistry::purgeInstance();
 
         parent::tearDown();

--- a/Tests/LegacyFunctional/Mapper/EventDateMapperTest.php
+++ b/Tests/LegacyFunctional/Mapper/EventDateMapperTest.php
@@ -44,6 +44,7 @@ final class EventDateMapperTest extends FunctionalTestCase
 
     protected function tearDown(): void
     {
+        MapperRegistry::purgeInstance();
         $this->testingFramework->cleanUpWithoutDatabase();
 
         parent::tearDown();

--- a/Tests/LegacyFunctional/Mapper/EventMapperTest.php
+++ b/Tests/LegacyFunctional/Mapper/EventMapperTest.php
@@ -41,6 +41,7 @@ final class EventMapperTest extends FunctionalTestCase
 
     protected function tearDown(): void
     {
+        MapperRegistry::purgeInstance();
         $this->testingFramework->cleanUpWithoutDatabase();
 
         parent::tearDown();

--- a/Tests/LegacyFunctional/Mapper/EventTopicMapperTest.php
+++ b/Tests/LegacyFunctional/Mapper/EventTopicMapperTest.php
@@ -43,6 +43,7 @@ final class EventTopicMapperTest extends FunctionalTestCase
 
     protected function tearDown(): void
     {
+        MapperRegistry::purgeInstance();
         $this->testingFramework->cleanUpWithoutDatabase();
 
         parent::tearDown();

--- a/Tests/LegacyFunctional/Mapper/RegistrationMapperTest.php
+++ b/Tests/LegacyFunctional/Mapper/RegistrationMapperTest.php
@@ -39,6 +39,7 @@ final class RegistrationMapperTest extends FunctionalTestCase
 
     protected function tearDown(): void
     {
+        MapperRegistry::purgeInstance();
         $this->testingFramework->cleanUpWithoutDatabase();
 
         parent::tearDown();

--- a/Tests/LegacyFunctional/Mapper/SingleEventMapperTest.php
+++ b/Tests/LegacyFunctional/Mapper/SingleEventMapperTest.php
@@ -43,6 +43,7 @@ final class SingleEventMapperTest extends FunctionalTestCase
 
     protected function tearDown(): void
     {
+        MapperRegistry::purgeInstance();
         $this->testingFramework->cleanUpWithoutDatabase();
 
         parent::tearDown();

--- a/Tests/LegacyFunctional/Model/EventDateTest.php
+++ b/Tests/LegacyFunctional/Model/EventDateTest.php
@@ -35,6 +35,13 @@ final class EventDateTest extends FunctionalTestCase
         $this->subject = new Event();
     }
 
+    protected function tearDown(): void
+    {
+        MapperRegistry::purgeInstance();
+
+        parent::tearDown();
+    }
+
     // Tests concerning the title.
 
     /**

--- a/Tests/LegacyFunctional/Model/EventTest.php
+++ b/Tests/LegacyFunctional/Model/EventTest.php
@@ -46,6 +46,7 @@ final class EventTest extends FunctionalTestCase
 
     protected function tearDown(): void
     {
+        MapperRegistry::purgeInstance();
         ConfigurationRegistry::purgeInstance();
 
         parent::tearDown();

--- a/Tests/LegacyFunctional/Model/RegistrationTest.php
+++ b/Tests/LegacyFunctional/Model/RegistrationTest.php
@@ -45,6 +45,7 @@ final class RegistrationTest extends FunctionalTestCase
 
     protected function tearDown(): void
     {
+        MapperRegistry::purgeInstance();
         $this->testingFramework->cleanUpWithoutDatabase();
 
         parent::tearDown();

--- a/Tests/LegacyFunctional/OldModel/LegacyEventTest.php
+++ b/Tests/LegacyFunctional/OldModel/LegacyEventTest.php
@@ -117,7 +117,6 @@ final class LegacyEventTest extends FunctionalTestCase
     protected function tearDown(): void
     {
         $this->testingFramework->cleanUpWithoutDatabase();
-
         ConfigurationRegistry::purgeInstance();
 
         parent::tearDown();

--- a/Tests/LegacyFunctional/OldModel/LegacyRegistrationTest.php
+++ b/Tests/LegacyFunctional/OldModel/LegacyRegistrationTest.php
@@ -126,6 +126,8 @@ final class LegacyRegistrationTest extends FunctionalTestCase
 
     protected function tearDown(): void
     {
+        MapperRegistry::purgeInstance();
+        ConfigurationRegistry::purgeInstance();
         $this->testingFramework->cleanUpWithoutDatabase();
 
         parent::tearDown();

--- a/Tests/LegacyFunctional/OldModel/LegacyTimeSlotTest.php
+++ b/Tests/LegacyFunctional/OldModel/LegacyTimeSlotTest.php
@@ -56,6 +56,7 @@ final class LegacyTimeSlotTest extends FunctionalTestCase
 
     protected function tearDown(): void
     {
+        ConfigurationRegistry::purgeInstance();
         $this->testingFramework->cleanUpWithoutDatabase();
 
         parent::tearDown();

--- a/Tests/LegacyFunctional/SchedulerTasks/MailNotifierTest.php
+++ b/Tests/LegacyFunctional/SchedulerTasks/MailNotifierTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace OliverKlee\Seminars\Tests\LegacyFunctional\SchedulerTasks;
 
 use OliverKlee\Oelib\Configuration\ConfigurationRegistry;
+use OliverKlee\Oelib\Configuration\PageFinder;
 use OliverKlee\Oelib\DataStructures\Collection;
 use OliverKlee\Oelib\Mapper\MapperRegistry;
 use OliverKlee\Oelib\Testing\TestingFramework;
@@ -106,6 +107,7 @@ final class MailNotifierTest extends FunctionalTestCase
 
         MapperRegistry::purgeInstance();
         ConfigurationRegistry::purgeInstance();
+        PageFinder::purgeInstance();
         GeneralUtility::resetSingletonInstances([]);
 
         parent::tearDown();

--- a/Tests/LegacyFunctional/Service/EmailServiceTest.php
+++ b/Tests/LegacyFunctional/Service/EmailServiceTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace OliverKlee\Seminars\Tests\LegacyFunctional\Service;
 
+use OliverKlee\Oelib\Configuration\ConfigurationRegistry;
 use OliverKlee\Oelib\DataStructures\Collection;
 use OliverKlee\Oelib\Testing\TestingFramework;
 use OliverKlee\Seminars\Model\Event;
@@ -88,7 +89,7 @@ final class EmailServiceTest extends FunctionalTestCase
     protected function tearDown(): void
     {
         $this->restoreOriginalEnvironment();
-
+        ConfigurationRegistry::purgeInstance();
         $this->testingFramework->cleanUpWithoutDatabase();
 
         parent::tearDown();

--- a/Tests/LegacyFunctional/Service/RegistrationManagerTest.php
+++ b/Tests/LegacyFunctional/Service/RegistrationManagerTest.php
@@ -147,6 +147,8 @@ final class RegistrationManagerTest extends FunctionalTestCase
 
     protected function tearDown(): void
     {
+        MapperRegistry::purgeInstance();
+        ConfigurationRegistry::purgeInstance();
         $this->testingFramework->cleanUpWithoutDatabase();
 
         $this->purgeMockedInstances();


### PR DESCRIPTION
Now that the oelib testing framework does not provide its cleanup hook anymore, we'll need to do the cleanup ourselves.