### PR TITLE
[TASK] Only PHP-lint the minimum and maximum PHP version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,15 +41,6 @@ jobs:
             php-version: "7.4"
             composer-dependencies: Max
           - typo3-version: "11.5"
-            php-version: "8.0"
-            composer-dependencies: Max
-          - typo3-version: "11.5"
-            php-version: "8.1"
-            composer-dependencies: Max
-          - typo3-version: "11.5"
-            php-version: "8.2"
-            composer-dependencies: Max
-          - typo3-version: "11.5"
             php-version: "8.3"
             composer-dependencies: Max
   code-quality:


### PR DESCRIPTION
This saves resources and allows for faster CI builds.