### PR TITLE
[TASK] Always use the system email as email sender

### DIFF
--- a/Build/phpstan/phpstan-baseline.neon
+++ b/Build/phpstan/phpstan-baseline.neon
@@ -2812,17 +2812,17 @@ parameters:
 
 		-
 			message: "#^Cannot access offset 'MAIL' on mixed\\.$#"
-			count: 6
+			count: 4
 			path: ../../Tests/LegacyFunctional/Service/EmailServiceTest.php
 
 		-
 			message: "#^Cannot access offset 'defaultMailFromAddr…' on mixed\\.$#"
-			count: 3
+			count: 2
 			path: ../../Tests/LegacyFunctional/Service/EmailServiceTest.php
 
 		-
 			message: "#^Cannot access offset 'defaultMailFromName' on mixed\\.$#"
-			count: 3
+			count: 2
 			path: ../../Tests/LegacyFunctional/Service/EmailServiceTest.php
 
 		-
@@ -2887,7 +2887,7 @@ parameters:
 
 		-
 			message: "#^Cannot access offset 'MAIL' on mixed\\.$#"
-			count: 12
+			count: 10
 			path: ../../Tests/LegacyFunctional/Service/RegistrationManagerTest.php
 
 		-
@@ -2897,12 +2897,12 @@ parameters:
 
 		-
 			message: "#^Cannot access offset 'defaultMailFromAddr…' on mixed\\.$#"
-			count: 6
+			count: 5
 			path: ../../Tests/LegacyFunctional/Service/RegistrationManagerTest.php
 
 		-
 			message: "#^Cannot access offset 'defaultMailFromName' on mixed\\.$#"
-			count: 6
+			count: 5
 			path: ../../Tests/LegacyFunctional/Service/RegistrationManagerTest.php
 
 		-

--- a/Classes/BackEnd/EmailService.php
+++ b/Classes/BackEnd/EmailService.php
@@ -4,9 +4,8 @@ declare(strict_types=1);
 
 namespace OliverKlee\Seminars\BackEnd;
 
-use OliverKlee\Oelib\Email\SystemEmailFromBuilder;
+use OliverKlee\Oelib\Email\SystemEmailBuilder;
 use OliverKlee\Oelib\Exception\NotFoundException;
-use OliverKlee\Oelib\Interfaces\MailRole;
 use OliverKlee\Seminars\Domain\Model\Event\Event;
 use OliverKlee\Seminars\Domain\Model\Event\EventDateInterface;
 use OliverKlee\Seminars\Domain\Model\FrontendUser;
