### PR TITLE
[TASK] Do not back up the environment in functional tests anymore

### DIFF
--- a/Build/phpstan/phpstan-baseline.neon
+++ b/Build/phpstan/phpstan-baseline.neon
@@ -1411,33 +1411,8 @@ parameters:
 			path: ../../Tests/Functional/Domain/Repository/Event/EventRepositoryTest.php
 
 		-
-			message: "#^Cannot access offset 'EXTCONF' on mixed\\.$#"
-			count: 3
-			path: ../../Tests/Functional/Domain/Repository/Event/EventRepositoryTest.php
-
-		-
-			message: "#^Cannot access offset 'getUserObj' on mixed\\.$#"
-			count: 2
-			path: ../../Tests/Functional/Domain/Repository/Event/EventRepositoryTest.php
-
-		-
-			message: "#^Cannot access offset 'seminars' on mixed\\.$#"
-			count: 1
-			path: ../../Tests/Functional/Domain/Repository/Event/EventRepositoryTest.php
-
-		-
 			message: "#^Parameter \\#1 \\$event of method OliverKlee\\\\Seminars\\\\Domain\\\\Repository\\\\Event\\\\EventRepository\\:\\:updateRegistrationCounterCache\\(\\) expects OliverKlee\\\\Seminars\\\\Domain\\\\Model\\\\Event\\\\Event, OliverKlee\\\\Seminars\\\\Domain\\\\Model\\\\Event\\\\Event\\|null given\\.$#"
 			count: 4
-			path: ../../Tests/Functional/Domain/Repository/Event/EventRepositoryTest.php
-
-		-
-			message: "#^Property OliverKlee\\\\Seminars\\\\Tests\\\\Functional\\\\Domain\\\\Repository\\\\Event\\\\EventRepositoryTest\\:\\:\\$extConfBackup type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: ../../Tests/Functional/Domain/Repository/Event/EventRepositoryTest.php
-
-		-
-			message: "#^Property OliverKlee\\\\Seminars\\\\Tests\\\\Functional\\\\Domain\\\\Repository\\\\Event\\\\EventRepositoryTest\\:\\:\\$t3VarBackup type has no value type specified in iterable type array\\.$#"
-			count: 1
 			path: ../../Tests/Functional/Domain/Repository/Event/EventRepositoryTest.php
 
 		-
@@ -1446,33 +1421,8 @@ parameters:
 			path: ../../Tests/Functional/Domain/Repository/Registration/RegistrationRepositoryTest.php
 
 		-
-			message: "#^Cannot access offset 'EXTCONF' on mixed\\.$#"
-			count: 3
-			path: ../../Tests/Functional/Domain/Repository/Registration/RegistrationRepositoryTest.php
-
-		-
-			message: "#^Cannot access offset 'getUserObj' on mixed\\.$#"
-			count: 2
-			path: ../../Tests/Functional/Domain/Repository/Registration/RegistrationRepositoryTest.php
-
-		-
-			message: "#^Cannot access offset 'seminars' on mixed\\.$#"
-			count: 1
-			path: ../../Tests/Functional/Domain/Repository/Registration/RegistrationRepositoryTest.php
-
-		-
 			message: "#^Parameter \\#1 \\$event of method OliverKlee\\\\Seminars\\\\Domain\\\\Repository\\\\Registration\\\\RegistrationRepository\\:\\:existsRegistrationForEventAndUser\\(\\) expects OliverKlee\\\\Seminars\\\\Domain\\\\Model\\\\Event\\\\EventInterface, OliverKlee\\\\Seminars\\\\Domain\\\\Model\\\\Event\\\\Event\\|null given\\.$#"
 			count: 7
