### PR TITLE
[TASK] Use more DI in `RegistrationManager`

### DIFF
--- a/Classes/Service/RegistrationManager.php
+++ b/Classes/Service/RegistrationManager.php
@@ -47,16 +47,32 @@ class RegistrationManager implements SingletonInterface
 
     private Context $context;
 
-    private ?Configuration $sharedPluginConfiguration = null;
+    private EventRepository $eventRepository;
+
+    private RegistrationMapper $registrationMapper;
+
+    private TemplateRegistry $templateRegistry;
+
+    private Configuration $sharedPluginConfiguration;
 
     private ?Template $emailTemplate = null;
 
     protected ?HookProvider $registrationEmailHookProvider = null;
 
-    public function __construct(ConnectionPool $connectionPool, Context $context)
-    {
+    public function __construct(
+        ConnectionPool $connectionPool,
+        Context $context,
+        EventRepository $eventRepository,
+        MapperRegistry $mapperRegistry,
+        TemplateRegistry $templateRegistry,
+        ConfigurationRegistry $configurationRegistry
+    ) {
         $this->connectionPool = $connectionPool;
         $this->context = $context;
+        $this->eventRepository = $eventRepository;
+        $this->registrationMapper = $mapperRegistry->getByClassName(RegistrationMapper::class);
+        $this->templateRegistry = $templateRegistry;
+        $this->sharedPluginConfiguration = $configurationRegistry->getByNamespace('plugin.tx_seminars');
     }
 
     private function isLoggedIn(): bool
@@ -273,7 +289,7 @@ class RegistrationManager implements SingletonInterface
             $this->notifyOrganizers($registration);
         }
 
-        if ($this->getSharedConfiguration()->getAsBoolean('sendAdditionalNotificationEmails')) {
+        if ($this->sharedPluginConfiguration->getAsBoolean('sendAdditionalNotificationEmails')) {
             $this->sendAdditionalNotification($registration);
         }
     }