@@ -31,9 +30,12 @@ class EmailService implements SingletonInterface
 {
     private RegistrationRepository $registrationRepository;
 
-    public function __construct(RegistrationRepository $registrationRepository)
+    private SystemEmailBuilder $systemEmailBuilder;
+
+    public function __construct(RegistrationRepository $registrationRepository, SystemEmailBuilder $systemEmailBuilder)
     {
         $this->registrationRepository = $registrationRepository;
+        $this->systemEmailBuilder = $systemEmailBuilder;
     }
 
     /**
@@ -47,7 +49,7 @@ class EmailService implements SingletonInterface
     public function sendPlainTextEmailToRegularAttendees($event, string $subject, string $rawBody): void
     {
         $organizer = $event->getFirstOrganizer();
-        $sender = $this->determineEmailSenderForEvent($event);
+        $sender = $this->systemEmailBuilder->build();
         $eventUid = $event->getUid();
         \assert(\is_int($eventUid) && $eventUid > 0);
 
@@ -77,23 +79,6 @@ class EmailService implements SingletonInterface
         \assert(\is_string($message));
         $flashMessage = GeneralUtility::makeInstance(FlashMessage::class, $message, '', $severity, true);
         $this->addFlashMessage($flashMessage);
-    }
-
-    /**
-     * Returns a `MailRole` with the default email data from the TYPO3 configuration if possible.
-     *
-     * Otherwise, returns the first organizer of the given event.
-     */
-    private function determineEmailSenderForEvent(EventDateInterface $event): MailRole
-    {
-        $systemEmailFromBuilder = GeneralUtility::makeInstance(SystemEmailFromBuilder::class);
-        if ($systemEmailFromBuilder->canBuild()) {
-            $sender = $systemEmailFromBuilder->build();
-        } else {
-            $sender = $event->getFirstOrganizer();
-        }
-
-        return $sender;
     }
 
     private function addFlashMessage(FlashMessage $flashMessage): void

--- a/Classes/SchedulerTasks/MailNotifier.php
+++ b/Classes/SchedulerTasks/MailNotifier.php
@@ -6,9 +6,8 @@ namespace OliverKlee\Seminars\SchedulerTasks;
 
 use OliverKlee\Oelib\Configuration\ConfigurationRegistry;
 use OliverKlee\Oelib\Configuration\PageFinder;
-use OliverKlee\Oelib\Email\SystemEmailFromBuilder;
+use OliverKlee\Oelib\Email\SystemEmailBuilder;
 use OliverKlee\Oelib\Interfaces\Configuration;
-use OliverKlee\Oelib\Interfaces\MailRole;
 use OliverKlee\Oelib\Mapper\MapperRegistry;
 use OliverKlee\Seminars\BagBuilder\EventBagBuilder;
 use OliverKlee\Seminars\Domain\Model\Event\EventInterface;
@@ -41,6 +40,8 @@ class MailNotifier extends AbstractTask
 
     protected RegistrationDigest $registrationDigest;
 
+    private SystemEmailBuilder $systemEmailBuilder;
+
     private bool $dependenciesAreSetUp = false;
 
     /**
@@ -58,6 +59,7 @@ class MailNotifier extends AbstractTask
         $this->emailService = GeneralUtility::makeInstance(EmailService::class);
         $this->eventMapper = GeneralUtility::makeInstance(MapperRegistry::class)->getByClassName(EventMapper::class);
         $this->registrationDigest = GeneralUtility::makeInstance(RegistrationDigest::class);
+        $this->systemEmailBuilder = GeneralUtility::makeInstance(SystemEmailBuilder::class);
 
         $this->dependenciesAreSetUp = true;
     }
@@ -144,7 +146,7 @@ class MailNotifier extends AbstractTask
     private function sendRemindersToOrganizers(LegacyEvent $event, string $messageKey): void
     {
         $replyTo = $event->getFirstOrganizer();
-        $sender = $this->determineEmailSenderForEvent($event);
+        $sender = $this->systemEmailBuilder->build();
         $subject = $this->customizeMessage($messageKey . 'Subject', $event);
 
         /** @var LegacyOrganizer $organizer */
@@ -158,23 +160,6 @@ class MailNotifier extends AbstractTask
             $emailBuilder->replyTo($replyTo);
             $emailBuilder->build()->send();
         }
