### PR TITLE
[TASK] Drop the legacy FE registration lists for managers

### DIFF
--- a/Build/phpstan/phpstan-baseline.neon
+++ b/Build/phpstan/phpstan-baseline.neon
@@ -776,8 +776,8 @@ parameters:
 			path: ../../Classes/FrontEnd/DefaultController.php
 
 		-
-			message: "#^Parameter \\#1 \\$whichPlugin of method OliverKlee\\\\Seminars\\\\OldModel\\\\LegacyEvent\\:\\:canViewRegistrationsList\\(\\) expects 'list_registrations'\\|'list_vip…'\\|'my_events'\\|'my_vip_events'\\|'seminar_list', string given\\.$#"
-			count: 2
+			message: "#^Parameter \\#1 \\$whichPlugin of method OliverKlee\\\\Seminars\\\\OldModel\\\\LegacyEvent\\:\\:canViewRegistrationsList\\(\\) expects 'list_registrations'\\|'my_events'\\|'my_vip_events'\\|'seminar_list', string given\\.$#"
+			count: 1
 			path: ../../Classes/FrontEnd/DefaultController.php
 
 		-
@@ -802,11 +802,6 @@ parameters:
 
 		-
 			message: "#^Parameter \\#2 \\$str of function explode expects string, array\\|float\\|int\\<min, \\-1\\>\\|int\\<1, max\\>\\|string given\\.$#"
-			count: 1
-			path: ../../Classes/FrontEnd/DefaultController.php
-
-		-
-			message: "#^Parameter \\#3 \\$registrationsVipListPID of method OliverKlee\\\\Seminars\\\\OldModel\\\\LegacyEvent\\:\\:canViewRegistrationsList\\(\\) expects int\\<0, max\\>, int given\\.$#"
 			count: 1
 			path: ../../Classes/FrontEnd/DefaultController.php
 
@@ -2161,17 +2156,12 @@ parameters:
 			path: ../../Tests/LegacyFunctional/OldModel/LegacyEventTest.php
 
 		-
-			message: "#^Parameter \\#1 \\$whichPlugin of method OliverKlee\\\\Seminars\\\\OldModel\\\\LegacyEvent\\:\\:canViewRegistrationsList\\(\\) expects 'list_registrations'\\|'list_vip…'\\|'my_events'\\|'my_vip_events'\\|'seminar_list', string given\\.$#"
+			message: "#^Parameter \\#1 \\$whichPlugin of method OliverKlee\\\\Seminars\\\\OldModel\\\\LegacyEvent\\:\\:canViewRegistrationsList\\(\\) expects 'list_registrations'\\|'my_events'\\|'my_vip_events'\\|'seminar_list', string given\\.$#"
 			count: 1
 			path: ../../Tests/LegacyFunctional/OldModel/LegacyEventTest.php
 
 		-
 			message: "#^Parameter \\#2 \\$registrationsListPID of method OliverKlee\\\\Seminars\\\\OldModel\\\\LegacyEvent\\:\\:canViewRegistrationsList\\(\\) expects int\\<0, max\\>, int given\\.$#"
