### PR TITLE
[TASK] Modernize `EventRegistrationController` (part 2)

### DIFF
--- a/Classes/Controller/EventRegistrationController.php
+++ b/Classes/Controller/EventRegistrationController.php
@@ -179,9 +179,13 @@ class EventRegistrationController extends ActionController
         $this->registrationProcessor->enrichWithMetadata($registration, $event, $this->settings, $this->request);
         $this->registrationProcessor->calculateTotalPrice($registration);
 
-        $this->view->assign('event', $event);
-        $this->view->assign('registration', $registration);
-        $this->view->assign('applicablePrices', $this->priceFinder->findApplicablePrices($event));
+        $this->view->assignMultiple(
+            [
+                'event' => $event,
+                'registration' => $registration,
+                'applicablePrices' => $this->priceFinder->findApplicablePrices($event),
+            ],
+        );
 
         return $this->htmlResponse();
     }

--- a/Tests/Unit/Controller/EventRegistrationControllerTest.php
+++ b/Tests/Unit/Controller/EventRegistrationControllerTest.php
@@ -962,13 +962,16 @@ final class EventRegistrationControllerTest extends UnitTestCase
     {
         $event = new SingleEvent();
 
-        $this->viewMock->expects(self::exactly(3))->method('assign')->withConsecutive(
-            ['event', $event],
-            ['registration', self::anything()],
-            ['applicablePrices', self::anything()],
+        $registration = new Registration();
+        $this->viewMock->expects(self::once())->method('assignMultiple')->with(
+            [
+                'event' => $event,
+                'registration' => $registration,
+                'applicablePrices' => [],
+            ],
         );
 
-        $this->subject->confirmAction($event, new Registration());
+        $this->subject->confirmAction($event, $registration);
     }
 
     /**
@@ -978,10 +981,13 @@ final class EventRegistrationControllerTest extends UnitTestCase
     {
         $event = new EventDate();
 
-        $this->viewMock->expects(self::exactly(3))->method('assign')->withConsecutive(
-            ['event', $event],
-            ['registration', self::anything()],
-            ['applicablePrices', self::anything()],
+        $registration = new Registration();
+        $this->viewMock->expects(self::once())->method('assignMultiple')->with(
+            [
+                'event' => $event,
+                'registration' => $registration,
+                'applicablePrices' => [],
+            ],
         );
 
         $this->subject->confirmAction($event, new Registration());
@@ -994,13 +1000,16 @@ final class EventRegistrationControllerTest extends UnitTestCase
     {
         $registration = new Registration();
 
-        $this->viewMock->expects(self::exactly(3))->method('assign')->withConsecutive(
-            ['event', self::anything()],
-            ['registration', $registration],
-            ['applicablePrices', self::anything()],
+        $event = new SingleEvent();
+        $this->viewMock->expects(self::once())->method('assignMultiple')->with(
+            [
+                'event' => $event,
+                'registration' => $registration,
+                'applicablePrices' => [],
+            ],
         );
 
-        $this->subject->confirmAction(new SingleEvent(), $registration);
+        $this->subject->confirmAction($event, $registration);
     }
 
     /**
@@ -1014,13 +1023,16 @@ final class EventRegistrationControllerTest extends UnitTestCase
             ->expects(self::once())->method('findApplicablePrices')->with($event)
             ->willReturn($applicablePrices);
 
-        $this->viewMock->expects(self::exactly(3))->method('assign')->withConsecutive(
-            ['event', self::anything()],
-            ['registration', self::anything()],
-            ['applicablePrices', $applicablePrices],
+        $registration = new Registration();
+        $this->viewMock->expects(self::once())->method('assignMultiple')->with(
+            [
+                'event' => $event,
+                'registration' => $registration,
+                'applicablePrices' => $applicablePrices,
+            ],
         );
 
-        $this->subject->confirmAction($event, new Registration());
+        $this->subject->confirmAction($event, $registration);
     }
 
     /**


### PR DESCRIPTION
Switch `confirmAction` to `assignMultiple` to avoid the deprecated `withConsecutive` in the tests.

Part of #5200