-    }
-
-    /**
-     * Returns a `MailRole` with the default email data from the TYPO3 configuration if possible.
-     *
-     * Otherwise, returns the first organizer of the given event.
-     */
-    private function determineEmailSenderForEvent(LegacyEvent $event): MailRole
-    {
-        $systemEmailFromBuilder = GeneralUtility::makeInstance(SystemEmailFromBuilder::class);
-        if ($systemEmailFromBuilder->canBuild()) {
-            $sender = $systemEmailFromBuilder->build();
-        } else {
-            $sender = $event->getFirstOrganizer();
-        }
-
-        return $sender;
     }
 
     /**

--- a/Classes/Service/EmailService.php
+++ b/Classes/Service/EmailService.php
@@ -4,8 +4,7 @@ declare(strict_types=1);
 
 namespace OliverKlee\Seminars\Service;
 
-use OliverKlee\Oelib\Email\SystemEmailFromBuilder;
-use OliverKlee\Oelib\Interfaces\MailRole;
+use OliverKlee\Oelib\Email\SystemEmailBuilder;
 use OliverKlee\Seminars\Email\EmailBuilder;
 use OliverKlee\Seminars\Email\Salutation;
 use OliverKlee\Seminars\Model\Event;
@@ -27,12 +26,15 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  */
 class EmailService implements SingletonInterface
 {
+    private SystemEmailBuilder $systemEmailBuilder;
+
     protected Salutation $salutationBuilder;
 
     protected DateRangeViewHelper $dateRangeViewHelper;
 
-    public function __construct()
+    public function __construct(SystemEmailBuilder $systemEmailBuilder)
     {
+        $this->systemEmailBuilder = $systemEmailBuilder;
         $this->salutationBuilder = GeneralUtility::makeInstance(Salutation::class);
         $this->dateRangeViewHelper = GeneralUtility::makeInstance(DateRangeViewHelper::class);
     }
@@ -44,7 +46,7 @@ class EmailService implements SingletonInterface
      */
     public function sendEmailToAttendees(Event $event, string $subject, string $body): void
     {
-        $sender = $this->determineEmailSenderForEvent($event);
+        $sender = $this->systemEmailBuilder->build();
         $firstOrganizer = $event->getFirstOrganizer();
 
         /** @var Registration $registration */
@@ -62,23 +64,6 @@ class EmailService implements SingletonInterface
                 ->text($this->buildMessageBody($body, $event, $user))
                 ->build()->send();
         }
-    }
-
-    /**
-     * Returns a `MailRole` with the default email data from the TYPO3 configuration if possible.
-     *
-     * Otherwise, returns the first organizer of the given event.
-     */
-    private function determineEmailSenderForEvent(Event $event): MailRole
-    {
-        $systemEmailFromBuilder = GeneralUtility::makeInstance(SystemEmailFromBuilder::class);
-        if ($systemEmailFromBuilder->canBuild()) {
-            $sender = $systemEmailFromBuilder->build();
-        } else {
-            $sender = $event->getFirstOrganizer();
-        }
-
-        return $sender;
     }
 
     /**

--- a/Classes/Service/RegistrationManager.php
+++ b/Classes/Service/RegistrationManager.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace OliverKlee\Seminars\Service;
 
 use OliverKlee\Oelib\Configuration\ConfigurationRegistry;
-use OliverKlee\Oelib\Email\SystemEmailFromBuilder;
+use OliverKlee\Oelib\Email\SystemEmailBuilder;
 use OliverKlee\Oelib\Interfaces\Configuration;
 use OliverKlee\Oelib\Interfaces\MailRole;
 use OliverKlee\Oelib\Mapper\MapperRegistry;
@@ -373,7 +373,7 @@ class RegistrationManager implements SingletonInterface
         $emailBuilder = GeneralUtility::makeInstance(EmailBuilder::class);
         $emailBuilder
             ->to($user)
-            ->from($this->determineEmailSenderForEvent($event))
+            ->from($this->determineEmailSenderForEvent())
             ->replyTo($event->getFirstOrganizer())
             ->subject(
                 $this->translate('email_' . $helloSubjectPrefix . 'Subject') . ': ' . $event->getTitleAndDate('-'),
@@ -400,16 +400,9 @@ class RegistrationManager implements SingletonInterface
      *
      * Otherwise, returns the first organizer of the given event.
      */
-    private function determineEmailSenderForEvent(LegacyEvent $event): MailRole
+    private function determineEmailSenderForEvent(): MailRole
     {
-        $systemEmailFromBuilder = GeneralUtility::makeInstance(SystemEmailFromBuilder::class);
-        if ($systemEmailFromBuilder->canBuild()) {
-            $sender = $systemEmailFromBuilder->build();
-        } else {
-            $sender = $event->getFirstOrganizer();
-        }
-
-        return $sender;
+        return GeneralUtility::makeInstance(SystemEmailBuilder::class)->build();
     }
 
     /**
@@ -501,7 +494,7 @@ class RegistrationManager implements SingletonInterface
         $organizers = $event->getOrganizerBag();
         $emailBuilder = GeneralUtility::makeInstance(EmailBuilder::class);
         $emailBuilder
-            ->from($this->determineEmailSenderForEvent($event))
+            ->from($this->determineEmailSenderForEvent())
             ->replyTo($event->getFirstOrganizer())
             ->subject(
                 $this->translate('email_' . $helloSubjectPrefix . 'Subject') . ': ' . $registration->getTitle(),
@@ -592,7 +585,7 @@ class RegistrationManager implements SingletonInterface
 
         $emailBuilder = GeneralUtility::makeInstance(EmailBuilder::class);
         $emailBuilder
-            ->from($this->determineEmailSenderForEvent($event))
+            ->from($this->determineEmailSenderForEvent())
             ->replyTo($event->getFirstOrganizer())
             ->text($this->getMessageForNotification($registration, $emailReason))
             ->subject(


### PR DESCRIPTION
This also migrates usages of the deprecated
`SystemEmailFromBuilder` class.

Fixes #4921