### PR TITLE
[BUGFIX] Use `GU::makeInstance` for the `DataHandler` in tests

### DIFF
--- a/Tests/Functional/Hooks/DataHandlerHookTest.php
+++ b/Tests/Functional/Hooks/DataHandlerHookTest.php
@@ -35,7 +35,7 @@ final class DataHandlerHookTest extends FunctionalTestCase
     {
         parent::setUp();
 
-        $this->dataHandler = new DataHandler();
+        $this->dataHandler = GeneralUtility::makeInstance(DataHandler::class);
 
         $this->subject = $this->get(DataHandlerHook::class);
     }


### PR DESCRIPTION
This allows TYPO3 to build the `DataHandler` using DI in the future.

Fixes #5025