### PR TITLE
[BUGFIX] Always load all dependencies in the functional tests

### DIFF
--- a/Tests/Functional/BackEnd/EmailServiceTest.php
+++ b/Tests/Functional/BackEnd/EmailServiceTest.php
@@ -23,7 +23,13 @@ final class EmailServiceTest extends FunctionalTestCase
     use EmailTrait;
     use MakeInstanceTrait;
 
+    protected array $coreExtensionsToLoad = [
+        'typo3/cms-extensionmanager',
+        'typo3/cms-install',
+    ];
+
     protected array $testExtensionsToLoad = [
+        'sjbr/static-info-tables',
         'oliverklee/feuserextrafields',
         'oliverklee/oelib',
         'oliverklee/seminars',

--- a/Tests/Functional/BackEnd/PermissionsTest.php
+++ b/Tests/Functional/BackEnd/PermissionsTest.php
@@ -12,7 +12,13 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
  */
 final class PermissionsTest extends FunctionalTestCase
 {
+    protected array $coreExtensionsToLoad = [
+        'typo3/cms-extensionmanager',
+        'typo3/cms-install',
+    ];
+
     protected array $testExtensionsToLoad = [
+        'sjbr/static-info-tables',
         'oliverklee/feuserextrafields',
         'oliverklee/oelib',
         'oliverklee/seminars',

--- a/Tests/Functional/Bag/SpeakerBagTest.php
+++ b/Tests/Functional/Bag/SpeakerBagTest.php
@@ -13,7 +13,13 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
  */
 final class SpeakerBagTest extends FunctionalTestCase
 {
+    protected array $coreExtensionsToLoad = [
+        'typo3/cms-extensionmanager',
+        'typo3/cms-install',
+    ];
+
     protected array $testExtensionsToLoad = [
+        'sjbr/static-info-tables',
         'oliverklee/feuserextrafields',
         'oliverklee/oelib',
         'oliverklee/seminars',

--- a/Tests/Functional/BagBuilder/AbstractBagBuilderTest.php
+++ b/Tests/Functional/BagBuilder/AbstractBagBuilderTest.php
@@ -13,7 +13,13 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
  */
 final class AbstractBagBuilderTest extends FunctionalTestCase
 {
+    protected array $coreExtensionsToLoad = [
+        'typo3/cms-extensionmanager',
+        'typo3/cms-install',
+    ];
+
     protected array $testExtensionsToLoad = [
+        'sjbr/static-info-tables',
         'oliverklee/feuserextrafields',
         'oliverklee/oelib',
         'oliverklee/seminars',

--- a/Tests/Functional/BagBuilder/EventBagBuilderTest.php
+++ b/Tests/Functional/BagBuilder/EventBagBuilderTest.php
@@ -14,7 +14,13 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
  */
 final class EventBagBuilderTest extends FunctionalTestCase
 {
+    protected array $coreExtensionsToLoad = [
+        'typo3/cms-extensionmanager',
+        'typo3/cms-install',
+    ];
+
     protected array $testExtensionsToLoad = [
+        'sjbr/static-info-tables',
         'oliverklee/feuserextrafields',
         'oliverklee/oelib',
         'oliverklee/seminars',

--- a/Tests/Functional/Controller/Event/BeforeAttendeeDownloadSentEventTest.php
+++ b/Tests/Functional/Controller/Event/BeforeAttendeeDownloadSentEventTest.php
@@ -18,7 +18,13 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
  */
 final class BeforeAttendeeDownloadSentEventTest extends FunctionalTestCase
 {
+    protected array $coreExtensionsToLoad = [
+        'typo3/cms-extensionmanager',
+        'typo3/cms-install',
+    ];
+
     protected array $testExtensionsToLoad = [
+        'sjbr/static-info-tables',
         'oliverklee/feuserextrafields',
         'oliverklee/oelib',
         'oliverklee/seminars',

--- a/Tests/Functional/Controller/EventControllerTest.php
+++ b/Tests/Functional/Controller/EventControllerTest.php
@@ -16,12 +16,15 @@ final class EventControllerTest extends FunctionalTestCase
     private const FIXTURES_PATH = __DIR__ . '/Fixtures/EventController';
 
     protected array $testExtensionsToLoad = [
+        'sjbr/static-info-tables',
         'oliverklee/feuserextrafields',
         'oliverklee/oelib',
         'oliverklee/seminars',
     ];
 
     protected array $coreExtensionsToLoad = [
+        'typo3/cms-extensionmanager',
+        'typo3/cms-install',
         'typo3/cms-fluid-styled-content',
     ];
 

--- a/Tests/Functional/Controller/FrontEndEditorControllerTest.php
+++ b/Tests/Functional/Controller/FrontEndEditorControllerTest.php
@@ -21,12 +21,15 @@ final class FrontEndEditorControllerTest extends FunctionalTestCase
     private const PAGE_UID = 8;
 
     protected array $testExtensionsToLoad = [
+        'sjbr/static-info-tables',
         'oliverklee/feuserextrafields',
         'oliverklee/oelib',
         'oliverklee/seminars',
     ];
 
     protected array $coreExtensionsToLoad = [
+        'typo3/cms-extensionmanager',
+        'typo3/cms-install',
         'typo3/cms-fluid-styled-content',
     ];
 

--- a/Tests/Functional/Controller/MyRegistrationsControllerTest.php
+++ b/Tests/Functional/Controller/MyRegistrationsControllerTest.php
@@ -17,12 +17,15 @@ final class MyRegistrationsControllerTest extends FunctionalTestCase
     private const FIXTURES_PATH = __DIR__ . '/Fixtures/MyRegistrationsController';
 
     protected array $testExtensionsToLoad = [
+        'sjbr/static-info-tables',
         'oliverklee/feuserextrafields',
         'oliverklee/oelib',
         'oliverklee/seminars',
     ];
 
     protected array $coreExtensionsToLoad = [
+        'typo3/cms-extensionmanager',
+        'typo3/cms-install',
         'typo3/cms-fluid-styled-content',
     ];
 

--- a/Tests/Functional/Csv/CsvDownloaderTest.php
+++ b/Tests/Functional/Csv/CsvDownloaderTest.php
@@ -15,7 +15,13 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
  */
 final class CsvDownloaderTest extends FunctionalTestCase
 {
+    protected array $coreExtensionsToLoad = [
+        'typo3/cms-extensionmanager',
+        'typo3/cms-install',
+    ];
+
     protected array $testExtensionsToLoad = [
+        'sjbr/static-info-tables',
         'oliverklee/feuserextrafields',
         'oliverklee/oelib',
         'oliverklee/seminars',

--- a/Tests/Functional/Csv/DownloadRegistrationListViewTest.php
+++ b/Tests/Functional/Csv/DownloadRegistrationListViewTest.php
@@ -15,7 +15,13 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
  */
 final class DownloadRegistrationListViewTest extends FunctionalTestCase
 {
+    protected array $coreExtensionsToLoad = [
+        'typo3/cms-extensionmanager',
+        'typo3/cms-install',
+    ];
+
     protected array $testExtensionsToLoad = [
+        'sjbr/static-info-tables',
         'oliverklee/feuserextrafields',
         'oliverklee/oelib',
         'oliverklee/seminars',

--- a/Tests/Functional/Domain/Model/Event/TimeSlotTest.php
+++ b/Tests/Functional/Domain/Model/Event/TimeSlotTest.php
@@ -15,7 +15,13 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
  */
 final class TimeSlotTest extends FunctionalTestCase
 {
+    protected array $coreExtensionsToLoad = [
+        'typo3/cms-extensionmanager',
+        'typo3/cms-install',
+    ];
+
     protected array $testExtensionsToLoad = [
+        'sjbr/static-info-tables',
         'oliverklee/feuserextrafields',
         'oliverklee/oelib',
         'oliverklee/seminars',

--- a/Tests/Functional/Domain/Repository/AccommodationOptionRepositoryTest.php
+++ b/Tests/Functional/Domain/Repository/AccommodationOptionRepositoryTest.php
@@ -15,7 +15,13 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
  */
 final class AccommodationOptionRepositoryTest extends FunctionalTestCase
 {
+    protected array $coreExtensionsToLoad = [
+        'typo3/cms-extensionmanager',
+        'typo3/cms-install',
+    ];
+
     protected array $testExtensionsToLoad = [
+        'sjbr/static-info-tables',
         'oliverklee/feuserextrafields',
         'oliverklee/oelib',
         'oliverklee/seminars',

--- a/Tests/Functional/Domain/Repository/CategoryRepositoryTest.php
+++ b/Tests/Functional/Domain/Repository/CategoryRepositoryTest.php
@@ -15,7 +15,13 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
  */
 final class CategoryRepositoryTest extends FunctionalTestCase
 {
+    protected array $coreExtensionsToLoad = [
+        'typo3/cms-extensionmanager',
+        'typo3/cms-install',
+    ];
+
     protected array $testExtensionsToLoad = [
+        'sjbr/static-info-tables',
         'oliverklee/feuserextrafields',
         'oliverklee/oelib',
         'oliverklee/seminars',

--- a/Tests/Functional/Domain/Repository/Event/EventRepositoryTest.php
+++ b/Tests/Functional/Domain/Repository/Event/EventRepositoryTest.php
@@ -44,7 +44,13 @@ final class EventRepositoryTest extends FunctionalTestCase
 {
     use BackEndTestsTrait;
 
+    protected array $coreExtensionsToLoad = [
+        'typo3/cms-extensionmanager',
+        'typo3/cms-install',
+    ];
+
     protected array $testExtensionsToLoad = [
+        'sjbr/static-info-tables',
         'oliverklee/feuserextrafields',
         'oliverklee/oelib',
         'oliverklee/seminars',

--- a/Tests/Functional/Domain/Repository/Event/TimeSlotRepositoryTest.php
+++ b/Tests/Functional/Domain/Repository/Event/TimeSlotRepositoryTest.php
@@ -17,7 +17,13 @@ final class TimeSlotRepositoryTest extends FunctionalTestCase
 {
     private const FIXTURES_PATH = __DIR__ . '/Fixtures';
 
+    protected array $coreExtensionsToLoad = [
+        'typo3/cms-extensionmanager',
+        'typo3/cms-install',
+    ];
+
     protected array $testExtensionsToLoad = [
+        'sjbr/static-info-tables',
         'oliverklee/feuserextrafields',
         'oliverklee/oelib',
         'oliverklee/seminars',

--- a/Tests/Functional/Domain/Repository/EventTypeRepositoryTest.php
+++ b/Tests/Functional/Domain/Repository/EventTypeRepositoryTest.php
@@ -16,7 +16,13 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
  */
 final class EventTypeRepositoryTest extends FunctionalTestCase
 {
+    protected array $coreExtensionsToLoad = [
+        'typo3/cms-extensionmanager',
+        'typo3/cms-install',
+    ];
+
     protected array $testExtensionsToLoad = [
+        'sjbr/static-info-tables',
         'oliverklee/feuserextrafields',
         'oliverklee/oelib',
         'oliverklee/seminars',

--- a/Tests/Functional/Domain/Repository/FoodOptionRepositoryTest.php
+++ b/Tests/Functional/Domain/Repository/FoodOptionRepositoryTest.php
@@ -15,7 +15,13 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
  */
 final class FoodOptionRepositoryTest extends FunctionalTestCase
 {
+    protected array $coreExtensionsToLoad = [
+        'typo3/cms-extensionmanager',
+        'typo3/cms-install',
+    ];
+
     protected array $testExtensionsToLoad = [
+        'sjbr/static-info-tables',
         'oliverklee/feuserextrafields',
         'oliverklee/oelib',
         'oliverklee/seminars',

--- a/Tests/Functional/Domain/Repository/FrontendUserRepositoryTest.php
+++ b/Tests/Functional/Domain/Repository/FrontendUserRepositoryTest.php
@@ -16,7 +16,13 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
  */
 final class FrontendUserRepositoryTest extends FunctionalTestCase
 {
+    protected array $coreExtensionsToLoad = [
+        'typo3/cms-extensionmanager',
+        'typo3/cms-install',
+    ];
+
     protected array $testExtensionsToLoad = [
+        'sjbr/static-info-tables',
         'oliverklee/feuserextrafields',
         'oliverklee/oelib',
         'oliverklee/seminars',

--- a/Tests/Functional/Domain/Repository/OrganizerRepositoryTest.php
+++ b/Tests/Functional/Domain/Repository/OrganizerRepositoryTest.php
@@ -15,7 +15,13 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
  */
 final class OrganizerRepositoryTest extends FunctionalTestCase
 {
+    protected array $coreExtensionsToLoad = [
+        'typo3/cms-extensionmanager',
+        'typo3/cms-install',
+    ];
+
     protected array $testExtensionsToLoad = [
+        'sjbr/static-info-tables',
         'oliverklee/feuserextrafields',
         'oliverklee/oelib',
         'oliverklee/seminars',

--- a/Tests/Functional/Domain/Repository/PageRepositoryTest.php
+++ b/Tests/Functional/Domain/Repository/PageRepositoryTest.php
@@ -12,7 +12,13 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
  */
 final class PageRepositoryTest extends FunctionalTestCase
 {
+    protected array $coreExtensionsToLoad = [
+        'typo3/cms-extensionmanager',
+        'typo3/cms-install',
+    ];
+
     protected array $testExtensionsToLoad = [
+        'sjbr/static-info-tables',
         'oliverklee/feuserextrafields',
         'oliverklee/oelib',
         'oliverklee/seminars',

--- a/Tests/Functional/Domain/Repository/PaymentMethodRepositoryTest.php
+++ b/Tests/Functional/Domain/Repository/PaymentMethodRepositoryTest.php
@@ -15,7 +15,13 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
  */
 final class PaymentMethodRepositoryTest extends FunctionalTestCase
 {
+    protected array $coreExtensionsToLoad = [
+        'typo3/cms-extensionmanager',
+        'typo3/cms-install',
+    ];
+
     protected array $testExtensionsToLoad = [
+        'sjbr/static-info-tables',
         'oliverklee/feuserextrafields',
         'oliverklee/oelib',
         'oliverklee/seminars',

--- a/Tests/Functional/Domain/Repository/Registration/RegistrationRepositoryTest.php
+++ b/Tests/Functional/Domain/Repository/Registration/RegistrationRepositoryTest.php
@@ -35,7 +35,13 @@ final class RegistrationRepositoryTest extends FunctionalTestCase
 {
     use BackEndTestsTrait;
 
+    protected array $coreExtensionsToLoad = [
+        'typo3/cms-extensionmanager',
+        'typo3/cms-install',
+    ];
+
     protected array $testExtensionsToLoad = [
+        'sjbr/static-info-tables',
         'oliverklee/feuserextrafields',
         'oliverklee/oelib',
         'oliverklee/seminars',

--- a/Tests/Functional/Domain/Repository/RegistrationCheckboxRepositoryTest.php
+++ b/Tests/Functional/Domain/Repository/RegistrationCheckboxRepositoryTest.php
@@ -15,7 +15,13 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
  */
 final class RegistrationCheckboxRepositoryTest extends FunctionalTestCase
 {
+    protected array $coreExtensionsToLoad = [
+        'typo3/cms-extensionmanager',
+        'typo3/cms-install',
+    ];
+
     protected array $testExtensionsToLoad = [
+        'sjbr/static-info-tables',
         'oliverklee/feuserextrafields',
         'oliverklee/oelib',
         'oliverklee/seminars',

--- a/Tests/Functional/Domain/Repository/SpeakerRepositoryTest.php
+++ b/Tests/Functional/Domain/Repository/SpeakerRepositoryTest.php
@@ -17,7 +17,13 @@ final class SpeakerRepositoryTest extends FunctionalTestCase
 {
     private const FIXTURES_PATH = __DIR__ . '/Fixtures/SpeakerRepository';
 
+    protected array $coreExtensionsToLoad = [
+        'typo3/cms-extensionmanager',
+        'typo3/cms-install',
+    ];
+
     protected array $testExtensionsToLoad = [
+        'sjbr/static-info-tables',
         'oliverklee/feuserextrafields',
         'oliverklee/oelib',
         'oliverklee/seminars',

--- a/Tests/Functional/Domain/Repository/VenueRepositoryTest.php
+++ b/Tests/Functional/Domain/Repository/VenueRepositoryTest.php
@@ -17,7 +17,13 @@ final class VenueRepositoryTest extends FunctionalTestCase
 {
     private const FIXTURES_PATH = __DIR__ . '/Fixtures/VenueRepository';
 
+    protected array $coreExtensionsToLoad = [
+        'typo3/cms-extensionmanager',
+        'typo3/cms-install',
+    ];
+
     protected array $testExtensionsToLoad = [
+        'sjbr/static-info-tables',
         'oliverklee/feuserextrafields',
         'oliverklee/oelib',
         'oliverklee/seminars',

--- a/Tests/Functional/Email/SalutationBuilderTest.php
+++ b/Tests/Functional/Email/SalutationBuilderTest.php
@@ -22,7 +22,13 @@ final class SalutationBuilderTest extends FunctionalTestCase
     private const TIME_FORMAT = 'H:i';
     private const SECONDS_PER_HOUR = 3600;
 
+    protected array $coreExtensionsToLoad = [
+        'typo3/cms-extensionmanager',
+        'typo3/cms-install',
+    ];
+
     protected array $testExtensionsToLoad = [
+        'sjbr/static-info-tables',
         'oliverklee/feuserextrafields',
         'oliverklee/oelib',
         'oliverklee/seminars',

--- a/Tests/Functional/Form/Element/EventDetailsElementTest.php
+++ b/Tests/Functional/Form/Element/EventDetailsElementTest.php
@@ -18,7 +18,13 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
  */
 final class EventDetailsElementTest extends FunctionalTestCase
 {
+    protected array $coreExtensionsToLoad = [
+        'typo3/cms-extensionmanager',
+        'typo3/cms-install',
+    ];
+
     protected array $testExtensionsToLoad = [
+        'sjbr/static-info-tables',
         'oliverklee/feuserextrafields',
         'oliverklee/oelib',
         'oliverklee/seminars',

--- a/Tests/Functional/FrontEnd/CategoryListTest.php
+++ b/Tests/Functional/FrontEnd/CategoryListTest.php
@@ -19,7 +19,13 @@ final class CategoryListTest extends FunctionalTestCase
 {
     use BackendLanguageTrait;
 
+    protected array $coreExtensionsToLoad = [
+        'typo3/cms-extensionmanager',
+        'typo3/cms-install',
+    ];
+
     protected array $testExtensionsToLoad = [
+        'sjbr/static-info-tables',
         'oliverklee/feuserextrafields',
         'oliverklee/oelib',
         'oliverklee/seminars',

--- a/Tests/Functional/FrontEnd/DefaultController/ListViewTest.php
+++ b/Tests/Functional/FrontEnd/DefaultController/ListViewTest.php
@@ -15,7 +15,13 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
  */
 final class ListViewTest extends FunctionalTestCase
 {
+    protected array $coreExtensionsToLoad = [
+        'typo3/cms-extensionmanager',
+        'typo3/cms-install',
+    ];
+
     protected array $testExtensionsToLoad = [
+        'sjbr/static-info-tables',
         'oliverklee/feuserextrafields',
         'oliverklee/oelib',
         'oliverklee/seminars',

--- a/Tests/Functional/FrontEnd/DefaultController/PluginDefinitionTest.php
+++ b/Tests/Functional/FrontEnd/DefaultController/PluginDefinitionTest.php
@@ -12,7 +12,13 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
  */
 final class PluginDefinitionTest extends FunctionalTestCase
 {
+    protected array $coreExtensionsToLoad = [
+        'typo3/cms-extensionmanager',
+        'typo3/cms-install',
+    ];
+
     protected array $testExtensionsToLoad = [
+        'sjbr/static-info-tables',
         'oliverklee/feuserextrafields',
         'oliverklee/oelib',
         'oliverklee/seminars',

--- a/Tests/Functional/FrontEnd/DefaultController/SingleViewTest.php
+++ b/Tests/Functional/FrontEnd/DefaultController/SingleViewTest.php
@@ -18,7 +18,13 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
  */
 final class SingleViewTest extends FunctionalTestCase
 {
+    protected array $coreExtensionsToLoad = [
+        'typo3/cms-extensionmanager',
+        'typo3/cms-install',
+    ];
+
     protected array $testExtensionsToLoad = [
+        'sjbr/static-info-tables',
         'oliverklee/feuserextrafields',
         'oliverklee/oelib',
         'oliverklee/seminars',

--- a/Tests/Functional/Hooks/DataHandlerHookTest.php
+++ b/Tests/Functional/Hooks/DataHandlerHookTest.php
@@ -21,7 +21,13 @@ final class DataHandlerHookTest extends FunctionalTestCase
 
     private const EVENTS_TABLE = 'tx_seminars_seminars';
 
+    protected array $coreExtensionsToLoad = [
+        'typo3/cms-extensionmanager',
+        'typo3/cms-install',
+    ];
+
     protected array $testExtensionsToLoad = [
+        'sjbr/static-info-tables',
         'oliverklee/feuserextrafields',
         'oliverklee/oelib',
         'oliverklee/seminars',

--- a/Tests/Functional/Mapper/EventMapperTest.php
+++ b/Tests/Functional/Mapper/EventMapperTest.php
@@ -16,7 +16,13 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
  */
 final class EventMapperTest extends FunctionalTestCase
 {
+    protected array $coreExtensionsToLoad = [
+        'typo3/cms-extensionmanager',
+        'typo3/cms-install',
+    ];
+
     protected array $testExtensionsToLoad = [
+        'sjbr/static-info-tables',
         'oliverklee/feuserextrafields',
         'oliverklee/oelib',
         'oliverklee/seminars',

--- a/Tests/Functional/Middleware/ResponseHeadersModifierTest.php
+++ b/Tests/Functional/Middleware/ResponseHeadersModifierTest.php
@@ -14,7 +14,13 @@ final class ResponseHeadersModifierTest extends FunctionalTestCase
 {
     protected bool $initializeDatabase = false;
 
+    protected array $coreExtensionsToLoad = [
+        'typo3/cms-extensionmanager',
+        'typo3/cms-install',
+    ];
+
     protected array $testExtensionsToLoad = [
+        'sjbr/static-info-tables',
         'oliverklee/feuserextrafields',
         'oliverklee/oelib',
         'oliverklee/seminars',

--- a/Tests/Functional/OldModel/AbstractModelTest.php
+++ b/Tests/Functional/OldModel/AbstractModelTest.php
@@ -21,7 +21,13 @@ final class AbstractModelTest extends FunctionalTestCase
      */
     private int $now;
 
+    protected array $coreExtensionsToLoad = [
+        'typo3/cms-extensionmanager',
+        'typo3/cms-install',
+    ];
+
     protected array $testExtensionsToLoad = [
+        'sjbr/static-info-tables',
         'oliverklee/feuserextrafields',
         'oliverklee/oelib',
         'oliverklee/seminars',

--- a/Tests/Functional/OldModel/AbstractTimeSpanTest.php
+++ b/Tests/Functional/OldModel/AbstractTimeSpanTest.php
@@ -20,7 +20,13 @@ final class AbstractTimeSpanTest extends FunctionalTestCase
 {
     use BackendLanguageTrait;
 
+    protected array $coreExtensionsToLoad = [
+        'typo3/cms-extensionmanager',
+        'typo3/cms-install',
+    ];
+
     protected array $testExtensionsToLoad = [
+        'sjbr/static-info-tables',
         'oliverklee/feuserextrafields',
         'oliverklee/oelib',
         'oliverklee/seminars',

--- a/Tests/Functional/OldModel/LegacyCategoryTest.php
+++ b/Tests/Functional/OldModel/LegacyCategoryTest.php
@@ -13,7 +13,13 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
  */
 final class LegacyCategoryTest extends FunctionalTestCase
 {
+    protected array $coreExtensionsToLoad = [
+        'typo3/cms-extensionmanager',
+        'typo3/cms-install',
+    ];
+
     protected array $testExtensionsToLoad = [
+        'sjbr/static-info-tables',
         'oliverklee/feuserextrafields',
         'oliverklee/oelib',
         'oliverklee/seminars',

--- a/Tests/Functional/OldModel/LegacyEventTest.php
+++ b/Tests/Functional/OldModel/LegacyEventTest.php
@@ -37,7 +37,10 @@ final class LegacyEventTest extends FunctionalTestCase
         'oliverklee/seminars',
     ];
 
-    protected array $coreExtensionsToLoad = ['typo3/cms-extensionmanager'];
+    protected array $coreExtensionsToLoad = [
+        'typo3/cms-extensionmanager',
+        'typo3/cms-install',
+    ];
 
     private TestingFramework $testingFramework;
 

--- a/Tests/Functional/OldModel/LegacyRegistrationTest.php
+++ b/Tests/Functional/OldModel/LegacyRegistrationTest.php
@@ -22,7 +22,13 @@ final class LegacyRegistrationTest extends FunctionalTestCase
 {
     use BackendLanguageTrait;
 
+    protected array $coreExtensionsToLoad = [
+        'typo3/cms-extensionmanager',
+        'typo3/cms-install',
+    ];
+
     protected array $testExtensionsToLoad = [
+        'sjbr/static-info-tables',
         'oliverklee/feuserextrafields',
         'oliverklee/oelib',
         'oliverklee/seminars',

--- a/Tests/Functional/OldModel/LegacySpeakerTest.php
+++ b/Tests/Functional/OldModel/LegacySpeakerTest.php
@@ -14,7 +14,13 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
  */
 final class LegacySpeakerTest extends FunctionalTestCase
 {
+    protected array $coreExtensionsToLoad = [
+        'typo3/cms-extensionmanager',
+        'typo3/cms-install',
+    ];
+
     protected array $testExtensionsToLoad = [
+        'sjbr/static-info-tables',
         'oliverklee/feuserextrafields',
         'oliverklee/oelib',
         'oliverklee/seminars',

--- a/Tests/Functional/SchedulerTasks/MailNotifierConfigurationTest.php
+++ b/Tests/Functional/SchedulerTasks/MailNotifierConfigurationTest.php
@@ -23,9 +23,14 @@ final class MailNotifierConfigurationTest extends FunctionalTestCase
 {
     private const LABEL_PREFIX = 'LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:';
 
-    protected array $coreExtensionsToLoad = ['typo3/cms-scheduler'];
+    protected array $coreExtensionsToLoad = [
+        'typo3/cms-extensionmanager',
+        'typo3/cms-install',
+        'typo3/cms-scheduler',
+    ];
 
     protected array $testExtensionsToLoad = [
+        'sjbr/static-info-tables',
         'oliverklee/feuserextrafields',
         'oliverklee/oelib',
         'oliverklee/seminars',

--- a/Tests/Functional/SchedulerTasks/MailNotifierTest.php
+++ b/Tests/Functional/SchedulerTasks/MailNotifierTest.php
@@ -20,9 +20,14 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
  */
 final class MailNotifierTest extends FunctionalTestCase
 {
-    protected array $coreExtensionsToLoad = ['typo3/cms-scheduler'];
+    protected array $coreExtensionsToLoad = [
+        'typo3/cms-extensionmanager',
+        'typo3/cms-install',
+        'typo3/cms-scheduler',
+    ];
 
     protected array $testExtensionsToLoad = [
+        'sjbr/static-info-tables',
         'oliverklee/feuserextrafields',
         'oliverklee/oelib',
         'oliverklee/seminars',

--- a/Tests/Functional/SchedulerTasks/RegistrationDigestTest.php
+++ b/Tests/Functional/SchedulerTasks/RegistrationDigestTest.php
@@ -24,9 +24,14 @@ final class RegistrationDigestTest extends FunctionalTestCase
 {
     use EmailTrait;
 
-    protected array $coreExtensionsToLoad = ['typo3/cms-scheduler'];
+    protected array $coreExtensionsToLoad = [
+        'typo3/cms-extensionmanager',
+        'typo3/cms-install',
+        'typo3/cms-scheduler',
+    ];
 
     protected array $testExtensionsToLoad = [
+        'sjbr/static-info-tables',
         'oliverklee/feuserextrafields',
         'oliverklee/oelib',
         'oliverklee/seminars',

--- a/Tests/Functional/Seo/Event/AfterSlugGeneratedEventTest.php
+++ b/Tests/Functional/Seo/Event/AfterSlugGeneratedEventTest.php
@@ -16,7 +16,13 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
  */
 final class AfterSlugGeneratedEventTest extends FunctionalTestCase
 {
+    protected array $coreExtensionsToLoad = [
+        'typo3/cms-extensionmanager',
+        'typo3/cms-install',
+    ];
+
     protected array $testExtensionsToLoad = [
+        'sjbr/static-info-tables',
         'oliverklee/feuserextrafields',
         'oliverklee/oelib',
         'oliverklee/seminars',

--- a/Tests/Functional/Seo/SlugGeneratorTest.php
+++ b/Tests/Functional/Seo/SlugGeneratorTest.php
@@ -16,7 +16,13 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
  */
 final class SlugGeneratorTest extends FunctionalTestCase
 {
+    protected array $coreExtensionsToLoad = [
+        'typo3/cms-extensionmanager',
+        'typo3/cms-install',
+    ];
+
     protected array $testExtensionsToLoad = [
+        'sjbr/static-info-tables',
         'oliverklee/feuserextrafields',
         'oliverklee/oelib',
         'oliverklee/seminars',

--- a/Tests/Functional/Service/EmailServiceTest.php
+++ b/Tests/Functional/Service/EmailServiceTest.php
@@ -27,7 +27,13 @@ final class EmailServiceTest extends FunctionalTestCase
     use EmailTrait;
     use MakeInstanceTrait;
 
+    protected array $coreExtensionsToLoad = [
+        'typo3/cms-extensionmanager',
+        'typo3/cms-install',
+    ];
+
     protected array $testExtensionsToLoad = [
+        'sjbr/static-info-tables',
         'oliverklee/feuserextrafields',
         'oliverklee/oelib',
         'oliverklee/seminars',

--- a/Tests/Functional/Service/EventStatisticsCalculatorTest.php
+++ b/Tests/Functional/Service/EventStatisticsCalculatorTest.php
@@ -14,7 +14,13 @@ final class EventStatisticsCalculatorTest extends FunctionalTestCase
 {
     protected bool $initializeDatabase = false;
 
+    protected array $coreExtensionsToLoad = [
+        'typo3/cms-extensionmanager',
+        'typo3/cms-install',
+    ];
+
     protected array $testExtensionsToLoad = [
+        'sjbr/static-info-tables',
         'oliverklee/feuserextrafields',
         'oliverklee/oelib',
         'oliverklee/seminars',

--- a/Tests/Functional/Service/OneTimeAccountConnectorTest.php
+++ b/Tests/Functional/Service/OneTimeAccountConnectorTest.php
@@ -14,7 +14,13 @@ final class OneTimeAccountConnectorTest extends FunctionalTestCase
 {
     protected bool $initializeDatabase = false;
 
+    protected array $coreExtensionsToLoad = [
+        'typo3/cms-extensionmanager',
+        'typo3/cms-install',
+    ];
+
     protected array $testExtensionsToLoad = [
+        'sjbr/static-info-tables',
         'oliverklee/feuserextrafields',
         'oliverklee/oelib',
         'oliverklee/seminars',

--- a/Tests/Functional/Service/PriceFinderTest.php
+++ b/Tests/Functional/Service/PriceFinderTest.php
@@ -17,7 +17,13 @@ final class PriceFinderTest extends FunctionalTestCase
 {
     protected bool $initializeDatabase = false;
 
+    protected array $coreExtensionsToLoad = [
+        'typo3/cms-extensionmanager',
+        'typo3/cms-install',
+    ];
+
     protected array $testExtensionsToLoad = [
+        'sjbr/static-info-tables',
         'oliverklee/feuserextrafields',
         'oliverklee/oelib',
         'oliverklee/seminars',

--- a/Tests/Functional/Service/RegistrationGuardTest.php
+++ b/Tests/Functional/Service/RegistrationGuardTest.php
@@ -14,7 +14,13 @@ final class RegistrationGuardTest extends FunctionalTestCase
 {
     protected bool $initializeDatabase = false;
 
+    protected array $coreExtensionsToLoad = [
+        'typo3/cms-extensionmanager',
+        'typo3/cms-install',
+    ];
+
     protected array $testExtensionsToLoad = [
+        'sjbr/static-info-tables',
         'oliverklee/feuserextrafields',
         'oliverklee/oelib',
         'oliverklee/seminars',

--- a/Tests/Functional/Service/RegistrationManagerTest.php
+++ b/Tests/Functional/Service/RegistrationManagerTest.php
@@ -42,7 +42,13 @@ final class RegistrationManagerTest extends FunctionalTestCase
      */
     private int $now;
 
+    protected array $coreExtensionsToLoad = [
+        'typo3/cms-extensionmanager',
+        'typo3/cms-install',
+    ];
+
     protected array $testExtensionsToLoad = [
+        'sjbr/static-info-tables',
         'oliverklee/feuserextrafields',
         'oliverklee/oelib',
         'oliverklee/seminars',

--- a/Tests/Functional/Service/RegistrationProcessorTest.php
+++ b/Tests/Functional/Service/RegistrationProcessorTest.php
@@ -17,7 +17,13 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
  */
 final class RegistrationProcessorTest extends FunctionalTestCase
 {
+    protected array $coreExtensionsToLoad = [
+        'typo3/cms-extensionmanager',
+        'typo3/cms-install',
+    ];
+
     protected array $testExtensionsToLoad = [
+        'sjbr/static-info-tables',
         'oliverklee/feuserextrafields',
         'oliverklee/oelib',
         'oliverklee/seminars',

--- a/Tests/Functional/Service/SingleViewLinkBuilderTest.php
+++ b/Tests/Functional/Service/SingleViewLinkBuilderTest.php
@@ -18,7 +18,13 @@ final class SingleViewLinkBuilderTest extends FunctionalTestCase
 {
     private const DEFAULT_SINGLE_VIEW_PAGE_UID = 3;
 
+    protected array $coreExtensionsToLoad = [
+        'typo3/cms-extensionmanager',
+        'typo3/cms-install',
+    ];
+
     protected array $testExtensionsToLoad = [
+        'sjbr/static-info-tables',
         'oliverklee/feuserextrafields',
         'oliverklee/oelib',
         'oliverklee/seminars',

--- a/Tests/Functional/Templating/TemplateHelperTest.php
+++ b/Tests/Functional/Templating/TemplateHelperTest.php
@@ -15,7 +15,13 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
  */
 final class TemplateHelperTest extends FunctionalTestCase
 {
+    protected array $coreExtensionsToLoad = [
+        'typo3/cms-extensionmanager',
+        'typo3/cms-install',
+    ];
+
     protected array $testExtensionsToLoad = [
+        'sjbr/static-info-tables',
         'oliverklee/feuserextrafields',
         'oliverklee/oelib',
         'oliverklee/seminars',

--- a/Tests/Functional/UpgradeWizards/CopyBillingAddressToRegistrationsUpgradeWizardTest.php
+++ b/Tests/Functional/UpgradeWizards/CopyBillingAddressToRegistrationsUpgradeWizardTest.php
@@ -16,7 +16,13 @@ class CopyBillingAddressToRegistrationsUpgradeWizardTest extends FunctionalTestC
     private const FIXTURES_PREFIX = __DIR__ . '/Fixtures/CopyBillingAddressToRegistrationsUpgradeWizard/';
     private const ASSERTIONS_PATH = __DIR__ . '/Assertions/CopyBillingAddressToRegistrationsUpgradeWizard/';
 
+    protected array $coreExtensionsToLoad = [
+        'typo3/cms-extensionmanager',
+        'typo3/cms-install',
+    ];
+
     protected array $testExtensionsToLoad = [
+        'sjbr/static-info-tables',
         'oliverklee/feuserextrafields',
         'oliverklee/oelib',
         'oliverklee/seminars',

--- a/Tests/Functional/UpgradeWizards/GenerateEventSlugsUpgradeWizardTest.php
+++ b/Tests/Functional/UpgradeWizards/GenerateEventSlugsUpgradeWizardTest.php
@@ -17,7 +17,13 @@ class GenerateEventSlugsUpgradeWizardTest extends FunctionalTestCase
 {
     private const FIXTURES_PREFIX = __DIR__ . '/Fixtures/GenerateEventSlugsUpgradeWizard/';
 
+    protected array $coreExtensionsToLoad = [
+        'typo3/cms-extensionmanager',
+        'typo3/cms-install',
+    ];
+
     protected array $testExtensionsToLoad = [
+        'sjbr/static-info-tables',
         'oliverklee/feuserextrafields',
         'oliverklee/oelib',
         'oliverklee/seminars',

--- a/Tests/Functional/UpgradeWizards/RemoveDuplicateEventVenueRelationsUpgradeWizardTest.php
+++ b/Tests/Functional/UpgradeWizards/RemoveDuplicateEventVenueRelationsUpgradeWizardTest.php
@@ -17,7 +17,13 @@ class RemoveDuplicateEventVenueRelationsUpgradeWizardTest extends FunctionalTest
     private const FIXTURES_PREFIX = __DIR__ . '/Fixtures/RemoveDuplicateEventVenueRelationsUpgradeWizard/';
     private const ASSERTIONS_PATH = __DIR__ . '/Assertions/RemoveDuplicateEventVenueRelationsUpgradeWizard/';
 
+    protected array $coreExtensionsToLoad = [
+        'typo3/cms-extensionmanager',
+        'typo3/cms-install',
+    ];
+
     protected array $testExtensionsToLoad = [
+        'sjbr/static-info-tables',
         'oliverklee/feuserextrafields',
         'oliverklee/oelib',
         'oliverklee/seminars',

--- a/Tests/Functional/ViewHelpers/DateRangeViewHelperTest.php
+++ b/Tests/Functional/ViewHelpers/DateRangeViewHelperTest.php
@@ -16,7 +16,13 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
  */
 final class DateRangeViewHelperTest extends FunctionalTestCase
 {
+    protected array $coreExtensionsToLoad = [
+        'typo3/cms-extensionmanager',
+        'typo3/cms-install',
+    ];
+
     protected array $testExtensionsToLoad = [
+        'sjbr/static-info-tables',
         'oliverklee/feuserextrafields',
         'oliverklee/oelib',
         'oliverklee/seminars',

--- a/Tests/Functional/ViewHelpers/SalutationAwareTranslateViewHelperTest.php
+++ b/Tests/Functional/ViewHelpers/SalutationAwareTranslateViewHelperTest.php
@@ -14,7 +14,13 @@ use TYPO3Fluid\Fluid\Core\Variables\StandardVariableProvider;
  */
 final class SalutationAwareTranslateViewHelperTest extends FunctionalTestCase
 {
+    protected array $coreExtensionsToLoad = [
+        'typo3/cms-extensionmanager',
+        'typo3/cms-install',
+    ];
+
     protected array $testExtensionsToLoad = [
+        'sjbr/static-info-tables',
         'oliverklee/feuserextrafields',
         'oliverklee/oelib',
         'oliverklee/seminars',

--- a/Tests/LegacyFunctional/Bag/AbstractBagTest.php
+++ b/Tests/LegacyFunctional/Bag/AbstractBagTest.php
@@ -13,7 +13,13 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
  */
 final class AbstractBagTest extends FunctionalTestCase
 {
+    protected array $coreExtensionsToLoad = [
+        'typo3/cms-extensionmanager',
+        'typo3/cms-install',
+    ];
+
     protected array $testExtensionsToLoad = [
+        'sjbr/static-info-tables',
         'oliverklee/feuserextrafields',
         'oliverklee/oelib',
         'oliverklee/seminars',

--- a/Tests/LegacyFunctional/Bag/CategoryBagTest.php
+++ b/Tests/LegacyFunctional/Bag/CategoryBagTest.php
@@ -13,7 +13,13 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
  */
 final class CategoryBagTest extends FunctionalTestCase
 {
+    protected array $coreExtensionsToLoad = [
+        'typo3/cms-extensionmanager',
+        'typo3/cms-install',
+    ];
+
     protected array $testExtensionsToLoad = [
+        'sjbr/static-info-tables',
         'oliverklee/feuserextrafields',
         'oliverklee/oelib',
         'oliverklee/seminars',

--- a/Tests/LegacyFunctional/Bag/EventBagTest.php
+++ b/Tests/LegacyFunctional/Bag/EventBagTest.php
@@ -13,7 +13,13 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
  */
 final class EventBagTest extends FunctionalTestCase
 {
+    protected array $coreExtensionsToLoad = [
+        'typo3/cms-extensionmanager',
+        'typo3/cms-install',
+    ];
+
     protected array $testExtensionsToLoad = [
+        'sjbr/static-info-tables',
         'oliverklee/feuserextrafields',
         'oliverklee/oelib',
         'oliverklee/seminars',

--- a/Tests/LegacyFunctional/Bag/OrganizerBagTest.php
+++ b/Tests/LegacyFunctional/Bag/OrganizerBagTest.php
@@ -13,7 +13,13 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
  */
 final class OrganizerBagTest extends FunctionalTestCase
 {
+    protected array $coreExtensionsToLoad = [
+        'typo3/cms-extensionmanager',
+        'typo3/cms-install',
+    ];
+
     protected array $testExtensionsToLoad = [
+        'sjbr/static-info-tables',
         'oliverklee/feuserextrafields',
         'oliverklee/oelib',
         'oliverklee/seminars',

--- a/Tests/LegacyFunctional/BagBuilder/AbstractBagBuilderTest.php
+++ b/Tests/LegacyFunctional/BagBuilder/AbstractBagBuilderTest.php
@@ -14,7 +14,13 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
  */
 final class AbstractBagBuilderTest extends FunctionalTestCase
 {
+    protected array $coreExtensionsToLoad = [
+        'typo3/cms-extensionmanager',
+        'typo3/cms-install',
+    ];
+
     protected array $testExtensionsToLoad = [
+        'sjbr/static-info-tables',
         'oliverklee/feuserextrafields',
         'oliverklee/oelib',
         'oliverklee/seminars',

--- a/Tests/LegacyFunctional/BagBuilder/CategoryBagBuilderTest.php
+++ b/Tests/LegacyFunctional/BagBuilder/CategoryBagBuilderTest.php
@@ -14,7 +14,13 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
  */
 final class CategoryBagBuilderTest extends FunctionalTestCase
 {
+    protected array $coreExtensionsToLoad = [
+        'typo3/cms-extensionmanager',
+        'typo3/cms-install',
+    ];
+
     protected array $testExtensionsToLoad = [
+        'sjbr/static-info-tables',
         'oliverklee/feuserextrafields',
         'oliverklee/oelib',
         'oliverklee/seminars',

--- a/Tests/LegacyFunctional/BagBuilder/EventBagBuilderTest.php
+++ b/Tests/LegacyFunctional/BagBuilder/EventBagBuilderTest.php
@@ -22,7 +22,13 @@ final class EventBagBuilderTest extends FunctionalTestCase
     private const SECONDS_PER_DAY = 86400;
     private const SECONDS_PER_WEEK = 604800;
 
+    protected array $coreExtensionsToLoad = [
+        'typo3/cms-extensionmanager',
+        'typo3/cms-install',
+    ];
+
     protected array $testExtensionsToLoad = [
+        'sjbr/static-info-tables',
         'oliverklee/feuserextrafields',
         'oliverklee/oelib',
         'oliverklee/seminars',

--- a/Tests/LegacyFunctional/BagBuilder/OrganizerBagBuilderTest.php
+++ b/Tests/LegacyFunctional/BagBuilder/OrganizerBagBuilderTest.php
@@ -14,7 +14,13 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
  */
 final class OrganizerBagBuilderTest extends FunctionalTestCase
 {
+    protected array $coreExtensionsToLoad = [
+        'typo3/cms-extensionmanager',
+        'typo3/cms-install',
+    ];
+
     protected array $testExtensionsToLoad = [
+        'sjbr/static-info-tables',
         'oliverklee/feuserextrafields',
         'oliverklee/oelib',
         'oliverklee/seminars',

--- a/Tests/LegacyFunctional/BagBuilder/RegistrationBagBuilderTest.php
+++ b/Tests/LegacyFunctional/BagBuilder/RegistrationBagBuilderTest.php
@@ -22,7 +22,13 @@ final class RegistrationBagBuilderTest extends FunctionalTestCase
 {
     private const SECONDS_PER_DAY = 86400;
 
+    protected array $coreExtensionsToLoad = [
+        'typo3/cms-extensionmanager',
+        'typo3/cms-install',
+    ];
+
     protected array $testExtensionsToLoad = [
+        'sjbr/static-info-tables',
         'oliverklee/feuserextrafields',
         'oliverklee/oelib',
         'oliverklee/seminars',

--- a/Tests/LegacyFunctional/Csv/AbstractRegistrationListViewTest.php
+++ b/Tests/LegacyFunctional/Csv/AbstractRegistrationListViewTest.php
@@ -18,7 +18,13 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
  */
 final class AbstractRegistrationListViewTest extends FunctionalTestCase
 {
+    protected array $coreExtensionsToLoad = [
+        'typo3/cms-extensionmanager',
+        'typo3/cms-install',
+    ];
+
     protected array $testExtensionsToLoad = [
+        'sjbr/static-info-tables',
         'oliverklee/feuserextrafields',
         'oliverklee/oelib',
         'oliverklee/seminars',

--- a/Tests/LegacyFunctional/Csv/CsvDownloaderTest.php
+++ b/Tests/LegacyFunctional/Csv/CsvDownloaderTest.php
@@ -18,7 +18,13 @@ final class CsvDownloaderTest extends FunctionalTestCase
 {
     use BackEndTestsTrait;
 
+    protected array $coreExtensionsToLoad = [
+        'typo3/cms-extensionmanager',
+        'typo3/cms-install',
+    ];
+
     protected array $testExtensionsToLoad = [
+        'sjbr/static-info-tables',
         'oliverklee/feuserextrafields',
         'oliverklee/oelib',
         'oliverklee/seminars',

--- a/Tests/LegacyFunctional/FrontEnd/AbstractViewTest.php
+++ b/Tests/LegacyFunctional/FrontEnd/AbstractViewTest.php
@@ -15,7 +15,13 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
  */
 final class AbstractViewTest extends FunctionalTestCase
 {
+    protected array $coreExtensionsToLoad = [
+        'typo3/cms-extensionmanager',
+        'typo3/cms-install',
+    ];
+
     protected array $testExtensionsToLoad = [
+        'sjbr/static-info-tables',
         'oliverklee/feuserextrafields',
         'oliverklee/oelib',
         'oliverklee/seminars',

--- a/Tests/LegacyFunctional/FrontEnd/CategoryListTest.php
+++ b/Tests/LegacyFunctional/FrontEnd/CategoryListTest.php
@@ -19,7 +19,13 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
  */
 final class CategoryListTest extends FunctionalTestCase
 {
+    protected array $coreExtensionsToLoad = [
+        'typo3/cms-extensionmanager',
+        'typo3/cms-install',
+    ];
+
     protected array $testExtensionsToLoad = [
+        'sjbr/static-info-tables',
         'oliverklee/feuserextrafields',
         'oliverklee/oelib',
         'oliverklee/seminars',

--- a/Tests/LegacyFunctional/FrontEnd/DefaultControllerTest.php
+++ b/Tests/LegacyFunctional/FrontEnd/DefaultControllerTest.php
@@ -44,7 +44,10 @@ final class DefaultControllerTest extends FunctionalTestCase
         'oliverklee/seminars',
     ];
 
-    protected array $coreExtensionsToLoad = ['typo3/cms-extensionmanager'];
+    protected array $coreExtensionsToLoad = [
+        'typo3/cms-extensionmanager',
+        'typo3/cms-install',
+    ];
 
     private TestingDefaultController $subject;
 

--- a/Tests/LegacyFunctional/FrontEnd/RequirementsListTest.php
+++ b/Tests/LegacyFunctional/FrontEnd/RequirementsListTest.php
@@ -20,7 +20,13 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
  */
 final class RequirementsListTest extends FunctionalTestCase
 {
+    protected array $coreExtensionsToLoad = [
+        'typo3/cms-extensionmanager',
+        'typo3/cms-install',
+    ];
+
     protected array $testExtensionsToLoad = [
+        'sjbr/static-info-tables',
         'oliverklee/feuserextrafields',
         'oliverklee/oelib',
         'oliverklee/seminars',

--- a/Tests/LegacyFunctional/FrontEnd/SelectorWidgetTest.php
+++ b/Tests/LegacyFunctional/FrontEnd/SelectorWidgetTest.php
@@ -21,7 +21,13 @@ final class SelectorWidgetTest extends FunctionalTestCase
 {
     use BackendLanguageTrait;
 
+    protected array $coreExtensionsToLoad = [
+        'typo3/cms-extensionmanager',
+        'typo3/cms-install',
+    ];
+
     protected array $testExtensionsToLoad = [
+        'sjbr/static-info-tables',
         'oliverklee/feuserextrafields',
         'oliverklee/oelib',
         'oliverklee/seminars',

--- a/Tests/LegacyFunctional/Mapper/CategoryMapperTest.php
+++ b/Tests/LegacyFunctional/Mapper/CategoryMapperTest.php
@@ -15,7 +15,13 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
  */
 final class CategoryMapperTest extends FunctionalTestCase
 {
+    protected array $coreExtensionsToLoad = [
+        'typo3/cms-extensionmanager',
+        'typo3/cms-install',
+    ];
+
     protected array $testExtensionsToLoad = [
+        'sjbr/static-info-tables',
         'oliverklee/feuserextrafields',
         'oliverklee/oelib',
         'oliverklee/seminars',

--- a/Tests/LegacyFunctional/Mapper/EventDateMapperTest.php
+++ b/Tests/LegacyFunctional/Mapper/EventDateMapperTest.php
@@ -23,7 +23,13 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
  */
 final class EventDateMapperTest extends FunctionalTestCase
 {
+    protected array $coreExtensionsToLoad = [
+        'typo3/cms-extensionmanager',
+        'typo3/cms-install',
+    ];
+
     protected array $testExtensionsToLoad = [
+        'sjbr/static-info-tables',
         'oliverklee/feuserextrafields',
         'oliverklee/oelib',
         'oliverklee/seminars',

--- a/Tests/LegacyFunctional/Mapper/EventMapperTest.php
+++ b/Tests/LegacyFunctional/Mapper/EventMapperTest.php
@@ -20,7 +20,13 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
  */
 final class EventMapperTest extends FunctionalTestCase
 {
+    protected array $coreExtensionsToLoad = [
+        'typo3/cms-extensionmanager',
+        'typo3/cms-install',
+    ];
+
     protected array $testExtensionsToLoad = [
+        'sjbr/static-info-tables',
         'oliverklee/feuserextrafields',
         'oliverklee/oelib',
         'oliverklee/seminars',

--- a/Tests/LegacyFunctional/Mapper/EventTopicMapperTest.php
+++ b/Tests/LegacyFunctional/Mapper/EventTopicMapperTest.php
@@ -22,7 +22,13 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
  */
 final class EventTopicMapperTest extends FunctionalTestCase
 {
+    protected array $coreExtensionsToLoad = [
+        'typo3/cms-extensionmanager',
+        'typo3/cms-install',
+    ];
+
     protected array $testExtensionsToLoad = [
+        'sjbr/static-info-tables',
         'oliverklee/feuserextrafields',
         'oliverklee/oelib',
         'oliverklee/seminars',

--- a/Tests/LegacyFunctional/Mapper/EventTypeMapperTest.php
+++ b/Tests/LegacyFunctional/Mapper/EventTypeMapperTest.php
@@ -15,7 +15,13 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
  */
 final class EventTypeMapperTest extends FunctionalTestCase
 {
+    protected array $coreExtensionsToLoad = [
+        'typo3/cms-extensionmanager',
+        'typo3/cms-install',
+    ];
+
     protected array $testExtensionsToLoad = [
+        'sjbr/static-info-tables',
         'oliverklee/feuserextrafields',
         'oliverklee/oelib',
         'oliverklee/seminars',

--- a/Tests/LegacyFunctional/Mapper/OrganizerMapperTest.php
+++ b/Tests/LegacyFunctional/Mapper/OrganizerMapperTest.php
@@ -15,7 +15,13 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
  */
 final class OrganizerMapperTest extends FunctionalTestCase
 {
+    protected array $coreExtensionsToLoad = [
+        'typo3/cms-extensionmanager',
+        'typo3/cms-install',
+    ];
+
     protected array $testExtensionsToLoad = [
+        'sjbr/static-info-tables',
         'oliverklee/feuserextrafields',
         'oliverklee/oelib',
         'oliverklee/seminars',

--- a/Tests/LegacyFunctional/Mapper/PlaceMapperTest.php
+++ b/Tests/LegacyFunctional/Mapper/PlaceMapperTest.php
@@ -15,7 +15,13 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
  */
 final class PlaceMapperTest extends FunctionalTestCase
 {
+    protected array $coreExtensionsToLoad = [
+        'typo3/cms-extensionmanager',
+        'typo3/cms-install',
+    ];
+
     protected array $testExtensionsToLoad = [
+        'sjbr/static-info-tables',
         'oliverklee/feuserextrafields',
         'oliverklee/oelib',
         'oliverklee/seminars',

--- a/Tests/LegacyFunctional/Mapper/RegistrationMapperTest.php
+++ b/Tests/LegacyFunctional/Mapper/RegistrationMapperTest.php
@@ -18,7 +18,13 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
  */
 final class RegistrationMapperTest extends FunctionalTestCase
 {
+    protected array $coreExtensionsToLoad = [
+        'typo3/cms-extensionmanager',
+        'typo3/cms-install',
+    ];
+
     protected array $testExtensionsToLoad = [
+        'sjbr/static-info-tables',
         'oliverklee/feuserextrafields',
         'oliverklee/oelib',
         'oliverklee/seminars',

--- a/Tests/LegacyFunctional/Mapper/SingleEventMapperTest.php
+++ b/Tests/LegacyFunctional/Mapper/SingleEventMapperTest.php
@@ -22,7 +22,13 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
  */
 final class SingleEventMapperTest extends FunctionalTestCase
 {
+    protected array $coreExtensionsToLoad = [
+        'typo3/cms-extensionmanager',
+        'typo3/cms-install',
+    ];
+
     protected array $testExtensionsToLoad = [
+        'sjbr/static-info-tables',
         'oliverklee/feuserextrafields',
         'oliverklee/oelib',
         'oliverklee/seminars',

--- a/Tests/LegacyFunctional/Model/EventDateTest.php
+++ b/Tests/LegacyFunctional/Model/EventDateTest.php
@@ -17,7 +17,13 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
  */
 final class EventDateTest extends FunctionalTestCase
 {
+    protected array $coreExtensionsToLoad = [
+        'typo3/cms-extensionmanager',
+        'typo3/cms-install',
+    ];
+
     protected array $testExtensionsToLoad = [
+        'sjbr/static-info-tables',
         'oliverklee/feuserextrafields',
         'oliverklee/oelib',
         'oliverklee/seminars',

--- a/Tests/LegacyFunctional/Model/EventTest.php
+++ b/Tests/LegacyFunctional/Model/EventTest.php
@@ -20,7 +20,13 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
  */
 final class EventTest extends FunctionalTestCase
 {
+    protected array $coreExtensionsToLoad = [
+        'typo3/cms-extensionmanager',
+        'typo3/cms-install',
+    ];
+
     protected array $testExtensionsToLoad = [
+        'sjbr/static-info-tables',
         'oliverklee/feuserextrafields',
         'oliverklee/oelib',
         'oliverklee/seminars',

--- a/Tests/LegacyFunctional/Model/FrontEndUserTest.php
+++ b/Tests/LegacyFunctional/Model/FrontEndUserTest.php
@@ -14,7 +14,13 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
  */
 final class FrontEndUserTest extends FunctionalTestCase
 {
+    protected array $coreExtensionsToLoad = [
+        'typo3/cms-extensionmanager',
+        'typo3/cms-install',
+    ];
+
     protected array $testExtensionsToLoad = [
+        'sjbr/static-info-tables',
         'oliverklee/feuserextrafields',
         'oliverklee/oelib',
         'oliverklee/seminars',

--- a/Tests/LegacyFunctional/Model/OrganizerTest.php
+++ b/Tests/LegacyFunctional/Model/OrganizerTest.php
@@ -12,7 +12,13 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
  */
 final class OrganizerTest extends FunctionalTestCase
 {
+    protected array $coreExtensionsToLoad = [
+        'typo3/cms-extensionmanager',
+        'typo3/cms-install',
+    ];
+
     protected array $testExtensionsToLoad = [
+        'sjbr/static-info-tables',
         'oliverklee/feuserextrafields',
         'oliverklee/oelib',
         'oliverklee/seminars',

--- a/Tests/LegacyFunctional/Model/PlaceTest.php
+++ b/Tests/LegacyFunctional/Model/PlaceTest.php
@@ -12,7 +12,13 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
  */
 final class PlaceTest extends FunctionalTestCase
 {
+    protected array $coreExtensionsToLoad = [
+        'typo3/cms-extensionmanager',
+        'typo3/cms-install',
+    ];
+
     protected array $testExtensionsToLoad = [
+        'sjbr/static-info-tables',
         'oliverklee/feuserextrafields',
         'oliverklee/oelib',
         'oliverklee/seminars',

--- a/Tests/LegacyFunctional/Model/RegistrationTest.php
+++ b/Tests/LegacyFunctional/Model/RegistrationTest.php
@@ -18,7 +18,13 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
  */
 final class RegistrationTest extends FunctionalTestCase
 {
+    protected array $coreExtensionsToLoad = [
+        'typo3/cms-extensionmanager',
+        'typo3/cms-install',
+    ];
+
     protected array $testExtensionsToLoad = [
+        'sjbr/static-info-tables',
         'oliverklee/feuserextrafields',
         'oliverklee/oelib',
         'oliverklee/seminars',

--- a/Tests/LegacyFunctional/Model/SingleEventTest.php
+++ b/Tests/LegacyFunctional/Model/SingleEventTest.php
@@ -15,7 +15,13 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
  */
 final class SingleEventTest extends FunctionalTestCase
 {
+    protected array $coreExtensionsToLoad = [
+        'typo3/cms-extensionmanager',
+        'typo3/cms-install',
+    ];
+
     protected array $testExtensionsToLoad = [
+        'sjbr/static-info-tables',
         'oliverklee/feuserextrafields',
         'oliverklee/oelib',
         'oliverklee/seminars',

--- a/Tests/LegacyFunctional/OldModel/AbstractModelTest.php
+++ b/Tests/LegacyFunctional/OldModel/AbstractModelTest.php
@@ -15,7 +15,13 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
  */
 final class AbstractModelTest extends FunctionalTestCase
 {
+    protected array $coreExtensionsToLoad = [
+        'typo3/cms-extensionmanager',
+        'typo3/cms-install',
+    ];
+
     protected array $testExtensionsToLoad = [
+        'sjbr/static-info-tables',
         'oliverklee/feuserextrafields',
         'oliverklee/oelib',
         'oliverklee/seminars',

--- a/Tests/LegacyFunctional/OldModel/LegacyEventTest.php
+++ b/Tests/LegacyFunctional/OldModel/LegacyEventTest.php
@@ -40,7 +40,10 @@ final class LegacyEventTest extends FunctionalTestCase
         'oliverklee/seminars',
     ];
 
-    protected array $coreExtensionsToLoad = ['typo3/cms-extensionmanager'];
+    protected array $coreExtensionsToLoad = [
+        'typo3/cms-extensionmanager',
+        'typo3/cms-install',
+    ];
 
     private DummyConfiguration $configuration;
 

--- a/Tests/LegacyFunctional/OldModel/LegacyOrganizerTest.php
+++ b/Tests/LegacyFunctional/OldModel/LegacyOrganizerTest.php
@@ -14,7 +14,13 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
  */
 final class LegacyOrganizerTest extends FunctionalTestCase
 {
+    protected array $coreExtensionsToLoad = [
+        'typo3/cms-extensionmanager',
+        'typo3/cms-install',
+    ];
+
     protected array $testExtensionsToLoad = [
+        'sjbr/static-info-tables',
         'oliverklee/feuserextrafields',
         'oliverklee/oelib',
         'oliverklee/seminars',

--- a/Tests/LegacyFunctional/OldModel/LegacyRegistrationTest.php
+++ b/Tests/LegacyFunctional/OldModel/LegacyRegistrationTest.php
@@ -32,7 +32,10 @@ final class LegacyRegistrationTest extends FunctionalTestCase
         'oliverklee/seminars',
     ];
 
-    protected array $coreExtensionsToLoad = ['typo3/cms-extensionmanager'];
+    protected array $coreExtensionsToLoad = [
+        'typo3/cms-extensionmanager',
+        'typo3/cms-install',
+    ];
 
     private LegacyRegistration $subject;
 

--- a/Tests/LegacyFunctional/OldModel/LegacyTimeSlotTest.php
+++ b/Tests/LegacyFunctional/OldModel/LegacyTimeSlotTest.php
@@ -21,7 +21,13 @@ final class LegacyTimeSlotTest extends FunctionalTestCase
 {
     use BackendLanguageTrait;
 
+    protected array $coreExtensionsToLoad = [
+        'typo3/cms-extensionmanager',
+        'typo3/cms-install',
+    ];
+
     protected array $testExtensionsToLoad = [
+        'sjbr/static-info-tables',
         'oliverklee/feuserextrafields',
         'oliverklee/oelib',
         'oliverklee/seminars',

--- a/Tests/LegacyFunctional/SchedulerTasks/MailNotifierTest.php
+++ b/Tests/LegacyFunctional/SchedulerTasks/MailNotifierTest.php
@@ -36,9 +36,14 @@ final class MailNotifierTest extends FunctionalTestCase
 
     private const SECONDS_PER_DAY = 86400;
 
-    protected array $coreExtensionsToLoad = ['typo3/cms-scheduler'];
+    protected array $coreExtensionsToLoad = [
+        'typo3/cms-extensionmanager',
+        'typo3/cms-install',
+        'typo3/cms-scheduler',
+    ];
 
     protected array $testExtensionsToLoad = [
+        'sjbr/static-info-tables',
         'oliverklee/feuserextrafields',
         'oliverklee/oelib',
         'oliverklee/seminars',

--- a/Tests/LegacyFunctional/Service/EmailServiceTest.php
+++ b/Tests/LegacyFunctional/Service/EmailServiceTest.php
@@ -26,7 +26,13 @@ final class EmailServiceTest extends FunctionalTestCase
     use EmailTrait;
     use MakeInstanceTrait;
 
+    protected array $coreExtensionsToLoad = [
+        'typo3/cms-extensionmanager',
+        'typo3/cms-install',
+    ];
+
     protected array $testExtensionsToLoad = [
+        'sjbr/static-info-tables',
         'oliverklee/feuserextrafields',
         'oliverklee/oelib',
         'oliverklee/seminars',

--- a/Tests/LegacyFunctional/Service/EventStatusServiceTest.php
+++ b/Tests/LegacyFunctional/Service/EventStatusServiceTest.php
@@ -20,7 +20,13 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
  */
 final class EventStatusServiceTest extends FunctionalTestCase
 {
+    protected array $coreExtensionsToLoad = [
+        'typo3/cms-extensionmanager',
+        'typo3/cms-install',
+    ];
+
     protected array $testExtensionsToLoad = [
+        'sjbr/static-info-tables',
         'oliverklee/feuserextrafields',
         'oliverklee/oelib',
         'oliverklee/seminars',

--- a/Tests/LegacyFunctional/Service/RegistrationManagerTest.php
+++ b/Tests/LegacyFunctional/Service/RegistrationManagerTest.php
@@ -41,7 +41,13 @@ final class RegistrationManagerTest extends FunctionalTestCase
 
     private const SECONDS_PER_DAY = 86400;
 
+    protected array $coreExtensionsToLoad = [
+        'typo3/cms-extensionmanager',
+        'typo3/cms-install',
+    ];
+
     protected array $testExtensionsToLoad = [
+        'sjbr/static-info-tables',
         'oliverklee/feuserextrafields',
         'oliverklee/oelib',
         'oliverklee/seminars',


### PR DESCRIPTION
Otherwise, the functional test will fail due to missing dependencies with the TYPO3 Testing Framework V8.

Also always load the extension manager Core extension, which is a dependency of static-info-tables.