-			path: ../../Tests/Functional/Domain/Repository/Registration/RegistrationRepositoryTest.php
-
-		-
-			message: "#^Property OliverKlee\\\\Seminars\\\\Tests\\\\Functional\\\\Domain\\\\Repository\\\\Registration\\\\RegistrationRepositoryTest\\:\\:\\$extConfBackup type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: ../../Tests/Functional/Domain/Repository/Registration/RegistrationRepositoryTest.php
-
-		-
-			message: "#^Property OliverKlee\\\\Seminars\\\\Tests\\\\Functional\\\\Domain\\\\Repository\\\\Registration\\\\RegistrationRepositoryTest\\:\\:\\$t3VarBackup type has no value type specified in iterable type array\\.$#"
-			count: 1
 			path: ../../Tests/Functional/Domain/Repository/Registration/RegistrationRepositoryTest.php
 
 		-
@@ -1507,7 +1457,7 @@ parameters:
 
 		-
 			message: "#^Cannot access offset 'EXTCONF' on mixed\\.$#"
-			count: 7
+			count: 4
 			path: ../../Tests/Functional/Hooks/DataHandlerHookTest.php
 
 		-
@@ -1541,13 +1491,8 @@ parameters:
 			path: ../../Tests/Functional/Hooks/DataHandlerHookTest.php
 
 		-
-			message: "#^Cannot access offset 'getUserObj' on mixed\\.$#"
-			count: 2
-			path: ../../Tests/Functional/Hooks/DataHandlerHookTest.php
-
-		-
 			message: "#^Cannot access offset 'seminars' on mixed\\.$#"
-			count: 7
+			count: 6
 			path: ../../Tests/Functional/Hooks/DataHandlerHookTest.php
 
 		-
@@ -1568,16 +1513,6 @@ parameters:
 		-
 			message: "#^Cannot cast mixed to string\\.$#"
 			count: 2
-			path: ../../Tests/Functional/Hooks/DataHandlerHookTest.php
-
-		-
-			message: "#^Property OliverKlee\\\\Seminars\\\\Tests\\\\Functional\\\\Hooks\\\\DataHandlerHookTest\\:\\:\\$extConfBackup type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: ../../Tests/Functional/Hooks/DataHandlerHookTest.php
-
-		-
-			message: "#^Property OliverKlee\\\\Seminars\\\\Tests\\\\Functional\\\\Hooks\\\\DataHandlerHookTest\\:\\:\\$t3VarBackup type has no value type specified in iterable type array\\.$#"
-			count: 1
 			path: ../../Tests/Functional/Hooks/DataHandlerHookTest.php
 
 		-
@@ -2122,7 +2057,7 @@ parameters:
 
 		-
 			message: "#^Cannot access offset 'EXTCONF' on mixed\\.$#"
-			count: 4
+			count: 1
 			path: ../../Tests/LegacyFunctional/Csv/AbstractRegistrationListViewTest.php
 
 		-
@@ -2132,43 +2067,13 @@ parameters:
 
 		-
 			message: "#^Cannot access offset 'seminars' on mixed\\.$#"
-			count: 2
+			count: 1
 			path: ../../Tests/LegacyFunctional/Csv/AbstractRegistrationListViewTest.php
 
 		-
 			message: "#^PHPDoc tag @var with type PHPUnit\\\\Framework\\\\MockObject\\\\MockObject is not subtype of type PHPUnit\\\\Framework\\\\MockObject\\\\MockObject&stdClass\\.$#"
 			count: 4
 			path: ../../Tests/LegacyFunctional/Csv/AbstractRegistrationListViewTest.php
