### PR TITLE
[TASK] Migrate `createPartialMock` to the mock builder

### DIFF
--- a/Tests/Functional/FrontEnd/DefaultController/ListViewTest.php
+++ b/Tests/Functional/FrontEnd/DefaultController/ListViewTest.php
@@ -64,16 +64,17 @@ final class ListViewTest extends FunctionalTestCase
      */
     public function eventListFlavorWithoutUidCreatesListView(): void
     {
-        $controller = $this->createPartialMock(
-            TestingDefaultController::class,
-            [
+        $controller = $this
+            ->getMockBuilder(TestingDefaultController::class)
+            ->onlyMethods([
                 'createListView',
                 'createSingleView',
                 'pi_initPIflexForm',
                 'getTemplateCode',
                 'setLabels',
-            ],
-        );
+            ])
+            ->disableOriginalConstructor()
+            ->getMock();
         $controller->expects(self::once())->method('createListView')->with('seminar_list');
         $controller->expects(self::never())->method('createSingleView');
 
@@ -87,16 +88,17 @@ final class ListViewTest extends FunctionalTestCase
      */
     public function eventListFlavorWithUidCreatesListView(): void
     {
-        $controller = $this->createPartialMock(
-            TestingDefaultController::class,
-            [
+        $controller = $this
+            ->getMockBuilder(TestingDefaultController::class)
+            ->onlyMethods([
                 'createListView',
                 'createSingleView',
                 'pi_initPIflexForm',
                 'getTemplateCode',
                 'setLabels',
-            ],
-        );
+            ])
+            ->disableOriginalConstructor()
+            ->getMock();
         $controller->expects(self::once())->method('createListView')->with('seminar_list');
         $controller->expects(self::never())->method('createSingleView');
 

--- a/Tests/Functional/FrontEnd/DefaultController/SingleViewTest.php
+++ b/Tests/Functional/FrontEnd/DefaultController/SingleViewTest.php
@@ -60,16 +60,13 @@ final class SingleViewTest extends FunctionalTestCase
      */
     public function singleViewFlavorWithUidCreatesSingleView(): void
     {
-        $controller = $this->createPartialMock(
-            TestingDefaultController::class,
-            [
-                'createListView',
-                'createSingleView',
-                'pi_initPIflexForm',
-                'getTemplateCode',
-                'setLabels',
-            ],
-        );
+        $controller = $this->getMockBuilder(TestingDefaultController::class)->onlyMethods([
+            'createListView',
+            'createSingleView',
+            'pi_initPIflexForm',
+            'getTemplateCode',
+            'setLabels',
+        ])->getMock();
         $controller->expects(self::once())->method('createSingleView');
         $controller->expects(self::never())->method('createListView');
 
@@ -83,16 +80,13 @@ final class SingleViewTest extends FunctionalTestCase
      */
     public function singleViewFlavorWithUidFromShowSingleEventConfigurationCreatesSingleView(): void
     {
-        $controller = $this->createPartialMock(
-            TestingDefaultController::class,
-            [
-                'createListView',
-                'createSingleView',
-                'pi_initPIflexForm',
-                'getTemplateCode',
-                'setLabels',
-            ],
-        );
+        $controller = $this->getMockBuilder(TestingDefaultController::class)->onlyMethods([
+            'createListView',
+            'createSingleView',
+            'pi_initPIflexForm',
+            'getTemplateCode',
+            'setLabels',
+        ])->getMock();
         $controller->expects(self::once())->method('createSingleView');
         $controller->expects(self::never())->method('createListView');
 
@@ -106,16 +100,13 @@ final class SingleViewTest extends FunctionalTestCase
      */
     public function singleViewFlavorWithoutUidCreatesSingleView(): void
     {
-        $controller = $this->createPartialMock(
-            TestingDefaultController::class,
-            [
-                'createListView',
-                'createSingleView',
-                'pi_initPIflexForm',
-                'getTemplateCode',
-                'setLabels',
-            ],
-        );
+        $controller = $this->getMockBuilder(TestingDefaultController::class)->onlyMethods([
+            'createListView',
+            'createSingleView',
+            'pi_initPIflexForm',
+            'getTemplateCode',
+            'setLabels',
+        ])->getMock();
         $controller->expects(self::once())->method('createSingleView');
         $controller->expects(self::never())->method('createListView');
 

--- a/Tests/Functional/SchedulerTasks/MailNotifierTest.php
+++ b/Tests/Functional/SchedulerTasks/MailNotifierTest.php
@@ -129,10 +129,14 @@ final class MailNotifierTest extends FunctionalTestCase
     public function executeWithPageConfigurationCallsAllSeparateSteps(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/MailNotifierConfiguration.csv');
-        $subject = $this->createPartialMock(
-            MailNotifier::class,
-            ['sendEventTakesPlaceReminders', 'sendCancellationDeadlineReminders', 'automaticallyChangeEventStatuses'],
-        );
+        $subject =
+            $this->getMockBuilder(MailNotifier::class)->onlyMethods(
+                [
+                    'sendEventTakesPlaceReminders',
+                    'sendCancellationDeadlineReminders',
+                    'automaticallyChangeEventStatuses',
+                ],
+            )->getMock();
         $subject->setConfigurationPageUid(1);
 
         $subject->expects(self::once())->method('sendEventTakesPlaceReminders');
@@ -147,10 +151,14 @@ final class MailNotifierTest extends FunctionalTestCase
      */
     public function executeWithoutPageConfigurationNotCallsAnySeparateStep(): void
     {
-        $subject = $this->createPartialMock(
-            MailNotifier::class,
-            ['sendEventTakesPlaceReminders', 'sendCancellationDeadlineReminders', 'automaticallyChangeEventStatuses'],
-        );
+        $subject =
+            $this->getMockBuilder(MailNotifier::class)->onlyMethods(
+                [
+                    'sendEventTakesPlaceReminders',
+                    'sendCancellationDeadlineReminders',
+                    'automaticallyChangeEventStatuses',
+                ],
+            )->getMock();
         $subject->setConfigurationPageUid(0);
 
         $subject->expects(self::never())->method('sendEventTakesPlaceReminders');
@@ -166,10 +174,14 @@ final class MailNotifierTest extends FunctionalTestCase
     public function executeWithPageConfigurationExecutesRegistrationDigest(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/MailNotifierConfiguration.csv');
-        $subject = $this->createPartialMock(
-            MailNotifier::class,
-            ['sendEventTakesPlaceReminders', 'sendCancellationDeadlineReminders', 'automaticallyChangeEventStatuses'],
-        );
+        $subject =
+            $this->getMockBuilder(MailNotifier::class)->onlyMethods(
+                [
+                    'sendEventTakesPlaceReminders',
+                    'sendCancellationDeadlineReminders',
+                    'automaticallyChangeEventStatuses',
+                ],
+            )->getMock();
         $subject->setConfigurationPageUid(1);
         $this->registrationDigestMock->expects(self::once())->method('execute');
 

--- a/Tests/LegacyFunctional/FrontEnd/DefaultControllerTest.php
+++ b/Tests/LegacyFunctional/FrontEnd/DefaultControllerTest.php
@@ -5395,10 +5395,10 @@ final class DefaultControllerTest extends FunctionalTestCase
      */
     public function initListViewForDefaultListLimitsListByAdditionalParameters(): void
     {
-        $subject = $this->createPartialMock(
-            TestingDefaultController::class,
-            ['limitForAdditionalParameters'],
-        );
+        $subject =
+            $this->getMockBuilder(TestingDefaultController::class)
+                ->onlyMethods(['limitForAdditionalParameters'])
+                ->getMock();
         $subject->setUpDependencies();
         $subject->setContentObjectRenderer($this->createMock(ContentObjectRenderer::class));
         $subject->expects(self::once())->method('limitForAdditionalParameters');
@@ -5411,10 +5411,10 @@ final class DefaultControllerTest extends FunctionalTestCase
      */
     public function initListViewForTopicListLimitsListByAdditionalParameters(): void
     {
-        $subject = $this->createPartialMock(
-            TestingDefaultController::class,
-            ['limitForAdditionalParameters'],
-        );
+        $subject =
+            $this->getMockBuilder(TestingDefaultController::class)
+                ->onlyMethods(['limitForAdditionalParameters'])
+                ->getMock();
         $subject->setUpDependencies();
         $subject->setContentObjectRenderer($this->createMock(ContentObjectRenderer::class));
         $subject->expects(self::once())->method('limitForAdditionalParameters');
@@ -5427,10 +5427,10 @@ final class DefaultControllerTest extends FunctionalTestCase
      */
     public function initListViewForMyEventsListNotLimitsListByAdditionalParameters(): void
     {
-        $subject = $this->createPartialMock(
-            TestingDefaultController::class,
-            ['limitForAdditionalParameters'],
-        );
+        $subject =
+            $this->getMockBuilder(TestingDefaultController::class)
+                ->onlyMethods(['limitForAdditionalParameters'])
+                ->getMock();
         $subject->setUpDependencies();
         $subject->setContentObjectRenderer($this->createMock(ContentObjectRenderer::class));
         $subject->expects(self::never())->method('limitForAdditionalParameters');
@@ -5566,10 +5566,10 @@ final class DefaultControllerTest extends FunctionalTestCase
         int $listPid,
         int $vipListPid
     ): void {
-        $subject = $this->createPartialMock(
-            TestingDefaultController::class,
-            ['isRegistrationEnabled', 'isLoggedIn', 'hideColumns'],
-        );
+        $subject =
+            $this->getMockBuilder(TestingDefaultController::class)->onlyMethods(
+                ['isRegistrationEnabled', 'isLoggedIn', 'hideColumns'],
+            )->getMock();
         $subject
             ->method('isRegistrationEnabled')
             ->willReturn(true);
@@ -5611,10 +5611,10 @@ final class DefaultControllerTest extends FunctionalTestCase
         int $listPid,
         int $vipListPid
     ): void {
-        $subject = $this->createPartialMock(
-            TestingDefaultController::class,
-            ['isRegistrationEnabled', 'isLoggedIn', 'hideColumns'],
-        );
+        $subject =
+            $this->getMockBuilder(TestingDefaultController::class)->onlyMethods(
+                ['isRegistrationEnabled', 'isLoggedIn', 'hideColumns'],
+            )->getMock();
         $subject
             ->method('isRegistrationEnabled')
             ->willReturn(true);
@@ -5652,10 +5652,10 @@ final class DefaultControllerTest extends FunctionalTestCase
         int $listPid,
         int $vipListPid
     ): void {
-        $subject = $this->createPartialMock(
-            TestingDefaultController::class,
-            ['isRegistrationEnabled', 'isLoggedIn', 'hideColumns'],
-        );
+        $subject =
+            $this->getMockBuilder(TestingDefaultController::class)->onlyMethods(
+                ['isRegistrationEnabled', 'isLoggedIn', 'hideColumns'],
+            )->getMock();
         $subject
             ->method('isRegistrationEnabled')
             ->willReturn(false);

--- a/Tests/LegacyFunctional/Model/EventTest.php
+++ b/Tests/LegacyFunctional/Model/EventTest.php
@@ -87,10 +87,7 @@ final class EventTest extends FunctionalTestCase
         $registrations = new Collection();
         $registration = $this->registrationMapper->getLoadedTestingModel(['seats' => 1]);
         $registrations->add($registration);
-        $event = $this->createPartialMock(
-            Event::class,
-            ['getRegularRegistrations'],
-        );
+        $event = $this->getMockBuilder(Event::class)->onlyMethods(['getRegularRegistrations'])->getMock();
         $event->setData([]);
         $event
             ->method('getRegularRegistrations')
@@ -110,10 +107,7 @@ final class EventTest extends FunctionalTestCase
         $registrations = new Collection();
         $registration = $this->registrationMapper->getLoadedTestingModel(['seats' => 2]);
         $registrations->add($registration);
-        $event = $this->createPartialMock(
-            Event::class,
-            ['getRegularRegistrations'],
-        );
+        $event = $this->getMockBuilder(Event::class)->onlyMethods(['getRegularRegistrations'])->getMock();
         $event->setData([]);
         $event
             ->method('getRegularRegistrations')

--- a/Tests/LegacyFunctional/OldModel/LegacyEventTest.php
+++ b/Tests/LegacyFunctional/OldModel/LegacyEventTest.php
@@ -6114,10 +6114,10 @@ final class LegacyEventTest extends FunctionalTestCase
         int $registrationsListPID,
         int $registrationsVipListPID
     ): void {
-        $subject = $this->createPartialMock(
-            LegacyEvent::class,
-            ['needsRegistration', 'isUserRegistered', 'isUserVip'],
-        );
+        $subject =
+            $this->getMockBuilder(LegacyEvent::class)->onlyMethods(
+                ['needsRegistration', 'isUserRegistered', 'isUserVip'],
+            )->getMock();
         $subject
             ->method('needsRegistration')
             ->willReturn(true);
@@ -6159,10 +6159,10 @@ final class LegacyEventTest extends FunctionalTestCase
         int $registrationsListPID,
         int $registrationsVipListPID
     ): void {
-        $subject = $this->createPartialMock(
-            LegacyEvent::class,
-            ['needsRegistration', 'isUserRegistered', 'isUserVip'],
-        );
+        $subject =
+            $this->getMockBuilder(LegacyEvent::class)->onlyMethods(
+                ['needsRegistration', 'isUserRegistered', 'isUserVip'],
+            )->getMock();
         $subject
             ->method('needsRegistration')
             ->willReturn(true);
@@ -6361,10 +6361,10 @@ final class LegacyEventTest extends FunctionalTestCase
         int $registrationsListPID,
         int $registrationsVipListPID
     ): void {
-        $subject = $this->createPartialMock(
-            LegacyEvent::class,
-            ['needsRegistration', 'isUserRegistered', 'isUserVip'],
-        );
+        $subject =
+            $this->getMockBuilder(LegacyEvent::class)->onlyMethods(
+                ['needsRegistration', 'isUserRegistered', 'isUserVip'],
+            )->getMock();
         $subject
             ->method('needsRegistration')
             ->willReturn(true);
@@ -6495,10 +6495,10 @@ final class LegacyEventTest extends FunctionalTestCase
         string $whichPlugin,
         string $accessLevel
     ): void {
-        $subject = $this->createPartialMock(
-            LegacyEvent::class,
-            ['needsRegistration', 'canViewRegistrationsList'],
-        );
+        $subject =
+            $this->getMockBuilder(LegacyEvent::class)
+                ->onlyMethods(['needsRegistration', 'canViewRegistrationsList'])
+                ->getMock();
         $subject->method('needsRegistration')->willReturn(true);
         $subject
             ->method('canViewRegistrationsList')
@@ -6518,10 +6518,10 @@ final class LegacyEventTest extends FunctionalTestCase
      */
     public function canViewRegistrationsListMessageWithLoginAndAccessGrantedReturnsEmptyString(): void
     {
-        $subject = $this->createPartialMock(
-            LegacyEvent::class,
-            ['needsRegistration', 'canViewRegistrationsList'],
-        );
+        $subject =
+            $this->getMockBuilder(LegacyEvent::class)
+                ->onlyMethods(['needsRegistration', 'canViewRegistrationsList'])
+                ->getMock();
         $subject->method('needsRegistration')->willReturn(true);
         $subject->method('canViewRegistrationsList')->willReturn(true);
 
@@ -6541,10 +6541,10 @@ final class LegacyEventTest extends FunctionalTestCase
      */
     public function canViewRegistrationsListMessageWithLoginAndAccessDeniedReturnsAccessDeniedMessage(): void
     {
-        $subject = $this->createPartialMock(
-            LegacyEvent::class,
-            ['needsRegistration', 'canViewRegistrationsList'],
-        );
+        $subject =
+            $this->getMockBuilder(LegacyEvent::class)
+                ->onlyMethods(['needsRegistration', 'canViewRegistrationsList'])
+                ->getMock();
         $subject->method('needsRegistration')->willReturn(true);
         $subject->method('canViewRegistrationsList')->willReturn(false);
 

--- a/Tests/Support/BackEndTestsTrait.php
+++ b/Tests/Support/BackEndTestsTrait.php
@@ -81,10 +81,10 @@ trait BackEndTestsTrait
         if ($currentBackEndUser instanceof BackendUserAuthentication) {
             $this->backEndUserBackup = $currentBackEndUser;
         }
-        $mockBackEndUser = $this->createPartialMock(
-            BackendUserAuthentication::class,
-            ['check', 'doesUserHaveAccess', 'setAndSaveSessionData', 'writeUC'],
-        );
+        $mockBackEndUser =
+            $this->getMockBuilder(BackendUserAuthentication::class)->onlyMethods(
+                ['check', 'doesUserHaveAccess', 'setAndSaveSessionData', 'writeUC'],
+            )->getMock();
         $mockBackEndUser->method('check')->willReturn(true);
         $mockBackEndUser->method('doesUserHaveAccess')->willReturn(true);
         $mockBackEndUser->user['uid'] = 1;

--- a/Tests/Unit/Model/EventTest.php
+++ b/Tests/Unit/Model/EventTest.php
@@ -395,10 +395,7 @@ final class EventTest extends UnitTestCase
      */
     public function hasCombinedSingleViewPageForEmptySingleViewPageReturnsFalse(): void
     {
-        $subject = $this->createPartialMock(
-            Event::class,
-            ['getCombinedSingleViewPage'],
-        );
+        $subject = $this->getMockBuilder(Event::class)->onlyMethods(['getCombinedSingleViewPage'])->getMock();
         $subject
             ->expects(self::atLeastOnce())
             ->method('getCombinedSingleViewPage')->willReturn('');
@@ -413,10 +410,7 @@ final class EventTest extends UnitTestCase
      */
     public function hasCombinedSingleViewPageForNonEmptySingleViewPageReturnsTrue(): void
     {
-        $subject = $this->createPartialMock(
-            Event::class,
-            ['getCombinedSingleViewPage'],
-        );
+        $subject = $this->getMockBuilder(Event::class)->onlyMethods(['getCombinedSingleViewPage'])->getMock();
         $subject
             ->expects(self::atLeastOnce())
             ->method('getCombinedSingleViewPage')->willReturn('42');
@@ -910,10 +904,7 @@ final class EventTest extends UnitTestCase
      */
     public function getRegisteredSeatsForNoRegularRegistrationsReturnsZero(): void
     {
-        $event = $this->createPartialMock(
-            Event::class,
-            ['getRegularRegistrations'],
-        );
+        $event = $this->getMockBuilder(Event::class)->onlyMethods(['getRegularRegistrations'])->getMock();
         $event->setData([]);
         $event
             ->method('getRegularRegistrations')
@@ -930,10 +921,7 @@ final class EventTest extends UnitTestCase
      */
     public function getRegisteredSeatsCountsOfflineRegistrations(): void
     {
-        $event = $this->createPartialMock(
-            Event::class,
-            ['getRegularRegistrations'],
-        );
+        $event = $this->getMockBuilder(Event::class)->onlyMethods(['getRegularRegistrations'])->getMock();
         $event->setData(['offline_attendees' => 2]);
         $event
             ->method('getRegularRegistrations')
@@ -954,10 +942,7 @@ final class EventTest extends UnitTestCase
      */
     public function hasEnoughRegistrationsForZeroSeatsAndZeroNeededReturnsTrue(): void
     {
-        $event = $this->createPartialMock(
-            Event::class,
-            ['getRegisteredSeats'],
-        );
+        $event = $this->getMockBuilder(Event::class)->onlyMethods(['getRegisteredSeats'])->getMock();
         $event->setData(['attendees_min' => 0]);
         $event
             ->method('getRegisteredSeats')
@@ -973,10 +958,7 @@ final class EventTest extends UnitTestCase
      */
     public function hasEnoughRegistrationsForLessSeatsThanNeededReturnsFalse(): void
     {
-        $event = $this->createPartialMock(
-            Event::class,
-            ['getRegisteredSeats'],
-        );
+        $event = $this->getMockBuilder(Event::class)->onlyMethods(['getRegisteredSeats'])->getMock();
         $event->setData(['attendees_min' => 2]);
         $event
             ->method('getRegisteredSeats')
@@ -992,10 +974,7 @@ final class EventTest extends UnitTestCase
      */
     public function hasEnoughRegistrationsForAsManySeatsAsNeededReturnsTrue(): void
     {
-        $event = $this->createPartialMock(
-            Event::class,
-            ['getRegisteredSeats'],
-        );
+        $event = $this->getMockBuilder(Event::class)->onlyMethods(['getRegisteredSeats'])->getMock();
         $event->setData(['attendees_min' => 2]);
         $event
             ->method('getRegisteredSeats')
@@ -1011,10 +990,7 @@ final class EventTest extends UnitTestCase
      */
     public function hasEnoughRegistrationsForMoreSeatsThanNeededReturnsTrue(): void
     {
-        $event = $this->createPartialMock(
-            Event::class,
-            ['getRegisteredSeats'],
-        );
+        $event = $this->getMockBuilder(Event::class)->onlyMethods(['getRegisteredSeats'])->getMock();
         $event->setData(['attendees_min' => 1]);
         $event
             ->method('getRegisteredSeats')


### PR DESCRIPTION
This allows us to keep calling the original constructor (which we need for testing with dependencies).

Fixes #5045