### PR TITLE
[FEATURE] Add the event UID to the FE list views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Add `Event.timeSlots` (#5149)
 - Add a `TimeSlot` model and repository (#5039)
 - Add more columns to the FE list views
-  (#5119, #5131, #5150, #5152, #5171, #5177)
+  (#5119, #5131, #5150, #5152, #5171, #5177, #5182)
 - Restyle the FE list views (#5043, #5117)
 - Add the venue to the "my registrations" list (#4982)
 - Add the city to the "my registrations" list (#4981)

--- a/Configuration/FlexForms/EventArchive.xml
+++ b/Configuration/FlexForms/EventArchive.xml
@@ -100,7 +100,7 @@
                                 <renderType>selectCheckBox</renderType>
                                 <minitems>1</minitems>
                                 <maxitems>99</maxitems>
-                                <default>date,topic,city</default>
+                                <default>date,topic,city,eventUid</default>
                                 <items type="array">
                                     <numIndex index="0" type="array">
                                         <numIndex index="0">
@@ -155,6 +155,12 @@
                                             LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:plugin.eventArchive.settings.displayOptions.columns.speakers
                                         </numIndex>
                                         <numIndex index="1">speakers</numIndex>
+                                    </numIndex>
+                                    <numIndex index="9" type="array">
+                                        <numIndex index="0">
+                                            LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:plugin.eventArchive.settings.displayOptions.columns.eventUid
+                                        </numIndex>
+                                        <numIndex index="1">eventUid</numIndex>
                                     </numIndex>
                                 </items>
                             </config>

--- a/Configuration/FlexForms/EventOutlook.xml
+++ b/Configuration/FlexForms/EventOutlook.xml
@@ -171,17 +171,23 @@
                                     </numIndex>
                                     <numIndex index="9" type="array">
                                         <numIndex index="0">
+                                            LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:plugin.eventOutlook.settings.displayOptions.columns.eventUid
+                                        </numIndex>
+                                        <numIndex index="1">eventUid</numIndex>
+                                    </numIndex>
+                                    <numIndex index="10" type="array">
+                                        <numIndex index="0">
                                             LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:plugin.eventOutlook.settings.displayOptions.columns.price
                                         </numIndex>
                                         <numIndex index="1">price</numIndex>
                                     </numIndex>
-                                    <numIndex index="10" type="array">
+                                    <numIndex index="11" type="array">
                                         <numIndex index="0">
                                             LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:plugin.eventOutlook.settings.displayOptions.columns.vacancies
                                         </numIndex>
                                         <numIndex index="1">vacancies</numIndex>
                                     </numIndex>
-                                    <numIndex index="11" type="array">
+                                    <numIndex index="12" type="array">
                                         <numIndex index="0">
                                             LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:plugin.eventOutlook.settings.displayOptions.columns.registration
                                         </numIndex>

--- a/Configuration/FlexForms/MyRegistrations.xml
+++ b/Configuration/FlexForms/MyRegistrations.xml
@@ -78,11 +78,17 @@
                                     </numIndex>
                                     <numIndex index="9" type="array">
                                         <numIndex index="0">
+                                            LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:plugin.myRegistrations.settings.displayOptions.columns.eventUid
+                                        </numIndex>
+                                        <numIndex index="1">eventUid</numIndex>
+                                    </numIndex>
+                                    <numIndex index="10" type="array">
+                                        <numIndex index="0">
                                             LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:plugin.myRegistrations.settings.displayOptions.columns.registrationStatus
                                         </numIndex>
                                         <numIndex index="1">registrationStatus</numIndex>
                                     </numIndex>
-                                    <numIndex index="10" type="array">
+                                    <numIndex index="11" type="array">
                                         <numIndex index="0">
                                             LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:plugin.myRegistrations.settings.displayOptions.columns.certificateOfAttendance
                                         </numIndex>

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -1860,6 +1860,9 @@
       <trans-unit id="plugin.eventArchive.settings.displayOptions.columns.speakers">
         <source>speakers</source>
       </trans-unit>
+      <trans-unit id="plugin.eventArchive.settings.displayOptions.columns.eventUid">
+        <source>UID</source>
+      </trans-unit>
       <trans-unit id="plugin.eventArchive.message.noEventsFound">
         <source>No events found.</source>
       </trans-unit>
@@ -1898,6 +1901,12 @@
       </trans-unit>
       <trans-unit id="plugin.eventArchive.events.property.speakers">
         <source>Speakers</source>
+      </trans-unit>
+      <trans-unit id="plugin.eventArchive.events.property.eventUid">
+        <source>Number</source>
+      </trans-unit>
+      <trans-unit id="plugin.eventArchive.events.property.eventUid.number">
+        <source>#%1$u</source>
       </trans-unit>
       <trans-unit id="plugin.eventOutlook">
         <source>Event outlook</source>
@@ -1950,6 +1959,9 @@
       <trans-unit id="plugin.eventOutlook.settings.displayOptions.columns.speakers">
         <source>speakers</source>
       </trans-unit>
+      <trans-unit id="plugin.eventOutlook.settings.displayOptions.columns.eventUid">
+        <source>UID</source>
+      </trans-unit>
       <trans-unit id="plugin.eventOutlook.settings.displayOptions.columns.price">
         <source>price</source>
       </trans-unit>
@@ -1997,6 +2009,12 @@
       </trans-unit>
       <trans-unit id="plugin.eventOutlook.events.property.speakers">
         <source>Speakers</source>
+      </trans-unit>
+      <trans-unit id="plugin.eventOutlook.events.property.eventUid">
+        <source>Number</source>
+      </trans-unit>
+      <trans-unit id="plugin.eventOutlook.events.property.eventUid.number">
+        <source>#%1$u</source>
       </trans-unit>
       <trans-unit id="plugin.eventOutlook.events.property.price">
         <source>Price</source>
@@ -2154,6 +2172,9 @@
       <trans-unit id="plugin.myRegistrations.settings.displayOptions.columns.speakers">
         <source>speakers</source>
       </trans-unit>
+      <trans-unit id="plugin.myRegistrations.settings.displayOptions.columns.eventUid">
+        <source>event UID</source>
+      </trans-unit>
       <trans-unit id="plugin.myRegistrations.settings.displayOptions.columns.registrationStatus">
         <source>registration status</source>
       </trans-unit>
@@ -2235,6 +2256,9 @@
       <trans-unit id="plugin.myRegistrations.index.heading.speakers">
         <source>Speakers</source>
       </trans-unit>
+      <trans-unit id="plugin.myRegistrations.index.heading.eventUid">
+        <source>Event number</source>
+      </trans-unit>
       <trans-unit id="plugin.myRegistrations.index.heading.registrationStatus">
         <source>Status</source>
       </trans-unit>
@@ -2246,6 +2270,9 @@
       </trans-unit>
       <trans-unit id="plugin.myRegistrations.index.displayCertificateOfAttendance.long">
         <source>📄 Display certificate of attendance</source>
+      </trans-unit>
+      <trans-unit id="plugin.myRegistrations.property.eventUid.number">
+        <source>#%1$u</source>
       </trans-unit>
       <trans-unit id="plugin.myRegistrations.property.attendanceMode.1">
         <source>on-site</source>

--- a/Resources/Private/Partials/Event/ArchiveList.html
+++ b/Resources/Private/Partials/Event/ArchiveList.html
@@ -49,6 +49,11 @@
                             <f:translate key="plugin.eventArchive.events.property.speakers"/>
                         </th>
                     </oelib:isFieldEnabled>
+                    <oelib:isFieldEnabled fieldName="eventUid">
+                        <th scope="col">
+                            <f:translate key="plugin.eventArchive.events.property.eventUid"/>
+                        </th>
+                    </oelib:isFieldEnabled>
                 </tr>
             </thead>
             <tbody>
@@ -112,6 +117,12 @@
                                 <f:for each="{event.speakers}" as="speaker" iteration="iteration">
                                     {speaker.name}{f:if(condition: iteration.isLast, then: '', else: ', ')}
                                 </f:for>
+                            </td>
+                        </oelib:isFieldEnabled>
+                        <oelib:isFieldEnabled fieldName="eventUid">
+                            <td class="text-end">
+                                <f:translate key="plugin.eventArchive.events.property.eventUid.number"
+                                             arguments="{0: event.uid}"/>
                             </td>
                         </oelib:isFieldEnabled>
                     </tr>

--- a/Resources/Private/Partials/Event/OutlookList.html
+++ b/Resources/Private/Partials/Event/OutlookList.html
@@ -49,6 +49,11 @@
                             <f:translate key="plugin.eventOutlook.events.property.speakers"/>
                         </th>
                     </oelib:isFieldEnabled>
+                    <oelib:isFieldEnabled fieldName="eventUid">
+                        <th scope="col">
+                            <f:translate key="plugin.eventOutlook.events.property.eventUid"/>
+                        </th>
+                    </oelib:isFieldEnabled>
                     <oelib:isFieldEnabled fieldName="price">
                         <th scope="col">
                             <f:translate key="plugin.eventOutlook.events.property.price"/>
@@ -127,6 +132,12 @@
                                 <f:for each="{event.speakers}" as="speaker" iteration="iteration">
                                     {speaker.name}{f:if(condition: iteration.isLast, then: '', else: ', ')}
                                 </f:for>
+                            </td>
+                        </oelib:isFieldEnabled>
+                        <oelib:isFieldEnabled fieldName="eventUid">
+                            <td class="text-end">
+                                <f:translate key="plugin.eventOutlook.events.property.eventUid.number"
+                                             arguments="{0: event.uid}"/>
                             </td>
                         </oelib:isFieldEnabled>
                         <oelib:isFieldEnabled fieldName="price">

--- a/Resources/Private/Partials/MyRegistrations/Index.html
+++ b/Resources/Private/Partials/MyRegistrations/Index.html
@@ -49,6 +49,11 @@
                             <f:translate key="plugin.myRegistrations.index.heading.speakers"/>
                         </th>
                     </oelib:isFieldEnabled>
+                    <oelib:isFieldEnabled configurationKey="columnsToShow" fieldName="eventUid">
+                        <th scope="col">
+                            <f:translate key="plugin.myRegistrations.index.heading.eventUid"/>
+                        </th>
+                    </oelib:isFieldEnabled>
                     <oelib:isFieldEnabled configurationKey="columnsToShow" fieldName="registrationStatus">
                         <th scope="col">
                             <f:translate key="plugin.myRegistrations.index.heading.registrationStatus"/>
@@ -126,6 +131,12 @@
                                     <f:for each="{event.speakers}" as="speaker" iteration="iteration">
                                         {speaker.name}{f:if(condition: iteration.isLast, then: '', else: ', ')}
                                     </f:for>
+                                </td>
+                            </oelib:isFieldEnabled>
+                            <oelib:isFieldEnabled configurationKey="columnsToShow" fieldName="eventUid">
+                                <td class="text-end">
+                                    <f:translate key="plugin.myRegistrations.property.eventUid.number"
+                                                 arguments="{0: event.uid}"/>
                                 </td>
                             </oelib:isFieldEnabled>
                             <oelib:isFieldEnabled configurationKey="columnsToShow" fieldName="registrationStatus">

--- a/Tests/Functional/Controller/EventControllerTest.php
+++ b/Tests/Functional/Controller/EventControllerTest.php
@@ -371,6 +371,28 @@ final class EventControllerTest extends FunctionalTestCase
     /**
      * @test
      */
+    public function archiveActionRendersEventUid(): void
+    {
+        $this->importCSVDataSet(self::FIXTURES_PATH . '/archiveAction/EventArchiveContentElement.csv');
+        $this->importCSVDataSet(self::FIXTURES_PATH . '/archiveAction/PastEvent.csv');
+
+        $request = (new InternalRequest())->withPageId(1);
+
+        $html = (string)$this->executeFrontendSubRequest($request)->getBody();
+
+        $labelWithPlaceholder = LocalizationUtility::translate(
+            'plugin.eventArchive.events.property.eventUid.number',
+            'seminars',
+        );
+        self::assertIsString($labelWithPlaceholder);
+        $expected = sprintf($labelWithPlaceholder, 1);
+        self::assertSame('#1', $expected);
+        self::assertStringContainsString($expected, $html);
+    }
+
+    /**
+     * @test
+     */
     public function outlookActionForNoEventsShowsMessage(): void
     {
         $this->importCSVDataSet(self::FIXTURES_PATH . '/outlookAction/EventOutlookContentElement.csv');
@@ -660,6 +682,28 @@ final class EventControllerTest extends FunctionalTestCase
 
         self::assertStringContainsString('Sally Speaker,', $html);
         self::assertStringContainsString('Sam Speaker', $html);
+    }
+
+    /**
+     * @test
+     */
+    public function outlookActionRendersEventUid(): void
+    {
+        $this->importCSVDataSet(self::FIXTURES_PATH . '/outlookAction/EventOutlookContentElement.csv');
+        $this->importCSVDataSet(self::FIXTURES_PATH . '/outlookAction/FutureEvent.csv');
+
+        $request = (new InternalRequest())->withPageId(1);
+
+        $html = (string)$this->executeFrontendSubRequest($request)->getBody();
+
+        $labelWithPlaceholder = LocalizationUtility::translate(
+            'plugin.eventOutlook.events.property.eventUid.number',
+            'seminars',
+        );
+        self::assertIsString($labelWithPlaceholder);
+        $expected = sprintf($labelWithPlaceholder, 1);
+        self::assertSame('#1', $expected);
+        self::assertStringContainsString($expected, $html);
     }
 
     /**

--- a/Tests/Functional/Controller/Fixtures/EventController/archiveAction/EventArchiveContentElement.csv
+++ b/Tests/Functional/Controller/Fixtures/EventController/archiveAction/EventArchiveContentElement.csv
@@ -19,7 +19,7 @@
                                                                  <sheet index=""displayOptions"">
                                                                      <language index=""lDEF"">
                                                                          <field index=""settings.fieldsToShow"">
-                                                                             <value index=""vDEF"">date,eventType,topic,organizer,city,venue,eventFormat,categories,speakers</value>
+                                                                             <value index=""vDEF"">date,eventType,topic,organizer,city,venue,eventFormat,categories,speakers,eventUid</value>
                                                                         </field>
                                                                      </language>
                                                                  </sheet>

--- a/Tests/Functional/Controller/Fixtures/EventController/outlookAction/EventOutlookContentElement.csv
+++ b/Tests/Functional/Controller/Fixtures/EventController/outlookAction/EventOutlookContentElement.csv
@@ -22,7 +22,7 @@
                                                                  <sheet index=""displayOptions"">
                                                                      <language index=""lDEF"">
                                                                         <field index=""settings.fieldsToShow"">
-                                                                            <value index=""vDEF"">date,eventType,topic,organizer,city,venue,eventFormat,categories,speakers,price,vacancies,registration</value>
+                                                                            <value index=""vDEF"">date,eventType,topic,organizer,city,venue,eventFormat,categories,speakers,eventUid,price,vacancies,registration</value>
                                                                         </field>
                                                                     </language>
                                                                 </sheet>

--- a/Tests/Functional/Controller/Fixtures/MyRegistrationsController/MyRegistrationsContentElement.csv
+++ b/Tests/Functional/Controller/Fixtures/MyRegistrationsController/MyRegistrationsContentElement.csv
@@ -6,7 +6,7 @@
                                                                       <sheet index=""displayOptions"">
                                                                           <language index=""lDEF"">
                                                                               <field index=""settings.columnsToShow"">
-                                                                                  <value index=""vDEF"">date,eventType,topic,organizer,city,venue,attendanceMode,categories,speakers,registrationStatus</value>
+                                                                                  <value index=""vDEF"">date,eventType,topic,organizer,city,venue,attendanceMode,categories,speakers,eventUid,registrationStatus</value>
                                                                               </field>
                                                                               <field index=""settings.fieldsToShow"">
                                                                                   <value index=""vDEF"">topic,eventType,registrationStatus,dateAndTime,venue,room,description,speakers,unregistration,downloads</value>

--- a/Tests/Functional/Controller/MyRegistrationsControllerTest.php
+++ b/Tests/Functional/Controller/MyRegistrationsControllerTest.php
@@ -408,6 +408,28 @@ final class MyRegistrationsControllerTest extends FunctionalTestCase
     /**
      * @test
      */
+    public function indexActionRendersEventUid(): void
+    {
+        $this->importCSVDataSet(self::FIXTURES_PATH . '/FrontEndUserAndGroup.csv');
+        $this->importCSVDataSet(self::FIXTURES_PATH . '/indexAction/Registration.csv');
+
+        $request = (new InternalRequest())->withPageId(7);
+        $requestContext = (new InternalRequestContext())->withFrontendUserId(1);
+        $html = (string)$this->executeFrontendSubRequest($request, $requestContext)->getBody();
+
+        $labelWithPlaceholder = LocalizationUtility::translate(
+            'plugin.myRegistrations.property.eventUid.number',
+            'seminars',
+        );
+        self::assertIsString($labelWithPlaceholder);
+        $expected = sprintf($labelWithPlaceholder, 1);
+        self::assertSame('#1', $expected);
+        self::assertStringContainsString($expected, $html);
+    }
+
+    /**
+     * @test
+     */
     public function indexActionRendersRegularRegistrationStatusOfRegistrationOfTheLoggedInUser(): void
     {
         $this->importCSVDataSet(self::FIXTURES_PATH . '/FrontEndUserAndGroup.csv');


### PR DESCRIPTION
Also use localized labels for the output format so it can be changed using TypoScript easily.

Use shorter headings for the event outlook and archive for brevity, and use a more specific label for the "my registrations" list so we can add the registration UID there later without confusing the attendees.

Fixes #4973