### PR TITLE
[CLEANUP] Use `DateTime::createFromImmutable` in the tests

### DIFF
--- a/Tests/Functional/Service/PriceFinderTest.php
+++ b/Tests/Functional/Service/PriceFinderTest.php
@@ -39,17 +39,6 @@ final class PriceFinderTest extends FunctionalTestCase
     }
 
     /**
-     * @deprecated #1960 will be removed in seminars 6.0, use `DateTime::createFromImmutable()` instead (PHP >= 7.3)
-     */
-    private function createFromImmutable(\DateTimeInterface $dateTime): \DateTime
-    {
-        $result = \DateTime::createFromFormat(\DateTimeInterface::ATOM, $dateTime->format(\DateTime::ATOM));
-        self::assertInstanceOf(\DateTime::class, $result);
-
-        return $result;
-    }
-
-    /**
      * @test
      */
     public function isAvailableViaContainer(): void
@@ -79,7 +68,7 @@ final class PriceFinderTest extends FunctionalTestCase
         $event = new SingleEvent();
         $event->setStandardPrice(0.0);
         $earlyBirdDeadline = $this->now->modify('-1 day');
-        $event->setEarlyBirdDeadline($this->createFromImmutable($earlyBirdDeadline));
+        $event->setEarlyBirdDeadline(\DateTime::createFromImmutable($earlyBirdDeadline));
 
         $result = $this->subject->findApplicablePrices($event);
 
@@ -95,7 +84,7 @@ final class PriceFinderTest extends FunctionalTestCase
         $event = new SingleEvent();
         $event->setStandardPrice(0.0);
         $earlyBirdDeadline = $this->now->modify('+1 day');
-        $event->setEarlyBirdDeadline($this->createFromImmutable($earlyBirdDeadline));
+        $event->setEarlyBirdDeadline(\DateTime::createFromImmutable($earlyBirdDeadline));
 
         $result = $this->subject->findApplicablePrices($event);
 
@@ -111,7 +100,7 @@ final class PriceFinderTest extends FunctionalTestCase
         $event = new SingleEvent();
         $event->setStandardPrice(0.0);
         $earlyBirdDeadline = $this->now->modify('+1 day');
-        $event->setEarlyBirdDeadline($this->createFromImmutable($earlyBirdDeadline));
+        $event->setEarlyBirdDeadline(\DateTime::createFromImmutable($earlyBirdDeadline));
         $event->setEarlyBirdPrice(14.5);
 
         $result = $this->subject->findApplicablePrices($event);
