### PR TITLE
[BUGFIX] Avoid having the request as state in services

### DIFF
--- a/Classes/Controller/EventRegistrationController.php
+++ b/Classes/Controller/EventRegistrationController.php
@@ -68,7 +68,7 @@ class EventRegistrationController extends ActionController
         if (!$this->registrationGuard->existsFrontEndUserUidInSession($this->request)) {
             return $this->redirectToLoginPage($event);
         }
-        $userUid = $this->registrationGuard->getFrontEndUserUidFromSession();
+        $userUid = $this->registrationGuard->getFrontEndUserUidFromSession($this->request);
         if (!$this->registrationGuard->isFreeFromRegistrationConflicts($event, $userUid)) {
             return $this->forwardToDenyAction('alreadyRegistered');
         }
@@ -144,7 +144,7 @@ class EventRegistrationController extends ActionController
             $firstPriceCode = $firstPrice instanceof Price ? $firstPrice->getPriceCode() : Price::PRICE_STANDARD;
             $newRegistration->setPriceCode($firstPriceCode);
         }
-        $this->registrationProcessor->enrichWithMetadata($newRegistration, $event, $this->settings);
+        $this->registrationProcessor->enrichWithMetadata($newRegistration, $event, $this->settings, $this->request);
         $this->view->assign('registration', $newRegistration);
 
         $maximumBookableSeats = (int)($this->settings['maximumBookableSeats'] ?? self::MAXIMUM_BOOKABLE_SEATS);
@@ -172,7 +172,7 @@ class EventRegistrationController extends ActionController
         $this->registrationGuard->assertBookableEventType($event);
         \assert($event instanceof EventDateInterface);
 
-        $this->registrationProcessor->enrichWithMetadata($registration, $event, $this->settings);
+        $this->registrationProcessor->enrichWithMetadata($registration, $event, $this->settings, $this->request);
         $this->registrationProcessor->calculateTotalPrice($registration);
 
         $this->view->assign('event', $event);
@@ -192,7 +192,7 @@ class EventRegistrationController extends ActionController
         $this->registrationGuard->assertBookableEventType($event);
         \assert($event instanceof EventDateInterface);
 
-        $this->registrationProcessor->enrichWithMetadata($registration, $event, $this->settings);
+        $this->registrationProcessor->enrichWithMetadata($registration, $event, $this->settings, $this->request);
         $this->registrationProcessor->calculateTotalPrice($registration);
         $this->registrationProcessor->createTitle($registration);
         $userStorageFolderUid = (int)($this->settings['additionalPersonsStorageFolder'] ?? 0);
@@ -200,7 +200,7 @@ class EventRegistrationController extends ActionController
         $this->registrationProcessor->persist($registration);
         $this->registrationProcessor->sendEmails($registration);
 
-        $this->oneTimeAccountConnector->destroyOneTimeSession();
+        $this->oneTimeAccountConnector->destroyOneTimeSession($this->request);
 
         return $this->redirect('thankYou', null, null, ['event' => $event, 'registration' => $registration]);
     }