-
-		-
-			message: "#^Property OliverKlee\\\\Seminars\\\\Tests\\\\LegacyFunctional\\\\Csv\\\\AbstractRegistrationListViewTest\\:\\:\\$extConfBackup \\(array\\<string, mixed\\>\\) does not accept mixed\\.$#"
-			count: 1
-			path: ../../Tests/LegacyFunctional/Csv/AbstractRegistrationListViewTest.php
-
-		-
-			message: "#^Cannot access offset 'EXTCONF' on mixed\\.$#"
-			count: 3
-			path: ../../Tests/LegacyFunctional/Csv/CsvDownloaderTest.php
-
-		-
-			message: "#^Cannot access offset 'getUserObj' on mixed\\.$#"
-			count: 2
-			path: ../../Tests/LegacyFunctional/Csv/CsvDownloaderTest.php
-
-		-
-			message: "#^Cannot access offset 'seminars' on mixed\\.$#"
-			count: 1
-			path: ../../Tests/LegacyFunctional/Csv/CsvDownloaderTest.php
-
-		-
-			message: "#^Property OliverKlee\\\\Seminars\\\\Tests\\\\LegacyFunctional\\\\Csv\\\\CsvDownloaderTest\\:\\:\\$extConfBackup type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: ../../Tests/LegacyFunctional/Csv/CsvDownloaderTest.php
-
-		-
-			message: "#^Property OliverKlee\\\\Seminars\\\\Tests\\\\LegacyFunctional\\\\Csv\\\\CsvDownloaderTest\\:\\:\\$t3VarBackup type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: ../../Tests/LegacyFunctional/Csv/CsvDownloaderTest.php
 
 		-
 			message: "#^Method OliverKlee\\\\Seminars\\\\Tests\\\\LegacyFunctional\\\\FrontEnd\\\\AbstractViewTest\\:\\:getFrontEndController\\(\\) should return TYPO3\\\\CMS\\\\Frontend\\\\Controller\\\\TypoScriptFrontendController but returns mixed\\.$#"
@@ -2197,7 +2102,7 @@ parameters:
 
 		-
 			message: "#^Cannot access offset 'EXTCONF' on mixed\\.$#"
-			count: 9
+			count: 6
 			path: ../../Tests/LegacyFunctional/FrontEnd/DefaultControllerTest.php
 
 		-
@@ -2212,7 +2117,7 @@ parameters:
 
 		-
 			message: "#^Cannot access offset 'seminars' on mixed\\.$#"
-			count: 7
+			count: 6
 			path: ../../Tests/LegacyFunctional/FrontEnd/DefaultControllerTest.php
 
 		-
@@ -2232,11 +2137,6 @@ parameters:
 
 		-
 			message: "#^Method OliverKlee\\\\Seminars\\\\Tests\\\\LegacyFunctional\\\\FrontEnd\\\\DefaultControllerTest\\:\\:hideListRegistrationsColumnIfNecessaryDataProvider\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: ../../Tests/LegacyFunctional/FrontEnd/DefaultControllerTest.php
-
-		-
-			message: "#^Property OliverKlee\\\\Seminars\\\\Tests\\\\LegacyFunctional\\\\FrontEnd\\\\DefaultControllerTest\\:\\:\\$extConfBackup \\(array\\<string, mixed\\>\\) does not accept mixed\\.$#"
 			count: 1
 			path: ../../Tests/LegacyFunctional/FrontEnd/DefaultControllerTest.php
 
@@ -2366,11 +2266,6 @@ parameters:
 			path: ../../Tests/LegacyFunctional/OldModel/LegacyRegistrationTest.php
 
 		-
-			message: "#^Cannot access offset 'EXTCONF' on mixed\\.$#"
-			count: 3
-			path: ../../Tests/LegacyFunctional/SchedulerTasks/MailNotifierTest.php
-
-		-
 			message: "#^Cannot access offset 'MAIL' on mixed\\.$#"
 			count: 10
 			path: ../../Tests/LegacyFunctional/SchedulerTasks/MailNotifierTest.php
@@ -2383,16 +2278,6 @@ parameters:
 		-
 			message: "#^Cannot access offset 'defaultMailFromName' on mixed\\.$#"
 			count: 5
-			path: ../../Tests/LegacyFunctional/SchedulerTasks/MailNotifierTest.php
-
-		-
-			message: "#^Cannot access offset 'getUserObj' on mixed\\.$#"
-			count: 2
-			path: ../../Tests/LegacyFunctional/SchedulerTasks/MailNotifierTest.php
-
-		-
-			message: "#^Cannot access offset 'seminars' on mixed\\.$#"
-			count: 1
 			path: ../../Tests/LegacyFunctional/SchedulerTasks/MailNotifierTest.php
 
 		-