@@ -312,7 +328,7 @@ class RegistrationManager implements SingletonInterface
      */
     private function fillVacancies(LegacyRegistration $unregistration): void
     {
-        if (!$this->getSharedConfiguration()->getAsBoolean('automaticallyFillVacanciesOnUnregistration')) {
+        if (!$this->sharedPluginConfiguration->getAsBoolean('automaticallyFillVacanciesOnUnregistration')) {
             return;
         }
         $seminar = $unregistration->getSeminarObject();
@@ -329,7 +345,6 @@ class RegistrationManager implements SingletonInterface
         $registrationBagBuilder->limitToOnQueue();
         $registrationBagBuilder->limitToSeatsAtMost($vacancies);
 
-        $configuration = $this->getSharedConfiguration();
         foreach ($registrationBagBuilder->build() as $registration) {
             if ($vacancies <= 0) {
                 break;
@@ -346,7 +361,7 @@ class RegistrationManager implements SingletonInterface
                 $this->notifyAttendee($registration, 'confirmationOnQueueUpdate');
                 $this->notifyOrganizers($registration, 'notificationOnQueueUpdate');
 
-                if ($configuration->getAsBoolean('sendAdditionalNotificationEmails')) {
+                if ($this->sharedPluginConfiguration->getAsBoolean('sendAdditionalNotificationEmails')) {
                     $this->sendAdditionalNotification($registration);
                 }
             }
@@ -363,7 +378,7 @@ class RegistrationManager implements SingletonInterface
         LegacyRegistration $oldRegistration,
         string $helloSubjectPrefix = 'confirmation'
     ): void {
-        if (!$this->getSharedConfiguration()->getAsBoolean('send' . ucfirst($helloSubjectPrefix))) {
+        if (!$this->sharedPluginConfiguration->getAsBoolean('send' . ucfirst($helloSubjectPrefix))) {
             return;
         }
 
@@ -390,8 +405,7 @@ class RegistrationManager implements SingletonInterface
 
         $registrationUid = $oldRegistration->getUid();
         \assert($registrationUid > 0);
-        $registration = GeneralUtility::makeInstance(MapperRegistry::class)->getByClassName(RegistrationMapper::class)
-            ->find($registrationUid);
+        $registration = $this->registrationMapper->find($registrationUid);
         $this->addCalendarAttachment($emailBuilder, $event->getUid());
         $email = $emailBuilder->build();
 
@@ -424,7 +438,7 @@ class RegistrationManager implements SingletonInterface
      */
     private function addCalendarAttachment(EmailBuilder $emailBuilder, int $eventUid): void
     {
-        $event = $this->getEventRepository()->findByUid($eventUid);
+        $event = $this->eventRepository->findByUid($eventUid);
         if (!$event instanceof EventDateInterface) {
             return;
         }
@@ -468,11 +482,6 @@ class RegistrationManager implements SingletonInterface
         $emailBuilder->attach($content, 'text/calendar; charset="utf-8"; component="vevent"; method="publish"');
     }
 
-    private function getEventRepository(): EventRepository
-    {
-        return GeneralUtility::makeInstance(EventRepository::class);
-    }
-
     /**
      * @return non-empty-string
      */
@@ -493,8 +502,7 @@ class RegistrationManager implements SingletonInterface
         LegacyRegistration $registration,
         string $helloSubjectPrefix = 'notification'
     ): void {
-        $configuration = $this->getSharedConfiguration();
-        if (!$configuration->getAsBoolean('send' . ucfirst($helloSubjectPrefix))) {
+        if (!$this->sharedPluginConfiguration->getAsBoolean('send' . ucfirst($helloSubjectPrefix))) {
             return;
         }
         if (!$registration->hasExistingFrontEndUser()) {
@@ -522,34 +530,41 @@ class RegistrationManager implements SingletonInterface
         $emailBuilder->to(...$recipients);
 
         $template = $this->getInitializedEmailTemplate();
-        $template->hideSubparts($configuration->getAsString('hideFieldsInNotificationMail'), 'field_wrapper');
+        $template->hideSubparts(
+            $this->sharedPluginConfiguration->getAsString('hideFieldsInNotificationMail'),
+            'field_wrapper',
+        );
 
         $template->setMarker('hello', $this->translate('email_' . $helloSubjectPrefix . 'Hello'));
         $template->setMarker('summary', $registration->getTitle());
 
-        if ($configuration->hasString('showSeminarFieldsInNotificationMail')) {
+        if ($this->sharedPluginConfiguration->hasString('showSeminarFieldsInNotificationMail')) {
             $template->setMarker(
                 'seminardata',
-                $event->dumpSeminarValues($configuration->getAsString('showSeminarFieldsInNotificationMail')),
+                $event->dumpSeminarValues(
+                    $this->sharedPluginConfiguration->getAsString('showSeminarFieldsInNotificationMail'),
+                ),
             );
         } else {
             $template->hideSubparts('seminardata', 'field_wrapper');
         }
 
-        if ($configuration->hasString('showFeUserFieldsInNotificationMail')) {
+        if ($this->sharedPluginConfiguration->hasString('showFeUserFieldsInNotificationMail')) {
             $template->setMarker(
                 'feuserdata',
-                $registration->dumpUserValues($configuration->getAsString('showFeUserFieldsInNotificationMail')),
+                $registration->dumpUserValues(
+                    $this->sharedPluginConfiguration->getAsString('showFeUserFieldsInNotificationMail'),
+                ),
             );
         } else {
             $template->hideSubparts('feuserdata', 'field_wrapper');
         }
 
-        if ($configuration->hasString('showAttendanceFieldsInNotificationMail')) {
+        if ($this->sharedPluginConfiguration->hasString('showAttendanceFieldsInNotificationMail')) {
             $template->setMarker(
                 'attendancedata',
                 $registration->dumpAttendanceValues(
-                    $configuration->getAsString('showAttendanceFieldsInNotificationMail'),
+                    $this->sharedPluginConfiguration->getAsString('showAttendanceFieldsInNotificationMail'),
                 ),
             );
         } else {
@@ -560,8 +575,7 @@ class RegistrationManager implements SingletonInterface
 
         $registrationUid = $registration->getUid();
         \assert($registrationUid > 0);
-        $registrationNew = GeneralUtility::makeInstance(MapperRegistry::class)
-            ->getByClassName(RegistrationMapper::class)->find($registrationUid);
+        $registrationNew = $this->registrationMapper->find($registrationUid);
 
         $email = $emailBuilder->build();
         $this
@@ -619,8 +633,7 @@ class RegistrationManager implements SingletonInterface
 
         $registrationUid = $registration->getUid();
         \assert($registrationUid > 0);
-        $registrationNew = GeneralUtility::makeInstance(MapperRegistry::class)
-            ->getByClassName(RegistrationMapper::class)->find($registrationUid);
+        $registrationNew = $this->registrationMapper->find($registrationUid);
 
         $email = $emailBuilder->build();
         $this
@@ -680,7 +693,7 @@ class RegistrationManager implements SingletonInterface
         $template = $this->getInitializedEmailTemplate();
 
         $template->setMarker('message', $this->translate($localLanguageKey));
-        $showSeminarFields = $this->getSharedConfiguration()->getAsString('showSeminarFieldsInNotificationMail');
+        $showSeminarFields = $this->sharedPluginConfiguration->getAsString('showSeminarFieldsInNotificationMail');
         if ($showSeminarFields !== '') {
             $template->setMarker(
                 'seminardata',
@@ -706,8 +719,8 @@ class RegistrationManager implements SingletonInterface
             return $this->emailTemplate;
         }
 
-        $templateFileName = $this->getSharedConfiguration()->getAsString('templateFile');
-        $template = GeneralUtility::makeInstance(TemplateRegistry::class)->getByFileName($templateFileName);
+        $templateFileName = $this->sharedPluginConfiguration->getAsString('templateFile');
+        $template = $this->templateRegistry->getByFileName($templateFileName);
         foreach ($template->getLabelMarkerNames() as $label) {
             $template->setMarker($label, $this->translate($label));
         }
@@ -741,7 +754,7 @@ class RegistrationManager implements SingletonInterface
         $template = $this->getInitializedEmailTemplate();
         $template->setMarker('html_mail_charset', 'utf-8');
         $template->hideSubparts(
-            $this->getSharedConfiguration()->getAsString('hideFieldsInThankYouMail'),
+            $this->sharedPluginConfiguration->getAsString('hideFieldsInThankYouMail'),
             $wrapperPrefix,
         );
 
@@ -864,7 +877,7 @@ class RegistrationManager implements SingletonInterface
 
         $eventUid = $event->getUid();
         \assert($eventUid > 0);
-        $newEvent = $this->getEventRepository()->findByUid($eventUid);
+        $newEvent = $this->eventRepository->findByUid($eventUid);
         \assert($newEvent instanceof EventDateInterface);
         if ($newEvent->hasUsableWebinarUrl()) {
             $template->unhideSubparts('webinar_url', $wrapperPrefix);
@@ -911,8 +924,7 @@ class RegistrationManager implements SingletonInterface
 
         $registrationUid = $registration->getUid();
         \assert($registrationUid > 0);
-        $registrationNew = GeneralUtility::makeInstance(MapperRegistry::class)
-            ->getByClassName(RegistrationMapper::class)->find($registrationUid);
+        $registrationNew = $this->registrationMapper->find($registrationUid);
 
         $this->getRegistrationEmailHookProvider()->executeHook(
             $useHtml ? 'modifyAttendeeEmailBodyHtml' : 'modifyAttendeeEmailBodyPlainText',
@@ -943,13 +955,13 @@ class RegistrationManager implements SingletonInterface
     {
         // The CSS inlining uses a Composer-provided library and hence is a Composer-only feature.
         if (
-            !$this->getSharedConfiguration()->hasString('cssFileForAttendeeMail')
+            !$this->sharedPluginConfiguration->hasString('cssFileForAttendeeMail')
             || !\class_exists(CssInliner::class)
         ) {
             return $emailBody;
         }
 
-        $cssFile = $this->getSharedConfiguration()->getAsString('cssFileForAttendeeMail');
+        $cssFile = $this->sharedPluginConfiguration->getAsString('cssFileForAttendeeMail');
         $absolutePath = GeneralUtility::getFileAbsFileName($cssFile);
         if (\is_readable($absolutePath)) {
             $css = \file_get_contents($absolutePath);
@@ -1189,7 +1201,7 @@ class RegistrationManager implements SingletonInterface
      */
     private function translate(string $key): string
     {
-        $salutationSuffix = '_' . $this->getSharedConfiguration()->getAsString('salutation');
+        $salutationSuffix = '_' . $this->sharedPluginConfiguration->getAsString('salutation');
         $labelWithSalutation = LocalizationUtility::translate($key . $salutationSuffix, 'seminars');
         $labelWithoutSalutation = LocalizationUtility::translate($key, 'seminars');
 
@@ -1209,15 +1221,5 @@ class RegistrationManager implements SingletonInterface
         \assert($now > 0);
 
         return $now;
-    }
-
-    private function getSharedConfiguration(): Configuration
-    {
-        if (!$this->sharedPluginConfiguration instanceof Configuration) {
-            $this->sharedPluginConfiguration = GeneralUtility::makeInstance(ConfigurationRegistry::class)
-                ->getByNamespace('plugin.tx_seminars');
-        }
-
-        return $this->sharedPluginConfiguration;
     }
 }

--- a/Tests/LegacyFunctional/Service/RegistrationManagerTest.php
+++ b/Tests/LegacyFunctional/Service/RegistrationManagerTest.php
@@ -7,9 +7,11 @@ namespace OliverKlee\Seminars\Tests\LegacyFunctional\Service;
 use OliverKlee\Oelib\Configuration\ConfigurationRegistry;
 use OliverKlee\Oelib\Configuration\DummyConfiguration;
 use OliverKlee\Oelib\Mapper\MapperRegistry;
+use OliverKlee\Oelib\Templating\TemplateRegistry;
 use OliverKlee\Oelib\Testing\TestingFramework;
 use OliverKlee\Seminars\Domain\Model\Event\EventInterface;
 use OliverKlee\Seminars\Domain\Model\Registration\Registration;
+use OliverKlee\Seminars\Domain\Repository\Event\EventRepository;
 use OliverKlee\Seminars\Hooks\Interfaces\RegistrationEmail;
 use OliverKlee\Seminars\Mapper\RegistrationMapper;
 use OliverKlee\Seminars\Model\FrontEndUser;
@@ -51,13 +53,21 @@ final class RegistrationManagerTest extends FunctionalTestCase
 
     private ConnectionPool $connectionPool;
 
+    private EventRepository $eventRepository;
+
     private int $nowAsUnixTimestamp;
 
     private RegistrationManager $subject;
 
     private TestingFramework $testingFramework;
 
+    private MapperRegistry $mapperRegistry;
+
     private RegistrationMapper $registrationMapper;
+
+    private TemplateRegistry $templateRegistry;
+
+    private ConfigurationRegistry $configurationRegistry;
 
     /**
      * @var positive-int
@@ -96,6 +106,10 @@ final class RegistrationManagerTest extends FunctionalTestCase
 
         $this->connectionPool = $this->get(ConnectionPool::class);
         $this->context = $this->get(Context::class);
+        $this->eventRepository = $this->get(EventRepository::class);
+        $this->mapperRegistry = $this->get(MapperRegistry::class);
+        $this->templateRegistry = $this->get(TemplateRegistry::class);
+        $this->configurationRegistry = $this->get(ConfigurationRegistry::class);
 
         $now = new \DateTimeImmutable('2018-04-26 12:42:23');
         $this->context->setAspect('date', new DateTimeAspect($now));
@@ -106,7 +120,7 @@ final class RegistrationManagerTest extends FunctionalTestCase
         $this->extConfBackup = $GLOBALS['TYPO3_CONF_VARS']['EXTCONF'];
 
         $this->testingFramework = $this->get(TestingFramework::class);
-        $this->registrationMapper = $this->get(MapperRegistry::class)->getByClassName(RegistrationMapper::class);
+        $this->registrationMapper = $this->mapperRegistry->getByClassName(RegistrationMapper::class);
 
         $this->rootPageUid = $this->testingFramework->createFrontEndPage();
         $this->testingFramework->changeRecord('pages', $this->rootPageUid, ['slug' => '/home']);
@@ -118,16 +132,15 @@ final class RegistrationManagerTest extends FunctionalTestCase
         $this->addMockedInstance(MailMessage::class, $this->email);
         $this->addMockedInstance(MailMessage::class, $secondEmail);
 
-        $configurationRegistry = $this->get(ConfigurationRegistry::class);
         $this->configuration = new DummyConfiguration(
             [
                 'templateFile' => 'EXT:seminars/Resources/Private/Templates/Mail/e-mail.html',
             ],
         );
-        $configurationRegistry->set('plugin.tx_seminars', $this->configuration);
-        $configurationRegistry->set('plugin.tx_seminars._LOCAL_LANG.default', new DummyConfiguration());
-        $configurationRegistry->set('config', new DummyConfiguration());
-        $configurationRegistry->set('page.config', new DummyConfiguration());
+        $this->configurationRegistry->set('plugin.tx_seminars', $this->configuration);
+        $this->configurationRegistry->set('plugin.tx_seminars._LOCAL_LANG.default', new DummyConfiguration());
+        $this->configurationRegistry->set('config', new DummyConfiguration());
+        $this->configurationRegistry->set('page.config', new DummyConfiguration());
 
         $organizerUid = $this->testingFramework->createRecord(
             'tx_seminars_organizers',
@@ -947,7 +960,16 @@ final class RegistrationManagerTest extends FunctionalTestCase
         $subject = $this
             ->getMockBuilder(RegistrationManager::class)
             ->onlyMethods(['getUnregistrationNotice'])
-            ->setConstructorArgs([$this->connectionPool, $this->context])
+            ->setConstructorArgs(
+                [
+                    $this->connectionPool,
+                    $this->context,
+                    $this->eventRepository,
+                    $this->mapperRegistry,
+                    $this->templateRegistry,
+                    $this->configurationRegistry,
+                ],
+            )
             ->getMock();
         $subject->expects(self::never())->method('getUnregistrationNotice');
 
@@ -974,7 +996,16 @@ final class RegistrationManagerTest extends FunctionalTestCase
     {
         $subject = $this
             ->getMockBuilder(RegistrationManager::class)
-            ->setConstructorArgs([$this->connectionPool, $this->context])
+            ->setConstructorArgs(
+                [
+                    $this->connectionPool,
+                    $this->context,
+                    $this->eventRepository,
+                    $this->mapperRegistry,
+                    $this->templateRegistry,
+                    $this->configurationRegistry,
+                ],
+            )
             ->onlyMethods(['getUnregistrationNotice'])->getMock();
         $subject->expects(self::never())->method('getUnregistrationNotice');
         $this->configuration->setAsBoolean('sendConfirmation', true);
@@ -996,7 +1027,16 @@ final class RegistrationManagerTest extends FunctionalTestCase
     {
         $subject = $this
             ->getMockBuilder(RegistrationManager::class)
-            ->setConstructorArgs([$this->connectionPool, $this->context])
+            ->setConstructorArgs(
+                [
+                    $this->connectionPool,
+                    $this->context,
+                    $this->eventRepository,
+                    $this->mapperRegistry,
+                    $this->templateRegistry,
+                    $this->configurationRegistry,
+                ],
+            )
             ->onlyMethods(['getUnregistrationNotice'])->getMock();
         $subject->expects(self::atLeast(1))->method('getUnregistrationNotice');
         $this->configuration->setAsBoolean('sendConfirmation', true);
@@ -1025,7 +1065,16 @@ final class RegistrationManagerTest extends FunctionalTestCase
 
         $subject = $this
             ->getMockBuilder(RegistrationManager::class)
-            ->setConstructorArgs([$this->connectionPool, $this->context])
+            ->setConstructorArgs(
+                [
+                    $this->connectionPool,
+                    $this->context,
+                    $this->eventRepository,
+                    $this->mapperRegistry,
+                    $this->templateRegistry,
+                    $this->configurationRegistry,
+                ],
+            )
             ->onlyMethods(['getUnregistrationNotice'])->getMock();
         $subject->expects(self::atLeast(1))->method('getUnregistrationNotice');
 
@@ -1062,7 +1111,16 @@ final class RegistrationManagerTest extends FunctionalTestCase
 
         $subject = $this
             ->getMockBuilder(RegistrationManager::class)
-            ->setConstructorArgs([$this->connectionPool, $this->context])
+            ->setConstructorArgs(
+                [
+                    $this->connectionPool,
+                    $this->context,
+                    $this->eventRepository,
+                    $this->mapperRegistry,
+                    $this->templateRegistry,
+                    $this->configurationRegistry,
+                ],
+            )
             ->onlyMethods(['getUnregistrationNotice'])->getMock();
         $subject->expects(self::atLeast(1))->method('getUnregistrationNotice');
 


### PR DESCRIPTION
This is a preparational cleanup for decoupling the registration process from the FE registration form.

Part of #3605
Part of #4916