--- a/Classes/Service/OneTimeAccountConnector.php
+++ b/Classes/Service/OneTimeAccountConnector.php
@@ -13,13 +13,13 @@ use TYPO3\CMS\Frontend\Authentication\FrontendUserAuthentication;
  */
 class OneTimeAccountConnector implements SingletonInterface
 {
-    private FrontendUserAuthentication $frontEndUserAuthentication;
-
-    public function __construct()
-    {
-        $frontEndUserAuthentication = $this->getRequest()->getAttribute('frontend.user');
+    private function getFrontendUserAuthenticationFromRequest(
+        ServerRequestInterface $request
+    ): FrontendUserAuthentication {
+        $frontEndUserAuthentication = $request->getAttribute('frontend.user');
         \assert($frontEndUserAuthentication instanceof FrontendUserAuthentication);
-        $this->frontEndUserAuthentication = $frontEndUserAuthentication;
+
+        return $frontEndUserAuthentication;
     }
 
     /**
@@ -27,9 +27,11 @@ class OneTimeAccountConnector implements SingletonInterface
      *
      * @return positive-int|null
      */
-    public function getOneTimeAccountUserUid(): ?int
+    public function getOneTimeAccountUserUid(ServerRequestInterface $request): ?int
     {
-        $uid = $this->frontEndUserAuthentication->getSessionData('onetimeaccountUserUid');
+        $uid = $this
+            ->getFrontendUserAuthenticationFromRequest($request)
+            ->getSessionData('onetimeaccountUserUid');
         if (!\is_int($uid) || $uid <= 0) {
             return null;
         }
@@ -42,18 +44,12 @@ class OneTimeAccountConnector implements SingletonInterface
      *
      * If a onetimeaccount user UID is available in the session, it will be deleted.
      */
-    public function destroyOneTimeSession(): void
+    public function destroyOneTimeSession(ServerRequestInterface $request): void
     {
-        if (\is_int($this->getOneTimeAccountUserUid())) {
-            $this->frontEndUserAuthentication->setAndSaveSessionData('onetimeaccountUserUid', null);
+        if (\is_int($this->getOneTimeAccountUserUid($request))) {
+            $this
+                ->getFrontendUserAuthenticationFromRequest($request)
+                ->setAndSaveSessionData('onetimeaccountUserUid', null);
         }
-    }
-
-    private function getRequest(): ServerRequestInterface
-    {
-        $request = $GLOBALS['TYPO3_REQUEST'];
-        \assert($request instanceof ServerRequestInterface);
-
-        return $request;
     }
 }

--- a/Classes/Service/RegistrationGuard.php
+++ b/Classes/Service/RegistrationGuard.php
@@ -12,9 +12,9 @@ use OliverKlee\Seminars\Domain\Model\Event\EventStatistics;
 use OliverKlee\Seminars\Domain\Model\Event\EventTopic;
 use OliverKlee\Seminars\Domain\Model\Event\SingleEvent;
 use OliverKlee\Seminars\Domain\Repository\Registration\RegistrationRepository;
+use Psr\Http\Message\ServerRequestInterface;
 use TYPO3\CMS\Core\Context\Context;
 use TYPO3\CMS\Core\SingletonInterface;
-use TYPO3\CMS\Extbase\Mvc\Request;
 
 /**
  * This class provides functions to check whether a registration for an event is possible.
@@ -127,18 +127,18 @@ class RegistrationGuard implements SingletonInterface
             || !$this->registrationRepository->existsRegistrationForEventAndUser($event, $userUid);
     }
 
-    public function existsFrontEndUserUidInSession(Request $request): bool
+    public function existsFrontEndUserUidInSession(ServerRequestInterface $request): bool
     {
         $isLoggedIn = $this->context->getPropertyFromAspect('frontend.user', 'isLoggedIn');
         \assert(\is_bool($isLoggedIn));
 
-        return $isLoggedIn || \is_int($this->oneTimeAccountConnector->getOneTimeAccountUserUid());
+        return $isLoggedIn || \is_int($this->oneTimeAccountConnector->getOneTimeAccountUserUid($request));
     }
 
     /**
      * @return positive-int|null
      */
-    public function getFrontEndUserUidFromSession(): ?int
+    public function getFrontEndUserUidFromSession(ServerRequestInterface $request): ?int
     {
         $userUidFromLogin = $this->context->getPropertyFromAspect('frontend.user', 'id');
         \assert(\is_int($userUidFromLogin));
@@ -147,7 +147,7 @@ class RegistrationGuard implements SingletonInterface
             $userUidFromLogin = null;
         }
 
-        $userUidFromOneTimeAccount = $this->oneTimeAccountConnector->getOneTimeAccountUserUid();
+        $userUidFromOneTimeAccount = $this->oneTimeAccountConnector->getOneTimeAccountUserUid($request);
 
         return \is_int($userUidFromLogin) ? $userUidFromLogin : $userUidFromOneTimeAccount;
     }

--- a/Classes/Service/RegistrationProcessor.php
+++ b/Classes/Service/RegistrationProcessor.php
@@ -13,6 +13,7 @@ use OliverKlee\Seminars\Domain\Repository\Event\EventRepository;
 use OliverKlee\Seminars\Domain\Repository\FrontendUserRepository;
 use OliverKlee\Seminars\Domain\Repository\Registration\RegistrationRepository;
 use OliverKlee\Seminars\OldModel\LegacyRegistration;
+use Psr\Http\Message\ServerRequestInterface;
 use TYPO3\CMS\Core\SingletonInterface;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
@@ -62,12 +63,16 @@ class RegistrationProcessor implements SingletonInterface
      *
      * @param array{registrationRecordsStorageFolder?: numeric-string} $settings
      */
-    public function enrichWithMetadata(Registration $registration, Event $event, array $settings): void
-    {
+    public function enrichWithMetadata(
+        Registration $registration,
+        Event $event,
+        array $settings,
+        ServerRequestInterface $request
+    ): void {
         \assert($event instanceof EventDateInterface);
         $registration->setEvent($event);
 
-        $userUid = $this->registrationGuard->getFrontEndUserUidFromSession();
+        $userUid = $this->registrationGuard->getFrontEndUserUidFromSession($request);
         if (!\is_int($userUid)) {
             throw new \RuntimeException('No user UID found in the session.', 1668865776);
         }

--- a/Tests/Functional/Service/OneTimeAccountConnectorTest.php
+++ b/Tests/Functional/Service/OneTimeAccountConnectorTest.php
@@ -5,10 +5,6 @@ declare(strict_types=1);
 namespace OliverKlee\Seminars\Tests\Functional\Service;
 
 use OliverKlee\Seminars\Service\OneTimeAccountConnector;
-use TYPO3\CMS\Core\Core\SystemEnvironmentBuilder;
-use TYPO3\CMS\Core\Http\ServerRequestFactory;
-use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\CMS\Frontend\Authentication\FrontendUserAuthentication;
 use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
 
 /**
@@ -23,17 +19,6 @@ final class OneTimeAccountConnectorTest extends FunctionalTestCase
         'oliverklee/oelib',
         'oliverklee/seminars',
     ];
-
-    protected function setUp(): void
-    {
-        parent::setUp();
-
-        GeneralUtility::setIndpEnv('TYPO3_REQUEST_URL', 'https://www.example.com/');
-        $request = ServerRequestFactory::fromGlobals()
-            ->withAttribute('applicationType', SystemEnvironmentBuilder::REQUESTTYPE_FE)
-            ->withAttribute('frontend.user', $this->createStub(FrontendUserAuthentication::class));
-        $GLOBALS['TYPO3_REQUEST'] = $request;
-    }
 
     /**
      * @test

--- a/Tests/Functional/Service/RegistrationGuardTest.php
+++ b/Tests/Functional/Service/RegistrationGuardTest.php
@@ -5,10 +5,6 @@ declare(strict_types=1);
 namespace OliverKlee\Seminars\Tests\Functional\Service;
 
 use OliverKlee\Seminars\Service\RegistrationGuard;
-use TYPO3\CMS\Core\Core\SystemEnvironmentBuilder;
-use TYPO3\CMS\Core\Http\ServerRequestFactory;
-use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\CMS\Frontend\Authentication\FrontendUserAuthentication;
 use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
 
 /**
@@ -23,17 +19,6 @@ final class RegistrationGuardTest extends FunctionalTestCase
         'oliverklee/oelib',
         'oliverklee/seminars',
     ];
-
-    protected function setUp(): void
-    {
-        parent::setUp();
-
-        GeneralUtility::setIndpEnv('TYPO3_REQUEST_URL', 'https://www.example.com/');
-        $request = ServerRequestFactory::fromGlobals()
-            ->withAttribute('applicationType', SystemEnvironmentBuilder::REQUESTTYPE_FE)
-            ->withAttribute('frontend.user', $this->createStub(FrontendUserAuthentication::class));
-        $GLOBALS['TYPO3_REQUEST'] = $request;
-    }
 
     /**
      * @test

--- a/Tests/Unit/Controller/EventRegistrationControllerTest.php
+++ b/Tests/Unit/Controller/EventRegistrationControllerTest.php
@@ -201,7 +201,9 @@ final class EventRegistrationControllerTest extends UnitTestCase
     public function checkPrerequisitesActionForUserAlreadyRegisteredForwardsToDenyAction(): void
     {
         $userUid = 17;
-        $this->registrationGuardMock->method('getFrontEndUserUidFromSession')->willReturn($userUid);
+        $this->registrationGuardMock
+            ->method('getFrontEndUserUidFromSession')
+            ->with($this->requestStub)->willReturn($userUid);
 
         $event = new SingleEvent();
         $this->registrationGuardMock->method('isRegistrationPossibleAtAnyTimeAtAll')->with($event)->willReturn(true);
@@ -226,7 +228,9 @@ final class EventRegistrationControllerTest extends UnitTestCase
     public function checkPrerequisitesActionForFullyBookedEventWithoutWaitingListForwardsToDenyAction(): void
     {
         $userUid = 17;
-        $this->registrationGuardMock->method('getFrontEndUserUidFromSession')->willReturn($userUid);
+        $this->registrationGuardMock
+            ->method('getFrontEndUserUidFromSession')
+            ->with($this->requestStub)->willReturn($userUid);
 
         $event = new SingleEvent();
         $this->registrationGuardMock->method('isRegistrationPossibleAtAnyTimeAtAll')->with($event)->willReturn(true);
@@ -254,7 +258,9 @@ final class EventRegistrationControllerTest extends UnitTestCase
     public function checkPrerequisitesActionForFullyBookedEventWithWaitingListRedirectsToNewActionAndPassesEvent(): void
     {
         $userUid = 17;
-        $this->registrationGuardMock->method('getFrontEndUserUidFromSession')->willReturn($userUid);
+        $this->registrationGuardMock
+            ->method('getFrontEndUserUidFromSession')
+            ->with($this->requestStub)->willReturn($userUid);
 
         $event = new SingleEvent();
         $event->setWaitingList(true);
@@ -286,7 +292,9 @@ final class EventRegistrationControllerTest extends UnitTestCase
     public function checkPrerequisitesActionForNoProblemsAndInfiniteVacanciesRedirectsToNewActionAndPassesEvent(): void
     {
         $userUid = 17;
-        $this->registrationGuardMock->method('getFrontEndUserUidFromSession')->willReturn($userUid);
+        $this->registrationGuardMock
+            ->method('getFrontEndUserUidFromSession')
+            ->with($this->requestStub)->willReturn($userUid);
 
         $event = new SingleEvent();
         $this->registrationGuardMock
@@ -321,7 +329,9 @@ final class EventRegistrationControllerTest extends UnitTestCase
     public function checkPrerequisitesActionForNoProblemsAndNonZeroVacanciesRedirectsToNewActionAndPassesEvent(): void
     {
         $userUid = 17;
-        $this->registrationGuardMock->method('getFrontEndUserUidFromSession')->willReturn($userUid);
+        $this->registrationGuardMock
+            ->method('getFrontEndUserUidFromSession')
+            ->with($this->requestStub)->willReturn($userUid);
 
         $event = new SingleEvent();
         $this->registrationGuardMock
@@ -782,7 +792,7 @@ final class EventRegistrationControllerTest extends UnitTestCase
         $registration = new Registration();
         $this->registrationProcesserMock
             ->expects(self::once())->method('enrichWithMetadata')
-            ->with($registration, $event, $settings);
+            ->with($registration, $event, $settings, $this->requestStub);
 
         $this->subject->newAction($event, $registration);
     }
@@ -801,7 +811,7 @@ final class EventRegistrationControllerTest extends UnitTestCase
 
         $this->registrationProcesserMock
             ->expects(self::once())->method('enrichWithMetadata')
-            ->with($registration, $event, $settings);
+            ->with($registration, $event, $settings, $this->requestStub);
 
         $this->subject->newAction($event, null);
     }
@@ -820,7 +830,7 @@ final class EventRegistrationControllerTest extends UnitTestCase
 
         $this->registrationProcesserMock
             ->expects(self::once())->method('enrichWithMetadata')
-            ->with($registration, $event, $settings);
+            ->with($registration, $event, $settings, $this->requestStub);
 
         $this->subject->newAction($event);
     }
@@ -885,7 +895,7 @@ final class EventRegistrationControllerTest extends UnitTestCase
 
         $this->registrationProcesserMock
             ->expects(self::once())->method('enrichWithMetadata')
-            ->with($registration, $event, $settings);
+            ->with($registration, $event, $settings, $this->requestStub);
 
         $this->subject->confirmAction($event, $registration);
     }
@@ -997,7 +1007,7 @@ final class EventRegistrationControllerTest extends UnitTestCase
 
         $this->registrationProcesserMock
             ->expects(self::once())->method('enrichWithMetadata')
-            ->with($registration, $event, $settings);
+            ->with($registration, $event, $settings, $this->requestStub);
 
         $this->subject->createAction($event, $registration);
     }
@@ -1096,7 +1106,9 @@ final class EventRegistrationControllerTest extends UnitTestCase
         $registration = new Registration();
         $this->stubRedirect();
 
-        $this->oneTimeAccountConnectorMock->expects(self::once())->method('destroyOneTimeSession');
+        $this->oneTimeAccountConnectorMock
+            ->expects(self::once())->method('destroyOneTimeSession')
+            ->with($this->requestStub);
 
         $this->subject->createAction(new SingleEvent(), $registration);
     }

--- a/Tests/Unit/Service/OneTimeAccountConnectorTest.php
+++ b/Tests/Unit/Service/OneTimeAccountConnectorTest.php
@@ -7,6 +7,8 @@ namespace OliverKlee\Seminars\Tests\Unit\Service;
 use OliverKlee\Seminars\Service\OneTimeAccountConnector;
 use PHPUnit\Framework\MockObject\MockObject;
 use TYPO3\CMS\Core\Http\ServerRequest;
+use TYPO3\CMS\Extbase\Mvc\ExtbaseRequestParameters;
+use TYPO3\CMS\Extbase\Mvc\Request;
 use TYPO3\CMS\Frontend\Authentication\FrontendUserAuthentication;
 use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
 use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
@@ -17,6 +19,8 @@ use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
 final class OneTimeAccountConnectorTest extends UnitTestCase
 {
     private OneTimeAccountConnector $subject;
+
+    private Request $extbaseRequest;
 
     /**
      * @var FrontendUserAuthentication&MockObject
@@ -31,16 +35,12 @@ final class OneTimeAccountConnectorTest extends UnitTestCase
         $this->frontEndUserAuthenticationMock = $this->createMock(FrontendUserAuthentication::class);
         $mockFrontEndController->fe_user = $this->frontEndUserAuthenticationMock;
 
-        $request = (new ServerRequest())->withAttribute('frontend.user', $this->frontEndUserAuthenticationMock);
-        $GLOBALS['TYPO3_REQUEST'] = $request;
+        $serverRequest = (new ServerRequest())
+            ->withAttribute('extbase', $this->createStub(ExtbaseRequestParameters::class));
+        $this->extbaseRequest = (new Request($serverRequest))
+            ->withAttribute('frontend.user', $this->frontEndUserAuthenticationMock);
 
         $this->subject = new OneTimeAccountConnector();
-    }
-
-    protected function tearDown(): void
-    {
-        unset($GLOBALS['TYPO3_REQUEST']);
-        parent::tearDown();
     }
 
     /**
@@ -52,7 +52,7 @@ final class OneTimeAccountConnectorTest extends UnitTestCase
             ->method('getSessionData')->with('onetimeaccountUserUid')
             ->willReturn(null);
 
-        self::assertNull($this->subject->getOneTimeAccountUserUid());
+        self::assertNull($this->subject->getOneTimeAccountUserUid($this->extbaseRequest));
     }
 
     /**
@@ -62,7 +62,7 @@ final class OneTimeAccountConnectorTest extends UnitTestCase
     {
         $this->frontEndUserAuthenticationMock->method('getSessionData')->with('onetimeaccountUserUid')->willReturn('');
 
-        self::assertNull($this->subject->getOneTimeAccountUserUid());
+        self::assertNull($this->subject->getOneTimeAccountUserUid($this->extbaseRequest));
     }
 
     /**
@@ -72,7 +72,7 @@ final class OneTimeAccountConnectorTest extends UnitTestCase
     {
         $this->frontEndUserAuthenticationMock->method('getSessionData')->with('onetimeaccountUserUid')->willReturn(0);
 
-        self::assertNull($this->subject->getOneTimeAccountUserUid());
+        self::assertNull($this->subject->getOneTimeAccountUserUid($this->extbaseRequest));
     }
 
     /**
@@ -85,7 +85,7 @@ final class OneTimeAccountConnectorTest extends UnitTestCase
             ->method('getSessionData')
             ->with('onetimeaccountUserUid')->willReturn($userUid);
 
-        self::assertSame($userUid, $this->subject->getOneTimeAccountUserUid());
+        self::assertSame($userUid, $this->subject->getOneTimeAccountUserUid($this->extbaseRequest));
     }
 
     /**
@@ -97,7 +97,7 @@ final class OneTimeAccountConnectorTest extends UnitTestCase
 
         $this->frontEndUserAuthenticationMock->expects(self::never())->method('setAndSaveSessionData');
 
-        $this->subject->destroyOneTimeSession();
+        $this->subject->destroyOneTimeSession($this->extbaseRequest);
     }
 
     /**
@@ -114,7 +114,7 @@ final class OneTimeAccountConnectorTest extends UnitTestCase
             ->expects(self::once())->method('setAndSaveSessionData')
             ->with('onetimeaccountUserUid', null);
 
-        $this->subject->destroyOneTimeSession();
+        $this->subject->destroyOneTimeSession($this->extbaseRequest);
     }
 
     /**
@@ -131,6 +131,6 @@ final class OneTimeAccountConnectorTest extends UnitTestCase
             ->expects(self::once())->method('setAndSaveSessionData')
             ->with('onetimeaccountUserUid', null);
 
-        $this->subject->destroyOneTimeSession();
+        $this->subject->destroyOneTimeSession($this->extbaseRequest);
     }
 }

--- a/Tests/Unit/Service/RegistrationGuardTest.php
+++ b/Tests/Unit/Service/RegistrationGuardTest.php
@@ -14,11 +14,12 @@ use OliverKlee\Seminars\Service\EventStatisticsCalculator;
 use OliverKlee\Seminars\Service\OneTimeAccountConnector;
 use OliverKlee\Seminars\Service\RegistrationGuard;
 use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\MockObject\Stub;
+use Psr\Http\Message\ServerRequestInterface;
 use TYPO3\CMS\Core\Context\Context;
 use TYPO3\CMS\Core\Context\DateTimeAspect;
 use TYPO3\CMS\Core\Context\UserAspect;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\CMS\Extbase\Mvc\Request;
 use TYPO3\CMS\Frontend\Authentication\FrontendUserAuthentication;
 use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
 
@@ -35,6 +36,11 @@ final class RegistrationGuardTest extends UnitTestCase
     private string $now = '2022-04-01 10:00:00';
 
     private Context $context;
+
+    /**
+     * @var ServerRequestInterface&Stub
+     */
+    private ServerRequestInterface $requestStub;
 
     /**
      * @var RegistrationRepository&MockObject
@@ -58,6 +64,8 @@ final class RegistrationGuardTest extends UnitTestCase
         parent::setUp();
 
         $this->context = GeneralUtility::makeInstance(Context::class);
+
+        $this->requestStub = $this->createStub(ServerRequestInterface::class);
 
         $this->registrationRepositoryMock = $this->createMock(RegistrationRepository::class);
         $this->eventStatisticsCalculatorMock = $this->createMock(EventStatisticsCalculator::class);
@@ -483,9 +491,11 @@ final class RegistrationGuardTest extends UnitTestCase
     public function existsFrontEndUserUidInSessionForNoLoginAndNoOneTimeAccountDataReturnsFalse(): void
     {
         $this->context->setAspect('frontend.user', new UserAspect());
-        $this->oneTimeAccountConnectorMock->method('getOneTimeAccountUserUid')->willReturn(null);
+        $this->oneTimeAccountConnectorMock
+            ->method('getOneTimeAccountUserUid')
+            ->with($this->requestStub)->willReturn(null);
 
-        self::assertFalse($this->subject->existsFrontEndUserUidInSession($this->createStub(Request::class)));
+        self::assertFalse($this->subject->existsFrontEndUserUidInSession($this->requestStub));
     }
 
     /**
@@ -496,9 +506,11 @@ final class RegistrationGuardTest extends UnitTestCase
         $userAuthentication = new FrontendUserAuthentication();
         $userAuthentication->user = ['uid' => 5];
         $this->context->setAspect('frontend.user', new UserAspect($userAuthentication));
-        $this->oneTimeAccountConnectorMock->method('getOneTimeAccountUserUid')->willReturn(null);
+        $this->oneTimeAccountConnectorMock
+            ->method('getOneTimeAccountUserUid')
+            ->with($this->requestStub)->willReturn(null);
 
-        self::assertTrue($this->subject->existsFrontEndUserUidInSession($this->createStub(Request::class)));
+        self::assertTrue($this->subject->existsFrontEndUserUidInSession($this->requestStub));
     }
 
     /**
@@ -507,9 +519,11 @@ final class RegistrationGuardTest extends UnitTestCase
     public function existsFrontEndUserUidInSessionForNoLoginAndOneTimeAccountDataReturnsTrue(): void
     {
         $this->context->setAspect('frontend.user', new UserAspect());
-        $this->oneTimeAccountConnectorMock->method('getOneTimeAccountUserUid')->willReturn(5);
+        $this->oneTimeAccountConnectorMock
+            ->method('getOneTimeAccountUserUid')
+            ->with($this->requestStub)->willReturn(5);
 
-        self::assertTrue($this->subject->existsFrontEndUserUidInSession($this->createStub(Request::class)));
+        self::assertTrue($this->subject->existsFrontEndUserUidInSession($this->requestStub));
     }
 
     /**
@@ -520,9 +534,11 @@ final class RegistrationGuardTest extends UnitTestCase
         $userAuthentication = new FrontendUserAuthentication();
         $userAuthentication->user = ['uid' => 3];
         $this->context->setAspect('frontend.user', new UserAspect($userAuthentication));
-        $this->oneTimeAccountConnectorMock->method('getOneTimeAccountUserUid')->willReturn(5);
+        $this->oneTimeAccountConnectorMock
+            ->method('getOneTimeAccountUserUid')
+            ->with($this->requestStub)->willReturn(5);
 
-        self::assertTrue($this->subject->existsFrontEndUserUidInSession($this->createStub(Request::class)));
+        self::assertTrue($this->subject->existsFrontEndUserUidInSession($this->requestStub));
     }
 
     /**
@@ -531,9 +547,11 @@ final class RegistrationGuardTest extends UnitTestCase
     public function getFrontEndUserUidFromSessionForNoLoginAndNoOneTimeAccountDataReturnsNull(): void
     {
         $this->context->setAspect('frontend.user', new UserAspect());
-        $this->oneTimeAccountConnectorMock->method('getOneTimeAccountUserUid')->willReturn(null);
+        $this->oneTimeAccountConnectorMock
+            ->method('getOneTimeAccountUserUid')
+            ->with($this->requestStub)->willReturn(null);
 
-        self::assertNull($this->subject->getFrontEndUserUidFromSession());
+        self::assertNull($this->subject->getFrontEndUserUidFromSession($this->requestStub));
     }
 
     /**
@@ -546,9 +564,11 @@ final class RegistrationGuardTest extends UnitTestCase
         $userAuthentication->user = ['uid' => $userUidFromLogin];
         $this->context->setAspect('frontend.user', new UserAspect($userAuthentication));
 
-        $this->oneTimeAccountConnectorMock->method('getOneTimeAccountUserUid')->willReturn(null);
+        $this->oneTimeAccountConnectorMock
+            ->method('getOneTimeAccountUserUid')
+            ->with($this->requestStub)->willReturn(null);
 
-        self::assertSame($userUidFromLogin, $this->subject->getFrontEndUserUidFromSession());
+        self::assertSame($userUidFromLogin, $this->subject->getFrontEndUserUidFromSession($this->requestStub));
     }
 
     /**
@@ -558,9 +578,11 @@ final class RegistrationGuardTest extends UnitTestCase
     {
         $userUidFromOneTimeAccount = 12;
         $this->context->setAspect('frontend.user', new UserAspect());
-        $this->oneTimeAccountConnectorMock->method('getOneTimeAccountUserUid')->willReturn($userUidFromOneTimeAccount);
+        $this->oneTimeAccountConnectorMock
+            ->method('getOneTimeAccountUserUid')
+            ->with($this->requestStub)->willReturn($userUidFromOneTimeAccount);
 
-        self::assertSame($userUidFromOneTimeAccount, $this->subject->getFrontEndUserUidFromSession());
+        self::assertSame($userUidFromOneTimeAccount, $this->subject->getFrontEndUserUidFromSession($this->requestStub));
     }
 
     /**
@@ -574,9 +596,11 @@ final class RegistrationGuardTest extends UnitTestCase
         $this->context->setAspect('frontend.user', new UserAspect($userAuthentication));
 
         $userUidFromOneTimeAccount = 9;
-        $this->oneTimeAccountConnectorMock->method('getOneTimeAccountUserUid')->willReturn($userUidFromOneTimeAccount);
+        $this->oneTimeAccountConnectorMock
+            ->method('getOneTimeAccountUserUid')
+            ->with($this->requestStub)->willReturn($userUidFromOneTimeAccount);
 
-        self::assertSame($userUidFromLogin, $this->subject->getFrontEndUserUidFromSession());
+        self::assertSame($userUidFromLogin, $this->subject->getFrontEndUserUidFromSession($this->requestStub));
     }
 
     /**

--- a/Tests/Unit/Service/RegistrationProcessorTest.php
+++ b/Tests/Unit/Service/RegistrationProcessorTest.php
@@ -16,6 +16,8 @@ use OliverKlee\Seminars\Service\RegistrationGuard;
 use OliverKlee\Seminars\Service\RegistrationManager;
 use OliverKlee\Seminars\Service\RegistrationProcessor;
 use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\MockObject\Stub;
+use Psr\Http\Message\ServerRequestInterface;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
 
@@ -51,6 +53,11 @@ final class RegistrationProcessorTest extends UnitTestCase
 
     private RegistrationProcessor $subject;
 
+    /**
+     * @var ServerRequestInterface&Stub
+     */
+    private ServerRequestInterface $requestStub;
+
     protected function setUp(): void
     {
         parent::setUp();
@@ -60,6 +67,7 @@ final class RegistrationProcessorTest extends UnitTestCase
         $this->frontendUserRepositoryMock = $this->createMock(FrontendUserRepository::class);
         $this->registrationGuardMock = $this->createMock(RegistrationGuard::class);
         $this->registrationManagerMock = $this->createMock(RegistrationManager::class);
+        $this->requestStub = $this->createStub(ServerRequestInterface::class);
 
         $this->subject = new RegistrationProcessor(
             $this->registrationRepositoryMock,
@@ -84,10 +92,10 @@ final class RegistrationProcessorTest extends UnitTestCase
     {
         $event = new SingleEvent();
         $registration = new Registration();
-        $this->registrationGuardMock->method('getFrontEndUserUidFromSession')->willReturn(15);
+        $this->registrationGuardMock->method('getFrontEndUserUidFromSession')->with($this->requestStub)->willReturn(15);
         $this->frontendUserRepositoryMock->method('findByUid')->with(self::anything())->willReturn(new FrontendUser());
 
-        $this->subject->enrichWithMetadata($registration, $event, []);
+        $this->subject->enrichWithMetadata($registration, $event, [], $this->requestStub);
 
         self::assertSame($event, $registration->getEvent());
     }
@@ -102,12 +110,12 @@ final class RegistrationProcessorTest extends UnitTestCase
         $user = new FrontendUser();
         $this->registrationGuardMock
             ->expects(self::once())->method('getFrontEndUserUidFromSession')
-            ->willReturn($userUid);
+            ->with($this->requestStub)->willReturn($userUid);
         $this->frontendUserRepositoryMock
             ->expects(self::once())->method('findByUid')
             ->with($userUid)->willReturn($user);
 
-        $this->subject->enrichWithMetadata($registration, new SingleEvent(), []);
+        $this->subject->enrichWithMetadata($registration, new SingleEvent(), [], $this->requestStub);
 
         self::assertSame($user, $registration->getUser());
     }
@@ -120,13 +128,13 @@ final class RegistrationProcessorTest extends UnitTestCase
         $registration = new Registration();
         $this->registrationGuardMock
             ->expects(self::once())->method('getFrontEndUserUidFromSession')
-            ->willReturn(null);
+            ->with($this->requestStub)->willReturn(null);
 
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionCode(1668865776);
         $this->expectExceptionMessage('No user UID found in the session.');
 
-        $this->subject->enrichWithMetadata($registration, new SingleEvent(), []);
+        $this->subject->enrichWithMetadata($registration, new SingleEvent(), [], $this->requestStub);
     }
 
     /**
@@ -138,7 +146,7 @@ final class RegistrationProcessorTest extends UnitTestCase
         $registration = new Registration();
         $this->registrationGuardMock
             ->expects(self::once())->method('getFrontEndUserUidFromSession')
-            ->willReturn($userUid);
+            ->with($this->requestStub)->willReturn($userUid);
         $this->frontendUserRepositoryMock
             ->expects(self::once())->method('findByUid')
             ->with($userUid)->willReturn(null);
@@ -147,7 +155,7 @@ final class RegistrationProcessorTest extends UnitTestCase
         $this->expectExceptionCode(1668865839);
         $this->expectExceptionMessage('User with UID ' . $userUid . ' not found.');
 
-        $this->subject->enrichWithMetadata($registration, new SingleEvent(), []);
+        $this->subject->enrichWithMetadata($registration, new SingleEvent(), [], $this->requestStub);
     }
 
     /**
@@ -157,13 +165,14 @@ final class RegistrationProcessorTest extends UnitTestCase
     {
         $folderUid = 21;
         $registration = new Registration();
-        $this->registrationGuardMock->method('getFrontEndUserUidFromSession')->willReturn(15);
+        $this->registrationGuardMock->method('getFrontEndUserUidFromSession')->with($this->requestStub)->willReturn(15);
         $this->frontendUserRepositoryMock->method('findByUid')->with(self::anything())->willReturn(new FrontendUser());
 
         $this->subject->enrichWithMetadata(
             $registration,
             new SingleEvent(),
             ['registrationRecordsStorageFolder' => (string)$folderUid],
+            $this->requestStub,
         );
 
         self::assertSame($folderUid, $registration->getPid());
@@ -586,16 +595,16 @@ final class RegistrationProcessorTest extends UnitTestCase
     /**
      * @test
      */
-    public function enrichWithForEventWithVacanciesWithoutWaitingListKeepsRegistrationRegular(): void
+    public function enrichWithMetadataForEventWithVacanciesWithoutWaitingListKeepsRegistrationRegular(): void
     {
         $event = new SingleEvent();
         $event->setWaitingList(false);
         $registration = new Registration();
-        $this->registrationGuardMock->method('getFrontEndUserUidFromSession')->willReturn(15);
+        $this->registrationGuardMock->method('getFrontEndUserUidFromSession')->with($this->requestStub)->willReturn(15);
         $this->registrationGuardMock->method('getVacancies')->with($event)->willReturn(1);
         $this->frontendUserRepositoryMock->method('findByUid')->with(self::anything())->willReturn(new FrontendUser());
 
-        $this->subject->enrichWithMetadata($registration, $event, []);
+        $this->subject->enrichWithMetadata($registration, $event, [], $this->requestStub);
 
         self::assertFalse($registration->isOnWaitingList());
     }
@@ -603,16 +612,16 @@ final class RegistrationProcessorTest extends UnitTestCase
     /**
      * @test
      */
-    public function enrichWithForEventWithUnlimitedVacanciesWithoutWaitingListKeepsRegistrationRegular(): void
+    public function enrichWithMetadataForEventWithUnlimitedVacanciesWithoutWaitingListKeepsRegistrationRegular(): void
     {
         $event = new SingleEvent();
         $event->setWaitingList(false);
         $registration = new Registration();
-        $this->registrationGuardMock->method('getFrontEndUserUidFromSession')->willReturn(15);
+        $this->registrationGuardMock->method('getFrontEndUserUidFromSession')->with($this->requestStub)->willReturn(15);
         $this->registrationGuardMock->method('getVacancies')->with($event)->willReturn(null);
         $this->frontendUserRepositoryMock->method('findByUid')->with(self::anything())->willReturn(new FrontendUser());
 
-        $this->subject->enrichWithMetadata($registration, $event, []);
+        $this->subject->enrichWithMetadata($registration, $event, [], $this->requestStub);
 
         self::assertFalse($registration->isOnWaitingList());
     }
@@ -622,16 +631,16 @@ final class RegistrationProcessorTest extends UnitTestCase
      *
      * In the future, we should catch this case and redirect to the previous page (or the error page).
      */
-    public function enrichWithForEventWithZeroVacanciesWithoutWaitingListKeepsRegistrationRegular(): void
+    public function enrichWithMetadataForEventWithZeroVacanciesWithoutWaitingListKeepsRegistrationRegular(): void
     {
         $event = new SingleEvent();
         $event->setWaitingList(false);
         $registration = new Registration();
-        $this->registrationGuardMock->method('getFrontEndUserUidFromSession')->willReturn(15);
+        $this->registrationGuardMock->method('getFrontEndUserUidFromSession')->with($this->requestStub)->willReturn(15);
         $this->registrationGuardMock->method('getVacancies')->with($event)->willReturn(0);
         $this->frontendUserRepositoryMock->method('findByUid')->with(self::anything())->willReturn(new FrontendUser());
 
-        $this->subject->enrichWithMetadata($registration, $event, []);
+        $this->subject->enrichWithMetadata($registration, $event, [], $this->requestStub);
 
         self::assertFalse($registration->isOnWaitingList());
     }
@@ -639,16 +648,16 @@ final class RegistrationProcessorTest extends UnitTestCase
     /**
      * @test
      */
-    public function enrichWithForEventWithVacanciesWithWaitingListKeepsRegistrationRegular(): void
+    public function enrichWithMetadataForEventWithVacanciesWithWaitingListKeepsRegistrationRegular(): void
     {
         $event = new SingleEvent();
         $event->setWaitingList(true);
         $registration = new Registration();
-        $this->registrationGuardMock->method('getFrontEndUserUidFromSession')->willReturn(15);
+        $this->registrationGuardMock->method('getFrontEndUserUidFromSession')->with($this->requestStub)->willReturn(15);
         $this->registrationGuardMock->method('getVacancies')->with($event)->willReturn(1);
         $this->frontendUserRepositoryMock->method('findByUid')->with(self::anything())->willReturn(new FrontendUser());
 
-        $this->subject->enrichWithMetadata($registration, $event, []);
+        $this->subject->enrichWithMetadata($registration, $event, [], $this->requestStub);
 
         self::assertFalse($registration->isOnWaitingList());
     }
@@ -656,16 +665,16 @@ final class RegistrationProcessorTest extends UnitTestCase
     /**
      * @test
      */
-    public function enrichWithForEventWithUnlimitedVacanciesWithWaitingListKeepsRegistrationRegular(): void
+    public function enrichWithMetadataForEventWithUnlimitedVacanciesWithWaitingListKeepsRegistrationRegular(): void
     {
         $event = new SingleEvent();
         $event->setWaitingList(true);
         $registration = new Registration();
-        $this->registrationGuardMock->method('getFrontEndUserUidFromSession')->willReturn(15);
+        $this->registrationGuardMock->method('getFrontEndUserUidFromSession')->with($this->requestStub)->willReturn(15);
         $this->registrationGuardMock->method('getVacancies')->with($event)->willReturn(null);
         $this->frontendUserRepositoryMock->method('findByUid')->with(self::anything())->willReturn(new FrontendUser());
 
-        $this->subject->enrichWithMetadata($registration, $event, []);
+        $this->subject->enrichWithMetadata($registration, $event, [], $this->requestStub);
 
         self::assertFalse($registration->isOnWaitingList());
     }
@@ -675,16 +684,16 @@ final class RegistrationProcessorTest extends UnitTestCase
      *
      * In the future, we should catch this case and redirect to the previous page (or the error page).
      */
-    public function enrichWithForEventWithZeroVacanciesWithWaitingListMovesRegistrationToWaitingList(): void
+    public function enrichWithMetadataForEventWithZeroVacanciesWithWaitingListMovesRegistrationToWaitingList(): void
     {
         $event = new SingleEvent();
         $event->setWaitingList(true);
         $registration = new Registration();
-        $this->registrationGuardMock->method('getFrontEndUserUidFromSession')->willReturn(15);
+        $this->registrationGuardMock->method('getFrontEndUserUidFromSession')->with($this->requestStub)->willReturn(15);
         $this->registrationGuardMock->method('getVacancies')->with($event)->willReturn(0);
         $this->frontendUserRepositoryMock->method('findByUid')->with(self::anything())->willReturn(new FrontendUser());
 
-        $this->subject->enrichWithMetadata($registration, $event, []);
+        $this->subject->enrichWithMetadata($registration, $event, [], $this->requestStub);
 
         self::assertTrue($registration->isOnWaitingList());
     }


### PR DESCRIPTION
The `OneTimeAccountConnector` class is a service and hence should have no state. The request is state, though, and hence needs to be passed for each call.

Also add missing words to some test names.

Fixes #5035