### PR TITLE
[TASK] Increase the timeout for the functional tests CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,7 +150,7 @@ jobs:
   functional-tests:
     name: Functional tests
     runs-on: ubuntu-24.04
-    timeout-minutes: 6
+    timeout-minutes: 8
     needs: php-lint
     steps:
       - name: Checkout


### PR DESCRIPTION
Now that we aren't parallelizing our tests, we tend to run into the timeout of 6 minutes on GitHub.