### PR TITLE
[TASK] Modernize `EventRegistrationController` (part 3)

### DIFF
--- a/Classes/Controller/EventRegistrationController.php
+++ b/Classes/Controller/EventRegistrationController.php
@@ -225,8 +225,12 @@ class EventRegistrationController extends ActionController
      */
     public function thankYouAction(Event $event, Registration $registration): ResponseInterface
     {
-        $this->view->assign('event', $event);
-        $this->view->assign('registration', $registration);
+        $this->view->assignMultiple(
+            [
+                'event' => $event,
+                'registration' => $registration,
+            ],
+        );
 
         return $this->htmlResponse();
     }

--- a/Tests/Unit/Controller/EventRegistrationControllerTest.php
+++ b/Tests/Unit/Controller/EventRegistrationControllerTest.php
@@ -1235,30 +1235,18 @@ final class EventRegistrationControllerTest extends UnitTestCase
     /**
      * @test
      */
-    public function thankYouActionPassesProvidedEventToView(): void
+    public function thankYouActionPassesProvidedEventAndRegistrationToView(): void
     {
         $event = new SingleEvent();
-
-        $this->viewMock->expects(self::exactly(2))->method('assign')->withConsecutive(
-            ['event', $event],
-            ['registration', self::anything()],
-        );
-
-        $this->subject->thankYouAction($event, new Registration());
-    }
-
-    /**
-     * @test
-     */
-    public function thankYouActionPassesProvidedRegistrationToView(): void
-    {
         $registration = new Registration();
 
-        $this->viewMock->expects(self::exactly(2))->method('assign')->withConsecutive(
-            ['event', self::anything()],
-            ['registration', $registration],
+        $this->viewMock->expects(self::once())->method('assignMultiple')->with(
+            [
+                'event' => $event,
+                'registration' => $registration,
+            ],
         );
 
-        $this->subject->thankYouAction(new SingleEvent(), $registration);
+        $this->subject->thankYouAction($event, $registration);
     }
 }


### PR DESCRIPTION
Switch `thankYouAction` to `assignMultiple` to avoid the deprecated `withConsecutive` in the tests.

Part of #5200