@@ -2426,21 +2311,6 @@ parameters:
 			path: ../../Tests/LegacyFunctional/SchedulerTasks/MailNotifierTest.php
 
 		-
-			message: "#^Property OliverKlee\\\\Seminars\\\\Tests\\\\LegacyFunctional\\\\SchedulerTasks\\\\MailNotifierTest\\:\\:\\$extConfBackup type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: ../../Tests/LegacyFunctional/SchedulerTasks/MailNotifierTest.php
-
-		-
-			message: "#^Property OliverKlee\\\\Seminars\\\\Tests\\\\LegacyFunctional\\\\SchedulerTasks\\\\MailNotifierTest\\:\\:\\$t3VarBackup type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: ../../Tests/LegacyFunctional/SchedulerTasks/MailNotifierTest.php
-
-		-
-			message: "#^Cannot access offset 'EXTCONF' on mixed\\.$#"
-			count: 3
-			path: ../../Tests/LegacyFunctional/Service/EmailServiceTest.php
-
-		-
 			message: "#^Cannot access offset 'MAIL' on mixed\\.$#"
 			count: 6
 			path: ../../Tests/LegacyFunctional/Service/EmailServiceTest.php
@@ -2456,16 +2326,6 @@ parameters:
 			path: ../../Tests/LegacyFunctional/Service/EmailServiceTest.php
 
 		-
-			message: "#^Cannot access offset 'getUserObj' on mixed\\.$#"
-			count: 2
-			path: ../../Tests/LegacyFunctional/Service/EmailServiceTest.php
-
-		-
-			message: "#^Cannot access offset 'seminars' on mixed\\.$#"
-			count: 1
-			path: ../../Tests/LegacyFunctional/Service/EmailServiceTest.php
-
-		-
 			message: "#^Function str_contains not found\\.$#"
 			count: 1
 			path: ../../Tests/LegacyFunctional/Service/EmailServiceTest.php
@@ -2473,16 +2333,6 @@ parameters:
 		-
 			message: "#^Parameter \\#2 \\$haystack of static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertStringContainsString\\(\\) expects string, resource\\|string\\|null given\\.$#"
 			count: 5
-			path: ../../Tests/LegacyFunctional/Service/EmailServiceTest.php
-
-		-
-			message: "#^Property OliverKlee\\\\Seminars\\\\Tests\\\\LegacyFunctional\\\\Service\\\\EmailServiceTest\\:\\:\\$extConfBackup type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: ../../Tests/LegacyFunctional/Service/EmailServiceTest.php
-
-		-
-			message: "#^Property OliverKlee\\\\Seminars\\\\Tests\\\\LegacyFunctional\\\\Service\\\\EmailServiceTest\\:\\:\\$t3VarBackup type has no value type specified in iterable type array\\.$#"
-			count: 1
 			path: ../../Tests/LegacyFunctional/Service/EmailServiceTest.php
 
 		-

--- a/Tests/Functional/Support/BackEndTestsTrait.php
+++ b/Tests/Functional/Support/BackEndTestsTrait.php
@@ -9,8 +9,6 @@ use OliverKlee\Oelib\Configuration\DummyConfiguration;
 use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 use TYPO3\CMS\Core\Context\Context;
 use TYPO3\CMS\Core\Context\DateTimeAspect;
-use TYPO3\CMS\Core\Localization\LanguageService;
-use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
 use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
 