-			count: 1
-			path: ../../Tests/LegacyFunctional/OldModel/LegacyEventTest.php
-
-		-
-			message: "#^Parameter \\#3 \\$registrationsVipListPID of method OliverKlee\\\\Seminars\\\\OldModel\\\\LegacyEvent\\:\\:canViewRegistrationsList\\(\\) expects int\\<0, max\\>, int given\\.$#"
 			count: 1
 			path: ../../Tests/LegacyFunctional/OldModel/LegacyEventTest.php
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -178,7 +178,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 - Drop the hooks for the `DataHandler` hook (#5135)
 - Drop the hook system for modifying the CSV export (#5134)
-- Drop the legacy FE registration lists (#4277, #5133)
+- Drop the legacy FE registration lists (#4277, #5133, #5139)
 - Drop the email hook system (#5085)
 - Drop the CSV attachment from the scheduler task emails (#5028)
 - Drop `LegacyEvent::isUserRegisteredMessage()` (#4985)

--- a/Classes/FrontEnd/AbstractView.php
+++ b/Classes/FrontEnd/AbstractView.php
@@ -20,7 +20,7 @@ use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
 abstract class AbstractView extends TemplateHelper
 {
     /**
-     * @var 'seminar_list'|'my_events'|'my_vip_events'|'list_registrations'|'list_vip_registrations'
+     * @var 'seminar_list'|'my_events'|'my_vip_events'|'list_registrations'
      */
     protected string $whatToDisplay;
 

--- a/Classes/FrontEnd/DefaultController.php
+++ b/Classes/FrontEnd/DefaultController.php
@@ -208,14 +208,10 @@ class DefaultController extends TemplateHelper
             case 'single_view':
                 $result = $this->createSingleView();
                 break;
-            case 'list_vip_registrations':
-                // The fallthrough is intended
-                // because createRegistrationsListPage() will differentiate later.
             case 'list_registrations':
                 $registrationsList = GeneralUtility::makeInstance(
                     RegistrationsList::class,
                     $this->conf,
-                    $this->whatToDisplay,
                     (int)($this->piVars['seminar'] ?? 0),
                     $this->cObj,
                 );
@@ -340,15 +336,6 @@ class DefaultController extends TemplateHelper
 
         \assert($this->seminar instanceof LegacyEvent);
         if (
-            $this->seminar->canViewRegistrationsList(
-                $this->whatToDisplay,
-                0,
-                $this->getConfValueInteger('registrationsVipListPID'),
-            )
-        ) {
-            // So a link to the VIP list is possible.
-            $targetPageId = $this->getConfValueInteger('registrationsVipListPID');
-        } elseif (
             $this->seminar->canViewRegistrationsList(
                 $this->whatToDisplay,
                 $this->getConfValueInteger('registrationsListPID'),
@@ -1109,7 +1096,6 @@ class DefaultController extends TemplateHelper
         $canViewListOfRegistrations = $this->seminar->canViewRegistrationsList(
             $this->whatToDisplay,
             $this->getConfValueInteger('registrationsListPID'),
-            $this->getConfValueInteger('registrationsVipListPID'),
         );
 
         if (!$canViewListOfRegistrations) {
@@ -1945,14 +1931,13 @@ class DefaultController extends TemplateHelper
 
         switch ($whatToDisplay) {
             case 'seminar_list':
-                $hideIt = !$this->hasConfValueInteger('registrationsListPID')
-                    && !$this->hasConfValueInteger('registrationsVipListPID');
+                $hideIt = !$this->hasConfValueInteger('registrationsListPID');
                 break;
             case 'my_events':
                 $hideIt = !$this->hasConfValueInteger('registrationsListPID');
                 break;
             case 'my_vip_events':
-                $hideIt = !$this->hasConfValueInteger('registrationsVipListPID');
+                $hideIt = true;
                 break;
             default:
                 $hideIt = false;

--- a/Classes/FrontEnd/RegistrationsList.php
+++ b/Classes/FrontEnd/RegistrationsList.php
@@ -21,33 +21,21 @@ class RegistrationsList extends AbstractView
 
     private ResponseHeadersModifier $responseHeadersModifier;
 
+    protected string $whatToDisplay = 'list_registrations';
+
     /**
      * The constructor.
      *
      * @param array $configuration TypoScript configuration for the plugin, may be empty
-     * @param string $whatToDisplay a string selecting the flavor of the list view, either "list_registrations" or
-     *        "list_vip_registrations"
      * @param int $seminarUid UID of the seminar of which we want to list the registrations, invalid UIDs will be
      *        handled later
      * @param ContentObjectRenderer $contentObjectRenderer the parent cObj, needed for the flexforms
      */
-    public function __construct(
-        array $configuration,
-        string $whatToDisplay,
-        int $seminarUid,
-        ContentObjectRenderer $contentObjectRenderer
-    ) {
+    public function __construct(array $configuration, int $seminarUid, ContentObjectRenderer $contentObjectRenderer)
+    {
         parent::__construct($configuration, $contentObjectRenderer);
 
         $this->responseHeadersModifier = GeneralUtility::makeInstance(ResponseHeadersModifier::class);
-
-        if (!\in_array($whatToDisplay, ['list_registrations', 'list_vip_registrations'], true)) {
-            throw new \InvalidArgumentException(
-                'The value "' . $whatToDisplay . '" of the first parameter $whatToDisplay is not valid.',
-                1333293210,
-            );
-        }
-        $this->whatToDisplay = $whatToDisplay;
 
         $this->createSeminar($seminarUid);
     }

--- a/Classes/OldModel/LegacyEvent.php
+++ b/Classes/OldModel/LegacyEvent.php
@@ -1774,34 +1774,23 @@ class LegacyEvent extends AbstractTimeSpan
      * a) a link may be created to the page with the list of registrations
      *    (for $whichPlugin = (seminar_list|my_events|my_vip_events))
      * b) the user is allowed to view the list of registrations
-     *    (for $whichPlugin = (list_registrations|list_vip_registrations))
      *
-     * @param 'seminar_list'|'my_events'|'my_vip_events'|'list_registrations'|'list_vip_registrations' $whichPlugin
+     * @param 'seminar_list'|'my_events'|'my_vip_events'|'list_registrations' $whichPlugin
      * @param int<0, max> $registrationsListPID
      *        the value of the registrationsListPID parameter
-     *        (only relevant for (seminar_list|my_events|my_vip_events))
-     * @param int<0, max> $registrationsVipListPID
-     *        the value of the registrationsVipListPID parameter
      *        (only relevant for (seminar_list|my_events|my_vip_events))
      *
      * @return bool TRUE if a FE user is logged in and the user may view
      *                 the registrations list or may see a link to that
      *                 page, FALSE otherwise
      */
-    public function canViewRegistrationsList(
-        string $whichPlugin,
-        int $registrationsListPID = 0,
-        int $registrationsVipListPID = 0
-    ): bool {
+    public function canViewRegistrationsList(string $whichPlugin, int $registrationsListPID = 0): bool
+    {
         if (!$this->needsRegistration()) {
             return false;
         }
 
-        return $this->canViewRegistrationsListForAttendeesAndManagersAccess(
-            $whichPlugin,
-            $registrationsListPID,
-            $registrationsVipListPID,
-        );
+        return $this->canViewRegistrationsListForAttendeesAccess($whichPlugin, $registrationsListPID);
     }
 
     /**
@@ -1811,22 +1800,18 @@ class LegacyEvent extends AbstractTimeSpan
      * This function assumes that the access level for FE registration lists is
      * "attendees and managers".
      *
-     * @param 'seminar_list'|'my_events'|'my_vip_events'|'list_registrations'|'list_vip_registrations' $whichPlugin
+     * @param 'seminar_list'|'my_events'|'my_vip_events'|'list_registrations' $whichPlugin
      * @param int<0, max> $registrationsListPID
      *        the value of the registrationsListPID parameter
-     *        (only relevant for (seminar_list|my_events|my_vip_events))
-     * @param int<0, max> $registrationsVipListPID
-     *        the value of the registrationsVipListPID parameter
      *        (only relevant for (seminar_list|my_events|my_vip_events))
      *
      * @return bool TRUE if a FE user is logged in and the user may view
      *                 the registrations list or may see a link to that
      *                 page, FALSE otherwise
      */
-    protected function canViewRegistrationsListForAttendeesAndManagersAccess(
+    protected function canViewRegistrationsListForAttendeesAccess(
         string $whichPlugin,
-        int $registrationsListPID = 0,
-        int $registrationsVipListPID = 0
+        int $registrationsListPID = 0
     ): bool {
         $currentUserUid = $this->getLoggedInFrontEndUserUid();
         if ($currentUserUid === 0) {
@@ -1834,29 +1819,19 @@ class LegacyEvent extends AbstractTimeSpan
         }
 
         $hasListPid = ($registrationsListPID > 0);
-        $hasVipListPid = ($registrationsVipListPID > 0);
 
         switch ($whichPlugin) {
             case 'seminar_list':
-                // In the standard list view, we could have any kind of link.
-                $result = $this->canViewRegistrationsList('my_events', $registrationsListPID)
-                    || $this->canViewRegistrationsList(
-                        'my_vip_events',
-                        0,
-                        $registrationsVipListPID,
-                    );
+                $result = $this->canViewRegistrationsList('my_events', $registrationsListPID);
                 break;
             case 'my_events':
                 $result = $this->isUserRegistered($currentUserUid) && $hasListPid;
                 break;
             case 'my_vip_events':
-                $result = $this->isUserVip($currentUserUid) && $hasVipListPid;
+                $result = false;
                 break;
             case 'list_registrations':
                 $result = $this->isUserRegistered($currentUserUid);
-                break;
-            case 'list_vip_registrations':
-                $result = $this->isUserVip($currentUserUid);
                 break;
             default:
                 $result = false;
@@ -1867,11 +1842,11 @@ class LegacyEvent extends AbstractTimeSpan
 
     /**
      * Checks whether a FE user is logged in and whether he/she may view this
-     * seminar's registrations list.
-     * This function is intended to be used from the registrations list,
+     * seminar's registration list.
+     * This function is intended to be used from the registration list,
      * NOT to check whether a link to that list should be shown.
      *
-     * @param 'seminar_list'|'my_events'|'my_vip_events'|'list_registrations'|'list_vip_registrations' $whichPlugin
+     * @param 'seminar_list'|'my_events'|'my_vip_events'|'list_registrations' $whichPlugin
      *
      * @return string an empty string if everything is OK, a localized error message otherwise
      */

--- a/Configuration/FlexForms/flexforms_pi1.xml
+++ b/Configuration/FlexForms/flexforms_pi1.xml
@@ -57,12 +57,6 @@
                                         </numIndex>
                                         <numIndex index="1">list_registrations</numIndex>
                                     </numIndex>
-                                    <numIndex index="4" type="array">
-                                        <numIndex index="0">
-                                            LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:seminars.pi_flexform.list_vip_registrations
-                                        </numIndex>
-                                        <numIndex index="1">list_vip_registrations</numIndex>
-                                    </numIndex>
                                     <numIndex index="10" type="array">
                                         <numIndex index="0">
                                             LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:seminars.pi_flexform.category_list
@@ -177,23 +171,6 @@
                             </config>
                         </TCEforms>
                     </registrationsListPID>
-                    <registrationsVipListPID>
-                        <TCEforms>
-                            <exclude>1</exclude>
-                            <label>
-                                LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:seminars.pi_flexform.registrationsVipListPID
-                            </label>
-                            <config>
-                                <type>group</type>
-                                <internal_type>db</internal_type>
-                                <allowed>pages</allowed>
-                                <size>1</size>
-                                <minitems>0</minitems>
-                                <maxitems>1</maxitems>
-                                <hideSuggest>1</hideSuggest>
-                            </config>
-                        </TCEforms>
-                    </registrationsVipListPID>
                     <limitFileDownloadToAttendees>
                         <TCEforms>
                             <label>

--- a/Configuration/TypoScript/FrontEnd.typoscript
+++ b/Configuration/TypoScript/FrontEnd.typoscript
@@ -124,9 +124,6 @@ plugin.tx_seminars_pi1 {
   # PID of the page that contains the registrations list for participants
   registrationsListPID =
 
-  # PID of the page that contains the registrations list for event managers
-  registrationsVipListPID =
-
   # the maximum width of the image of a seminar in the single view
   seminarImageSingleViewWidth = 260
 

--- a/Documentation/Architecture/Controllers.rst
+++ b/Documentation/Architecture/Controllers.rst
@@ -61,9 +61,6 @@ In ``FrontEnd/``, there are additional classes that are used by the ``DefaultCon
 | ``list_registrations``     | List of all registrations for a specific event.                  |
 |                            | Intended for normal frontend users viewing event registrations.  |
 +----------------------------+------------------------------------------------------------------+
-| ``list_vip_registrations`` | List of all registrations for a specific event.                  |
-|                            | Intended for users with special management permissions.          |
-+----------------------------+------------------------------------------------------------------+
 | ``category_list``          | List of event categories.                                        |
 +----------------------------+------------------------------------------------------------------+
 | ``topic_list``             | List of event topics.                                            |

--- a/Documentation/Reference/SetupForTheSeminarManagerFront-endPlug-inInPlugintxSeminarsPi1/Index.rst
+++ b/Documentation/Reference/SetupForTheSeminarManagerFront-endPlug-inInPlugintxSeminarsPi1/Index.rst
@@ -650,21 +650,6 @@ override the corresponding value from TS Setup.**
 .. container:: table-row
 
    Property
-         registrationsVipListPID
-
-   Data type
-         page\_id
-
-   Description
-         PID of the page that contains the registrations list for editors
-
-   Default
-         None
-
-
-.. container:: table-row
-
-   Property
          defaultEventVipsFeGroupID
 
    Data type

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -553,9 +553,6 @@
       <trans-unit id="seminars.pi_flexform.list_registrations">
         <source>List of Registrations (for attendees)</source>
       </trans-unit>
-      <trans-unit id="seminars.pi_flexform.list_vip_registrations">
-        <source>List of Registrations (for event managers)</source>
-      </trans-unit>
       <trans-unit id="seminars.pi_flexform.category_list">
         <source>Category List</source>
       </trans-unit>
@@ -576,9 +573,6 @@
       </trans-unit>
       <trans-unit id="seminars.pi_flexform.registrationsListPID">
         <source>Page that contains the list of registrations (for attendees):</source>
-      </trans-unit>
-      <trans-unit id="seminars.pi_flexform.registrationsVipListPID">
-        <source>Page that contains the list of registrations (for event managers):</source>
       </trans-unit>
       <trans-unit id="seminars.pi_flexform.formal">
         <source>formal</source>

--- a/Tests/LegacyFunctional/FrontEnd/DefaultControllerTest.php
+++ b/Tests/LegacyFunctional/FrontEnd/DefaultControllerTest.php
@@ -4936,8 +4936,6 @@ final class DefaultControllerTest extends FunctionalTestCase
      *                            expected to be hidden
      *               [whatToDisplay] string: the value for what_to_display
      *               [listPid] integer: the PID of the registration list page
-     *               [vipListPid] integer: the PID of the VIP registration list
-     *                            page
      */
     public function hideListRegistrationsColumnIfNecessaryDataProvider(): array
     {
@@ -4946,91 +4944,61 @@ final class DefaultControllerTest extends FunctionalTestCase
                 'getsHidden' => false,
                 'whatToDisplay' => 'seminar_list',
                 'listPid' => 1,
-                'vipListPid' => 1,
             ],
             'hiddenForListForNoPidsSet' => [
                 'getsHidden' => true,
                 'whatToDisplay' => 'seminar_list',
                 'listPid' => 0,
-                'vipListPid' => 0,
             ],
             'notHiddenForListForListPidSet' => [
                 'getsHidden' => false,
                 'whatToDisplay' => 'seminar_list',
                 'listPid' => 1,
-                'vipListPid' => 0,
             ],
-            'notHiddenForListForVipListPidSet' => [
-                'getsHidden' => false,
-                'whatToDisplay' => 'seminar_list',
-                'listPid' => 0,
-                'vipListPid' => 1,
-            ],
-            'hiddenForOtherDatesForAndBothPidsSet' => [
-                'getsHidden' => true,
-                'whatToDisplay' => 'other_dates',
-                'listPid' => 1,
-                'vipListPid' => 1,
-            ],
-            'hiddenForEventsNextDayForBothPidsSet' => [
+            'hiddenForEventsNextDayForListPidSet' => [
                 'getsHidden' => true,
                 'whatToDisplay' => 'events_next_day',
                 'listPid' => 1,
-                'vipListPid' => 1,
             ],
-            'notHiddenForMyEventsForBothPidsSet' => [
+            'notHiddenForMyEventsForListPisSet' => [
                 'getsHidden' => false,
                 'whatToDisplay' => 'my_events',
                 'listPid' => 1,
-                'vipListPid' => 1,
             ],
-            'hiddenForMyEventsForNoPidsSet' => [
+            'hiddenForMyEventsForNoPidSet' => [
                 'getsHidden' => true,
                 'whatToDisplay' => 'my_events',
                 'listPid' => 0,
-                'vipListPid' => 0,
             ],
             'notHiddenForMyEventsForListPidSet' => [
                 'getsHidden' => false,
                 'whatToDisplay' => 'my_events',
                 'listPid' => 1,
-                'vipListPid' => 0,
             ],
-            'hiddenForMyEventsForVipListPidSet' => [
+            'notHiddenForMyVipEventsForListPidSet' => [
                 'getsHidden' => true,
-                'whatToDisplay' => 'my_events',
-                'listPid' => 0,
-                'vipListPid' => 1,
-            ],
-            'notHiddenForMyVipEventsForBothPidsSet' => [
-                'getsHidden' => false,
                 'whatToDisplay' => 'my_vip_events',
                 'listPid' => 1,
-                'vipListPid' => 1,
             ],
-            'hiddenForMyVipEventsForNoPidsSet' => [
+            'hiddenForMyVipEventsForNoPidSet' => [
                 'getsHidden' => true,
                 'whatToDisplay' => 'my_vip_events',
                 'listPid' => 0,
-                'vipListPid' => 0,
             ],
             'hiddenForMyVipEventsForListPidSet' => [
                 'getsHidden' => true,
                 'whatToDisplay' => 'my_vip_events',
                 'listPid' => 1,
-                'vipListPid' => 0,
             ],
             'notHiddenForMyVipEventsForVipListPidSet' => [
-                'getsHidden' => false,
+                'getsHidden' => true,
                 'whatToDisplay' => 'my_vip_events',
                 'listPid' => 0,
-                'vipListPid' => 1,
             ],
-            'hiddenForTopicListForBothPidsSet' => [
+            'hiddenForTopicListForListPidSet' => [
                 'getsHidden' => true,
                 'whatToDisplay' => 'topic_list',
                 'listPid' => 1,
-                'vipListPid' => 1,
             ],
         ];
     }
@@ -5039,17 +5007,11 @@ final class DefaultControllerTest extends FunctionalTestCase
      * @test
      *
      * @dataProvider hideListRegistrationsColumnIfNecessaryDataProvider
-     *
-     * @param bool $getsHidden
-     * @param string $whatToDisplay
-     * @param int $listPid
-     * @param int $vipListPid
      */
     public function hideListRegistrationsColumnIfNecessaryWithRegistrationEnabledAndLoggedIn(
         bool $getsHidden,
         string $whatToDisplay,
-        int $listPid,
-        int $vipListPid
+        int $listPid
     ): void {
         $subject =
             $this->getMockBuilder(TestingDefaultController::class)->onlyMethods(
@@ -5070,12 +5032,7 @@ final class DefaultControllerTest extends FunctionalTestCase
             $subject->expects(self::never())->method('hideColumns');
         }
 
-        $subject->init(
-            [
-                'registrationsListPID' => $listPid,
-                'registrationsVipListPID' => $vipListPid,
-            ],
-        );
+        $subject->init(['registrationsListPID' => $listPid]);
 
         $subject->hideListRegistrationsColumnIfNecessary($whatToDisplay);
     }
@@ -5086,15 +5043,11 @@ final class DefaultControllerTest extends FunctionalTestCase
      * @dataProvider hideListRegistrationsColumnIfNecessaryDataProvider
      *
      * @param bool $getsHidden (ignored)
-     * @param string $whatToDisplay
-     * @param int $listPid
-     * @param int $vipListPid
      */
     public function hideListRegistrationsColumnIfNecessaryWithRegistrationEnabledAndNotLoggedInAlwaysHidesColumn(
         bool $getsHidden,
         string $whatToDisplay,
-        int $listPid,
-        int $vipListPid
+        int $listPid
     ): void {
         $subject =
             $this->getMockBuilder(TestingDefaultController::class)->onlyMethods(
@@ -5111,12 +5064,7 @@ final class DefaultControllerTest extends FunctionalTestCase
             ->expects(self::once())->method('hideColumns')
             ->with(['list_registrations']);
 
-        $subject->init(
-            [
-                'registrationsListPID' => $listPid,
-                'registrationsVipListPID' => $vipListPid,
-            ],
-        );
+        $subject->init(['registrationsListPID' => $listPid]);
 
         $subject->hideListRegistrationsColumnIfNecessary($whatToDisplay);
     }
@@ -5127,15 +5075,11 @@ final class DefaultControllerTest extends FunctionalTestCase
      * @dataProvider hideListRegistrationsColumnIfNecessaryDataProvider
      *
      * @param bool $getsHidden (ignored)
-     * @param string $whatToDisplay
-     * @param int $listPid
-     * @param int $vipListPid
      */
     public function hideListRegistrationsColumnIfNecessaryWithRegistrationDisabledAndLoggedInAlwaysHidesColumn(
         bool $getsHidden,
         string $whatToDisplay,
-        int $listPid,
-        int $vipListPid
+        int $listPid
     ): void {
         $subject =
             $this->getMockBuilder(TestingDefaultController::class)->onlyMethods(
@@ -5152,12 +5096,7 @@ final class DefaultControllerTest extends FunctionalTestCase
             ->expects(self::once())->method('hideColumns')
             ->with(['list_registrations']);
 
-        $subject->init(
-            [
-                'registrationsListPID' => $listPid,
-                'registrationsVipListPID' => $vipListPid,
-            ],
-        );
+        $subject->init(['registrationsListPID' => $listPid]);
 
         $subject->hideListRegistrationsColumnIfNecessary($whatToDisplay);
     }

--- a/Tests/LegacyFunctional/FrontEnd/RegistrationsListTest.php
+++ b/Tests/LegacyFunctional/FrontEnd/RegistrationsListTest.php
@@ -92,7 +92,6 @@ final class RegistrationsListTest extends FunctionalTestCase
                 'templateFile' => 'EXT:seminars/Resources/Private/Templates/FrontEnd/FrontEnd.html',
                 'enableRegistration' => 1,
             ],
-            'list_registrations',
             $this->seminarUid,
             $this->getFrontEndController()->cObj,
         );
@@ -165,55 +164,6 @@ final class RegistrationsListTest extends FunctionalTestCase
         );
     }
 
-    ////////////////////////////////////
-    // Tests for creating the fixture.
-    ////////////////////////////////////
-
-    /**
-     * @test
-     */
-    public function createFixtureWithInvalidWhatToDisplayThrowsException(): void
-    {
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('The value "foo" of the first parameter $whatToDisplay is not valid.');
-        new RegistrationsList(
-            ['templateFile' => 'EXT:seminars/Resources/Private/Templates/FrontEnd/FrontEnd.html'],
-            'foo',
-            0,
-            $this->getFrontEndController()->cObj,
-        );
-    }
-
-    /**
-     * @test
-     *
-     * @doesNotPerformAssertions
-     */
-    public function createFixtureWithListRegistrationsAsWhatToDisplayDoesNotThrowException(): void
-    {
-        new RegistrationsList(
-            ['templateFile' => 'EXT:seminars/Resources/Private/Templates/FrontEnd/FrontEnd.html'],
-            'list_registrations',
-            0,
-            $this->getFrontEndController()->cObj,
-        );
-    }
-
-    /**
-     * @test
-     *
-     * @doesNotPerformAssertions
-     */
-    public function createFixtureWithListVipRegistrationsAsWhatToDisplayDoesNotThrowException(): void
-    {
-        new RegistrationsList(
-            ['templateFile' => 'EXT:seminars/Resources/Private/Templates/FrontEnd/FrontEnd.html'],
-            'list_vip_registrations',
-            0,
-            $this->getFrontEndController()->cObj,
-        );
-    }
-
     ///////////////////////
     // Tests for render()
     ///////////////////////
@@ -233,7 +183,6 @@ final class RegistrationsListTest extends FunctionalTestCase
     {
         $subject = new RegistrationsList(
             ['templateFile' => 'EXT:seminars/Resources/Private/Templates/FrontEnd/FrontEnd.html'],
-            'list_registrations',
             -1,
             $this->getFrontEndController()->cObj,
         );
@@ -249,7 +198,6 @@ final class RegistrationsListTest extends FunctionalTestCase
     {
         $subject = new RegistrationsList(
             ['templateFile' => 'EXT:seminars/Resources/Private/Templates/FrontEnd/FrontEnd.html'],
-            'list_registrations',
             0,
             $this->getFrontEndController()->cObj,
         );

--- a/Tests/LegacyFunctional/OldModel/LegacyEventTest.php
+++ b/Tests/LegacyFunctional/OldModel/LegacyEventTest.php
@@ -5965,7 +5965,6 @@ final class LegacyEventTest extends FunctionalTestCase
      *                                that event
      *               [whichPlugin] string: value for that parameter
      *               [registrationsListPID] integer: value for that parameter
-     *               [registrationsVipListPID] integer: value for that parameter
      */
     public function canViewRegistrationsListDataProvider(): array
     {
@@ -5977,7 +5976,6 @@ final class LegacyEventTest extends FunctionalTestCase
                 'isVip' => false,
                 'whichPlugin' => 'seminar_list',
                 'registrationsListPID' => 0,
-                'registrationsVipListPID' => 0,
             ],
             'seminarListLoggedInWithListPid' => [
                 'expected' => false,
@@ -5986,7 +5984,6 @@ final class LegacyEventTest extends FunctionalTestCase
                 'isVip' => false,
                 'whichPlugin' => 'seminar_list',
                 'registrationsListPID' => 1,
-                'registrationsVipListPID' => 0,
             ],
             'seminarListIsRegisteredWithListPid' => [
                 'expected' => true,
@@ -5995,7 +5992,6 @@ final class LegacyEventTest extends FunctionalTestCase
                 'isVip' => false,
                 'whichPlugin' => 'seminar_list',
                 'registrationsListPID' => 1,
-                'registrationsVipListPID' => 0,
             ],
             'seminarListIsRegisteredWithoutListPid' => [
                 'expected' => false,
@@ -6004,16 +6000,6 @@ final class LegacyEventTest extends FunctionalTestCase
                 'isVip' => false,
                 'whichPlugin' => 'seminar_list',
                 'registrationsListPID' => 0,
-                'registrationsVipListPID' => 0,
-            ],
-            'seminarListIsVipWithListPid' => [
-                'expected' => true,
-                'loggedIn' => true,
-                'isRegistered' => true,
-                'isVip' => true,
-                'whichPlugin' => 'seminar_list',
-                'registrationsListPID' => 0,
-                'registrationsVipListPID' => 1,
             ],
             'seminarListIsVipWithoutListPid' => [
                 'expected' => false,
@@ -6022,7 +6008,6 @@ final class LegacyEventTest extends FunctionalTestCase
                 'isVip' => true,
                 'whichPlugin' => 'seminar_list',
                 'registrationsListPID' => 0,
-                'registrationsVipListPID' => 0,
             ],
             'myEventsIsRegisteredWithListPid' => [
                 'expected' => true,
@@ -6031,7 +6016,6 @@ final class LegacyEventTest extends FunctionalTestCase
                 'isVip' => false,
                 'whichPlugin' => 'my_events',
                 'registrationsListPID' => 1,
-                'registrationsVipListPID' => 1,
             ],
             'myEventsIsVipWithListPid' => [
                 'expected' => false,
@@ -6040,7 +6024,6 @@ final class LegacyEventTest extends FunctionalTestCase
                 'isVip' => true,
                 'whichPlugin' => 'my_events',
                 'registrationsListPID' => 1,
-                'registrationsVipListPID' => 1,
             ],
             'myVipEventsIsRegisteredWithListPid' => [
                 'expected' => false,
@@ -6049,16 +6032,6 @@ final class LegacyEventTest extends FunctionalTestCase
                 'isVip' => false,
                 'whichPlugin' => 'my_vip_events',
                 'registrationsListPID' => 1,
-                'registrationsVipListPID' => 1,
-            ],
-            'myVipEventsIsVipWithListPid' => [
-                'expected' => true,
-                'loggedIn' => true,
-                'isRegistered' => false,
-                'isVip' => true,
-                'whichPlugin' => 'my_vip_events',
-                'registrationsListPID' => 1,
-                'registrationsVipListPID' => 1,
             ],
             'listRegistrationsIsRegistered' => [
                 'expected' => true,
@@ -6067,7 +6040,6 @@ final class LegacyEventTest extends FunctionalTestCase
                 'isVip' => false,
                 'whichPlugin' => 'list_registrations',
                 'registrationsListPID' => 0,
-                'registrationsVipListPID' => 0,
             ],
             'listRegistrationsIsVip' => [
                 'expected' => false,
@@ -6076,25 +6048,6 @@ final class LegacyEventTest extends FunctionalTestCase
                 'isVip' => true,
                 'whichPlugin' => 'list_registrations',
                 'registrationsListPID' => 0,
-                'registrationsVipListPID' => 0,
-            ],
-            'listVipRegistrationsIsRegistered' => [
-                'expected' => false,
-                'loggedIn' => true,
-                'isRegistered' => true,
-                'isVip' => false,
-                'whichPlugin' => 'list_vip_registrations',
-                'registrationsListPID' => 0,
-                'registrationsVipListPID' => 0,
-            ],
-            'listVipRegistrationsIsVip' => [
-                'expected' => true,
-                'loggedIn' => true,
-                'isRegistered' => false,
-                'isVip' => true,
-                'whichPlugin' => 'list_vip_registrations',
-                'registrationsListPID' => 0,
-                'registrationsVipListPID' => 0,
             ],
         ];
     }
@@ -6110,8 +6063,7 @@ final class LegacyEventTest extends FunctionalTestCase
         bool $isRegistered,
         bool $isVip,
         string $whichPlugin,
-        int $registrationsListPID,
-        int $registrationsVipListPID
+        int $registrationsListPID
     ): void {
         $subject = $this
             ->getMockBuilder(LegacyEvent::class)
@@ -6136,11 +6088,7 @@ final class LegacyEventTest extends FunctionalTestCase
 
         self::assertSame(
             $expected,
-            $subject->canViewRegistrationsList(
-                $whichPlugin,
-                $registrationsListPID,
-                $registrationsVipListPID,
-            ),
+            $subject->canViewRegistrationsList($whichPlugin, $registrationsListPID),
         );
     }
 
@@ -6171,20 +6119,6 @@ final class LegacyEventTest extends FunctionalTestCase
         self::assertSame(
             $this->translate('message_notLoggedIn'),
             $subject->canViewRegistrationsListMessage('list_registrations'),
-        );
-    }
-
-    /**
-     * @test
-     */
-    public function canViewRegistrationsListMessageForVipListAndNoLoginReturnsPleaseLoginMessage(): void
-    {
-        $subject = $this->getMockBuilder(LegacyEvent::class)->onlyMethods(['needsRegistration'])->getMock();
-        $subject->method('needsRegistration')->willReturn(true);
-
-        self::assertSame(
-            $this->translate('message_notLoggedIn'),
-            $subject->canViewRegistrationsListMessage('list_vip_registrations'),
         );
     }
 


### PR DESCRIPTION
Also drop the configuration for the PID of the VIP/manager
registration list.

The tests and the touched code now are bit rough around the
edges. This will get better when we completely remove the FE registration lists.

Part of #5105