### PR TITLE
[BUGFIX] Use the correct no-wrap Bootstrap class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -242,6 +242,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- Use the correct no-wrap Bootstrap class (#5151)
 - Avoid the deprecated static `TemplateRegistry` methods (#5013)
 - Avoid the deprecated static `ConfigurationRegistry` methods (#5009, #5010)
 - Avoid using the deprecated `MapperRegistry::getInstance()`

--- a/Resources/Private/Partials/BackEnd/EventList.html
+++ b/Resources/Private/Partials/BackEnd/EventList.html
@@ -10,26 +10,26 @@
         <table class="table table-hover table-striped">
             <thead>
                 <tr>
-                    <th scope="col" colspan="2" class="nowrap">
+                    <th scope="col" colspan="2" class="text-nowrap">
                         <f:translate key="{propertyLabelPrefix}.uid"/>
                     </th>
                     <th scope="col" class="col-title col-responsive">
                         <f:translate key="{propertyLabelPrefix}.internalTitle"/>
                     </th>
-                    <th scope="col" class="nowrap">
+                    <th scope="col" class="text-nowrap">
                         <f:translate key="{propertyLabelPrefix}.date"/>
                     </th>
                     <f:if condition="{permissions.writeAccessToEvents}">
-                        <th scope="col" class="col-control nowrap">&nbsp;</th>
+                        <th scope="col" class="col-control text-nowrap">&nbsp;</th>
                     </f:if>
-                    <th scope="col" class="nowrap">
+                    <th scope="col" class="text-nowrap">
                         <f:translate key="{propertyLabelPrefix}.seats"/>
                     </th>
-                    <th scope="col" colspan="2" class="nowrap">
+                    <th scope="col" colspan="2" class="text-nowrap">
                         <f:translate key="{propertyLabelPrefix}.registrations"/>
                     </th>
                     <f:if condition="{permissions.readAccessToRegistrations}">
-                        <th scope="col" class="col-control nowrap">&nbsp;</th>
+                        <th scope="col" class="col-control text-nowrap">&nbsp;</th>
                     </f:if>
                 </tr>
             </thead>
@@ -46,10 +46,10 @@
                         <f:variable name="visible"
                                     value="{f:if(condition: '{event.rawData.hidden}', then: 0, else: 1)}"/>
                         <f:variable name="statistics" value="{event.statistics}"/>
-                        <td class="text-end text-right nowrap">
+                        <td class="text-end text-nowrap">
                             {event.uid}
                         </td>
-                        <td class="col-icon nowrap">
+                        <td class="col-icon text-nowrap">
                             <core:iconForRecord table="{tableName}" row="{event.rawData}"/>
                         </td>
                         <td class="col-title col-responsive">
@@ -65,11 +65,11 @@
                                 </f:else>
                             </f:if>
                         </td>
-                        <td class="nowrap">
+                        <td class="text-nowrap">
                             <f:render partial="EventDate" arguments="{event: event}"/>
                         </td>
                         <f:if condition="{permissions.writeAccessToEvents}">
-                            <td class="col-control nowrap">
+                            <td class="col-control text-nowrap">
                                 <div class="btn-group" role="group">
                                     <be:link.editRecord uid="{event.uid}" table="{tableName}" class="btn btn-default"
                                                         title="{f:translate(key: '{actionLabelPrefix}.editEvent')}">
@@ -117,13 +117,13 @@
                                 </div>
                             </td>
                         </f:if>
-                        <td class="nowrap">
+                        <td class="text-nowrap">
                             <f:render partial="BackEnd/SeatStatistics" arguments="{event: event}"/>
                         </td>
-                        <td class="nowrap">
+                        <td class="text-nowrap">
                             <f:render partial="BackEnd/RegistrationStatistics" arguments="{event: event}"/>
                         </td>
-                        <td class="nowrap">
+                        <td class="text-nowrap">
                             <f:if condition="{statistics}">
                                 <f:if
                                     condition="{statistics.regularSeatsCount} || {statistics.waitingListSeatsCount} || {statistics.nonbindingReservationSeatsCount}">
@@ -139,7 +139,7 @@
                             </f:if>
                         </td>
                         <f:if condition="{permissions.readAccessToRegistrations}">
-                            <td class="col-icon nowrap">
+                            <td class="col-icon text-nowrap">
                                 <f:if condition="{visible} && {statistics.regularSeatsCount}">
                                     <f:link.action controller="BackEnd\Email" action="compose"
                                                    title="{f:translate(key: '{actionLabelPrefix}.email.long')}"

--- a/Resources/Private/Partials/BackEnd/RegistrationList.html
+++ b/Resources/Private/Partials/BackEnd/RegistrationList.html
@@ -10,20 +10,20 @@
         <table class="table table-hover table-striped">
             <thead>
                 <tr>
-                    <th scope="col" colspan="2" class="nowrap">
+                    <th scope="col" colspan="2" class="text-nowrap">
                         <f:translate key="{propertyLabelPrefix}.uid"/>
                     </th>
                     <th scope="col" class="col-title col-responsive">
                         <f:translate key="{propertyLabelPrefix}.name"/>
                     </th>
-                    <th scope="col" class="nowrap">
+                    <th scope="col" class="text-nowrap">
                         <f:translate key="{propertyLabelPrefix}.seats"/>
                     </th>
-                    <th scope="col" class="nowrap">
+                    <th scope="col" class="text-nowrap">
                         <f:translate key="{propertyLabelPrefix}.invoicingStatus"/>
                     </th>
                     <f:if condition="{permissions.writeAccessToRegistrations}">
-                        <th scope="col" class="col-control nowrap">&nbsp;</th>
+                        <th scope="col" class="col-control text-nowrap">&nbsp;</th>
                     </f:if>
                 </tr>
             </thead>
@@ -39,10 +39,10 @@
 
                 <f:for each="{registrations}" as="registration">
                     <tr>
-                        <td class="text-end text-right nowrap">
+                        <td class="text-end text-nowrap">
                             {registration.uid}
                         </td>
-                        <td class="col-icon nowrap">
+                        <td class="col-icon text-nowrap">
                             <core:iconForRecord table="{tableName}" row="{registration.rawData}"/>
                         </td>
                         <td class="col-title col-responsive">
@@ -79,10 +79,10 @@
                                 </f:else>
                             </f:if>
                         </td>
-                        <td class="text-end text-right nowrap">
+                        <td class="text-end text-nowrap">
                             {registration.seats}
                         </td>
-                        <td class="nowrap">
+                        <td class="text-nowrap">
                             <f:if condition="{registration.paid}">
                                 <f:then>
                                     <f:translate key="{propertyLabelPrefix}.invoicingStatus.paid"/>
@@ -93,7 +93,7 @@
                             </f:if>
                         </td>
                         <f:if condition="{permissions.writeAccessToRegistrations}">
-                            <td class="col-control nowrap">
+                            <td class="col-control text-nowrap">
                                 <div class="btn-group" role="group">
                                     <be:link.editRecord uid="{registration.uid}" table="{tableName}"
                                                         class="btn btn-default"

--- a/Resources/Private/Templates/BackEnd/Module/Overview.html
+++ b/Resources/Private/Templates/BackEnd/Module/Overview.html
@@ -56,10 +56,10 @@
                     <table class="table table-hover table-responsive w-auto">
                         <tbody>
                             <tr>
-                                <th scope="row" class="nowrap">
+                                <th scope="row" class="text-nowrap">
                                     <f:translate key="{propertyLabelPrefix}.registrations"/>
                                 </th>
-                                <td class="nowrap">
+                                <td class="text-nowrap">
                                     {numberOfRegistrations}
                                 </td>
                             </tr>

--- a/Resources/Private/Templates/BackEnd/Registration/ShowForEvent.html
+++ b/Resources/Private/Templates/BackEnd/Registration/ShowForEvent.html
@@ -42,18 +42,18 @@
                 <table class="table table-hover w-auto">
                     <tbody>
                         <tr>
-                            <th scope="row" class="nowrap">
+                            <th scope="row" class="text-nowrap">
                                 <f:translate key="{propertyLabelPrefix}.seats"/>
                             </th>
-                            <td class="nowrap">
+                            <td class="text-nowrap">
                                 <f:render partial="BackEnd/SeatStatistics" arguments="{event: event}"/>
                             </td>
                         </tr>
                         <tr>
-                            <th scope="row" class="nowrap">
+                            <th scope="row" class="text-nowrap">
                                 <f:translate key="{propertyLabelPrefix}.registrations"/>
                             </th>
-                            <td class="nowrap">
+                            <td class="text-nowrap">
                                 <f:render partial="BackEnd/RegistrationStatistics" arguments="{event: event}"/>
                             </td>
                         </tr>


### PR DESCRIPTION
The Bootstrap class for no-wrap text is named `text-nowrap`, not `nowrap`:

https://getbootstrap.com/docs/5.3/utilities/text/

Also drop `text-right` in favor of `text-end`, which fixes to RTL text. This class was introduced in Bootstrap 5.2, which TYPO3 11LTS adopted for the backend. So it's safe to use now.

Fixes #2087
Fixes #4569