@@ -20,24 +18,6 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
 trait BackEndTestsTrait
 {
     use BackendLanguageTrait;
-
-    /**
-     * @var array<mixed>
-     */
-    private array $getBackup = [];
-
-    /**
-     * @var array<mixed>
-     */
-    private array $postBackup = [];
-
-    private ?BackendUserAuthentication $backEndUserBackup = null;
-
-    private string $languageBackup = '';
-
-    private array $extConfBackup = [];
-
-    private array $t3VarBackup = [];
 
     private DummyConfiguration $configuration;
 
@@ -60,29 +40,13 @@ trait BackEndTestsTrait
         \assert($nowAsUnixTimestamp > 0);
         $this->now = $nowAsUnixTimestamp;
 
-        $this->cleanRequestVariables();
         $this->replaceBackEndUserWithMock();
         $this->unifyBackEndLanguage();
-        $this->unifyExtensionSettings();
         $this->setUpExtensionConfiguration();
-    }
-
-    private function cleanRequestVariables(): void
-    {
-        GeneralUtility::flushInternalRuntimeCaches();
-        unset($GLOBALS['TYPO3_REQUEST']);
-        $this->getBackup = $_GET;
-        $_GET = [];
-        $this->postBackup = $_POST;
-        $_POST = [];
     }
 
     private function replaceBackEndUserWithMock(): void
     {
-        $currentBackEndUser = $GLOBALS['BE_USER'] ?? null;
-        if ($currentBackEndUser instanceof BackendUserAuthentication) {
-            $this->backEndUserBackup = $currentBackEndUser;
-        }
         $mockBackEndUser = $this
             ->getMockBuilder(BackendUserAuthentication::class)
             ->onlyMethods(['check', 'doesUserHaveAccess', 'setAndSaveSessionData', 'writeUC'])
@@ -95,11 +59,6 @@ trait BackEndTestsTrait
 
     private function unifyBackEndLanguage(): void
     {
-        $currentLanguageService = $GLOBALS['LANG'] ?? null;
-        if ($currentLanguageService instanceof LanguageService) {
-            $this->languageBackup = $currentLanguageService->lang;
-        }
-
         $newLanguageService = $this->getLanguageService();
         $newLanguageService->lang = 'default';
 
@@ -110,41 +69,12 @@ trait BackEndTestsTrait
         $GLOBALS['LANG'] = $newLanguageService;
     }
 
-    private function unifyExtensionSettings(): void
-    {
-        $extConf = $GLOBALS['TYPO3_CONF_VARS']['EXTCONF'] ?? null;
-        $this->extConfBackup = \is_array($extConf) ? $extConf : [];
-        $t3var = $GLOBALS['T3_VAR']['getUserObj'] ?? null;
-        $this->t3VarBackup = \is_array($t3var) ? $t3var : [];
-        $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['seminars'] = [];
-    }
-
     private function setUpExtensionConfiguration(): void
     {
         $configurationRegistry = $this->get(ConfigurationRegistry::class);
         $configurationRegistry->set('plugin', new DummyConfiguration());
         $this->configuration = new DummyConfiguration();
         $configurationRegistry->set('plugin.tx_seminars', $this->configuration);
-    }
-
-    private function restoreOriginalEnvironment(): void
-    {
-        if ($this->backEndUserBackup !== null) {
-            $GLOBALS['BE_USER'] = $this->backEndUserBackup;
-        }
-        if ($this->languageBackup !== '') {
-            $this->getLanguageService()->lang = $this->languageBackup;
-        }
-        if ($this->extConfBackup !== []) {
-            $GLOBALS['TYPO3_CONF_VARS']['EXTCONF'] = $this->extConfBackup;
-        }
-        if ($this->t3VarBackup !== []) {
-            $GLOBALS['T3_VAR']['getUserObj'] = $this->t3VarBackup;
-        }
-        $_GET = $this->getBackup;
-        $_POST = $this->postBackup;
-        unset($GLOBALS['TYPO3_REQUEST']);
-        GeneralUtility::flushInternalRuntimeCaches();
     }
 
     /**

--- a/Tests/Functional/Support/BackendLanguageTrait.php
+++ b/Tests/Functional/Support/BackendLanguageTrait.php
@@ -32,7 +32,7 @@ trait BackendLanguageTrait
     }
 
     /**
-     * Sets $GLOBALS['LANG'].
+     * Sets `$GLOBALS['LANG']`.
      */
     private function initializeBackEndLanguage(): void
     {

--- a/Tests/LegacyFunctional/Csv/AbstractRegistrationListViewTest.php
+++ b/Tests/LegacyFunctional/Csv/AbstractRegistrationListViewTest.php
@@ -57,13 +57,6 @@ final class AbstractRegistrationListViewTest extends FunctionalTestCase
      */
     private array $mockedClassNames = [];
 
-    /**
-     * backed-up extension configuration of the TYPO3 configuration variables
-     *
-     * @var array<string, mixed>
-     */
-    private array $extConfBackup = [];
-
     protected function setUp(): void
     {
         parent::setUp();
@@ -73,9 +66,6 @@ final class AbstractRegistrationListViewTest extends FunctionalTestCase
         $nowAsUnixTimestamp = $now->getTimestamp();
         \assert($nowAsUnixTimestamp > 0);
         $this->nowAsUnixTimestamp = $nowAsUnixTimestamp;
-
-        $this->extConfBackup = $GLOBALS['TYPO3_CONF_VARS']['EXTCONF'];
-        $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['seminars'] = [];
 
         $this->testingFramework = $this->get(TestingFramework::class);
 
@@ -114,7 +104,6 @@ final class AbstractRegistrationListViewTest extends FunctionalTestCase
     protected function tearDown(): void
     {
         $this->purgeMockedInstances();
-        $GLOBALS['TYPO3_CONF_VARS']['EXTCONF'] = $this->extConfBackup;
         $this->testingFramework->cleanUpWithoutDatabase();
 
         parent::tearDown();

--- a/Tests/LegacyFunctional/Csv/CsvDownloaderTest.php
+++ b/Tests/LegacyFunctional/Csv/CsvDownloaderTest.php
@@ -73,7 +73,6 @@ final class CsvDownloaderTest extends FunctionalTestCase
     protected function tearDown(): void
     {
         $this->testingFramework->cleanUpWithoutDatabase();
-        $this->restoreOriginalEnvironment();
 
         parent::tearDown();
     }

--- a/Tests/LegacyFunctional/FrontEnd/DefaultControllerTest.php
+++ b/Tests/LegacyFunctional/FrontEnd/DefaultControllerTest.php
@@ -81,13 +81,6 @@ final class DefaultControllerTest extends FunctionalTestCase
      */
     private int $numberOfOrganizers = 0;
 
-    /**
-     * backed-up extension configuration of the TYPO3 configuration variables
-     *
-     * @var array<string, mixed>
-     */
-    private array $extConfBackup = [];
-
     private ConnectionPool $connectionPool;
 
     private DummyConfiguration $pluginConfiguration;
@@ -107,9 +100,6 @@ final class DefaultControllerTest extends FunctionalTestCase
         $nowAsUnixTimestamp = $now->getTimestamp();
         self::assertGreaterThan(0, $nowAsUnixTimestamp);
         $this->nowAsUnixTimestamp = $nowAsUnixTimestamp;
-
-        $this->extConfBackup = $GLOBALS['TYPO3_CONF_VARS']['EXTCONF'];
-        $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['seminars'] = [];
 
         $this->testingFramework = $this->get(TestingFramework::class);
         $this->eventMapper = $this->get(MapperRegistry::class)->getByClassName(EventMapper::class);
@@ -171,8 +161,6 @@ final class DefaultControllerTest extends FunctionalTestCase
     protected function tearDown(): void
     {
         $this->testingFramework->cleanUpWithoutDatabase();
-
-        $GLOBALS['TYPO3_CONF_VARS']['EXTCONF'] = $this->extConfBackup;
 
         parent::tearDown();
     }

--- a/Tests/LegacyFunctional/SchedulerTasks/MailNotifierTest.php
+++ b/Tests/LegacyFunctional/SchedulerTasks/MailNotifierTest.php
@@ -98,8 +98,6 @@ final class MailNotifierTest extends FunctionalTestCase
 
     protected function tearDown(): void
     {
-        $this->restoreOriginalEnvironment();
-
         if ($this->testingFramework instanceof TestingFramework) {
             $this->testingFramework->cleanUpWithoutDatabase();
         }


### PR DESCRIPTION
With the TYPO3 Testing Framework, this is not necessary anymore
as the TF resets (almost) everything between tests anyway.