@@ -153,7 +142,7 @@ final class PriceFinderTest extends FunctionalTestCase
     {
         $event = new SingleEvent();
         $earlyBirdDeadline = $this->now->modify('-1 day');
-        $event->setEarlyBirdDeadline($this->createFromImmutable($earlyBirdDeadline));
+        $event->setEarlyBirdDeadline(\DateTime::createFromImmutable($earlyBirdDeadline));
 
         $standardPriceAmount = 1.0;
         $earlyBirdPriceAmount = 2.0;
@@ -180,7 +169,7 @@ final class PriceFinderTest extends FunctionalTestCase
     public function findApplicablePricesForAllPricesAndEarlyBirdDeadlineNowReturnsNonEarlyBirdPrices(): void
     {
         $event = new SingleEvent();
-        $event->setEarlyBirdDeadline($this->createFromImmutable($this->now));
+        $event->setEarlyBirdDeadline(\DateTime::createFromImmutable($this->now));
 
         $standardPriceAmount = 1.0;
         $earlyBirdPriceAmount = 2.0;
@@ -208,7 +197,7 @@ final class PriceFinderTest extends FunctionalTestCase
     {
         $event = new SingleEvent();
         $earlyBirdDeadline = $this->now->modify('+1 day');
-        $event->setEarlyBirdDeadline($this->createFromImmutable($earlyBirdDeadline));
+        $event->setEarlyBirdDeadline(\DateTime::createFromImmutable($earlyBirdDeadline));
 
         $standardPriceAmount = 1.0;
         $earlyBirdPriceAmount = 2.0;
@@ -240,7 +229,7 @@ final class PriceFinderTest extends FunctionalTestCase
     {
         $event = new SingleEvent();
         $earlyBirdDeadline = $this->now->modify('+1 day');
-        $event->setEarlyBirdDeadline($this->createFromImmutable($earlyBirdDeadline));
+        $event->setEarlyBirdDeadline(\DateTime::createFromImmutable($earlyBirdDeadline));
 
         $standardPriceAmount = 1.0;
         $earlyBirdPriceAmount = 2.0;
@@ -263,7 +252,7 @@ final class PriceFinderTest extends FunctionalTestCase
     {
         $event = new SingleEvent();
         $earlyBirdDeadline = $this->now->modify('+1 day');
-        $event->setEarlyBirdDeadline($this->createFromImmutable($earlyBirdDeadline));
+        $event->setEarlyBirdDeadline(\DateTime::createFromImmutable($earlyBirdDeadline));
 
         $standardPriceAmount = 1.0;
         $specialPriceAmount = 3.0;
@@ -293,7 +282,7 @@ final class PriceFinderTest extends FunctionalTestCase
     {
         $event = new SingleEvent();
         $earlyBirdDeadline = $this->now->modify('+1 day');
-        $event->setEarlyBirdDeadline($this->createFromImmutable($earlyBirdDeadline));
+        $event->setEarlyBirdDeadline(\DateTime::createFromImmutable($earlyBirdDeadline));
 
         $standardPriceAmount = 1.0;
         $earlyBirdPriceAmount = 2.0;

--- a/Tests/Unit/Service/RegistrationGuardTest.php
+++ b/Tests/Unit/Service/RegistrationGuardTest.php
@@ -69,29 +69,6 @@ final class RegistrationGuardTest extends UnitTestCase
         );
     }
 
-    /**
-     * @deprecated #1960 will be removed in seminars 6.0, use `DateTime::createFromImmutable()` instead (PHP >= 7.3)
-     */
-    private function createFromImmutable(\DateTimeInterface $dateTime): \DateTime
-    {
-        $result = \DateTime::createFromFormat(\DateTimeInterface::ATOM, $dateTime->format(\DateTime::ATOM));
-        self::assertInstanceOf(\DateTime::class, $result);
-
-        return $result;
-    }
-
-    /**
-     * @test
-     */
-    public function createFromImmutableKeepsDatesComparable(): void
-    {
-        $dateTimeImmutable = new \DateTimeImmutable($this->now);
-        $dateTime = $this->createFromImmutable($dateTimeImmutable);
-
-        self::assertFalse($dateTimeImmutable < $dateTime);
-        self::assertFalse($dateTimeImmutable > $dateTime);
-    }
-
     private function now(): \DateTimeImmutable
     {
         return new \DateTimeImmutable($this->now);
@@ -200,7 +177,7 @@ final class RegistrationGuardTest extends UnitTestCase
      */
     public function registrationPossibleDataProvider(): array
     {
-        $now = $this->createFromImmutable($this->now());
+        $now = \DateTime::createFromImmutable($this->now());
         // We need the clone because `modify` on `DateTime` modifies the original object instead of returning a new one
         // (which would be the case for `DateTimeImmutable`.
         $future = (clone $now)->modify('+1 day');
@@ -259,7 +236,7 @@ final class RegistrationGuardTest extends UnitTestCase
      */
     public function registrationNotPossibleDataProvider(): array
     {
-        $now = $this->createFromImmutable($this->now());
+        $now = \DateTime::createFromImmutable($this->now());
         // We need the clone because `modify` on `DateTime` modifies the original object instead of returning a new one
         // (which would be the case for `DateTimeImmutable`.
         $future = (clone $now)->modify('+1 day');


### PR DESCRIPTION
Now that we have been requiring PHP >= 7.4 for quite some time, we can use this method.

Fixes #1960