### PR TITLE
[BUGFIX] Avoid deprecated query methods in `AbstractBag`

### DIFF
--- a/Build/phpstan/phpstan-baseline.neon
+++ b/Build/phpstan/phpstan-baseline.neon
@@ -41,7 +41,7 @@ parameters:
 			path: ../../Classes/Bag/AbstractBag.php
 
 		-
-			message: "#^Property OliverKlee\\\\Seminars\\\\Bag\\\\AbstractBag\\<M of OliverKlee\\\\Seminars\\\\OldModel\\\\AbstractModel\\>\\:\\:\\$queryResult \\(array\\<int, array\\<string, float\\|int\\|string\\|null\\>\\>\\) does not accept array\\.$#"
+			message: "#^Property OliverKlee\\\\Seminars\\\\Bag\\\\AbstractBag\\<M of OliverKlee\\\\Seminars\\\\OldModel\\\\AbstractModel\\>\\:\\:\\$queryResult \\(array\\<int, array\\<string, float\\|int\\|string\\|null\\>\\>\\) does not accept array\\<int, array\\<string, mixed\\>\\>\\.$#"
 			count: 1
 			path: ../../Classes/Bag/AbstractBag.php
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -245,6 +245,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- Avoid deprecated query methods in `AbstractBag` (#5203)
 - Fix property mapping with timeslots and registrations (#5155)
 - Use the correct no-wrap Bootstrap class (#5151)
 - Avoid the deprecated static `TemplateRegistry` methods (#5013)

--- a/Classes/Bag/AbstractBag.php
+++ b/Classes/Bag/AbstractBag.php
@@ -212,7 +212,7 @@ abstract class AbstractBag implements \Iterator
 
         $this->queryResult = $this->connectionPool
             ->getConnectionForTable($this->allTableNames)
-            ->query($sql)->fetchAll();
+            ->executeQuery($sql)->fetchAllAssociative();
 
         $this->queryHasBeenExecuted = true;
     }


### PR DESCRIPTION
`query()` and `fetchAll()` are deprecated.

Fixes #5198