### PR TITLE
[BUGFIX] Ensure to always have a currency record in the tests

### DIFF
--- a/Tests/Functional/Fixtures/EuroCurrency.csv
+++ b/Tests/Functional/Fixtures/EuroCurrency.csv
@@ -1,0 +1,3 @@
+"static_currencies"
+,"uid","cu_iso_3","cu_iso_nr","cu_name_en","cu_symbol_left","cu_thousands_point","cu_decimal_point","cu_decimal_digits","cu_sub_divisor"
+,49,"EUR",878,"Euro","€",".",",",2,100

--- a/Tests/Functional/OldModel/LegacyEventTest.php
+++ b/Tests/Functional/OldModel/LegacyEventTest.php
@@ -87,6 +87,10 @@ final class LegacyEventTest extends FunctionalTestCase
      */
     public function fromUidMapsDataFromDatabase(): void
     {
+        $currenciesConnection = $this->get(ConnectionPool::class)->getConnectionForTable('static_currencies');
+        if ($currenciesConnection->count('*', 'static_currencies', []) === 0) {
+            $this->importCSVDataSet(__DIR__ . '/../Fixtures/EuroCurrency.csv');
+        }
         $this->importCSVDataSet(__DIR__ . '/Fixtures/Events.csv');
 
         $subject = TestingLegacyEvent::fromUid(1);

--- a/Tests/LegacyFunctional/OldModel/LegacyEventTest.php
+++ b/Tests/LegacyFunctional/OldModel/LegacyEventTest.php
@@ -79,20 +79,7 @@ final class LegacyEventTest extends FunctionalTestCase
 
         $currenciesConnection = $this->connectionPool->getConnectionForTable('static_currencies');
         if ($currenciesConnection->count('*', 'static_currencies', []) === 0) {
-            $currenciesConnection->insert(
-                'static_currencies',
-                [
-                    'uid' => 49,
-                    'cu_iso_3' => 'EUR',
-                    'cu_iso_nr' => 978,
-                    'cu_name_en' => 'Euro',
-                    'cu_symbol_left' => '€',
-                    'cu_thousands_point' => '.',
-                    'cu_decimal_point' => ',',
-                    'cu_decimal_digits' => 2,
-                    'cu_sub_divisor' => 100,
-                ],
-            );
+            $this->importCSVDataSet(__DIR__ . '/../../Functional/Fixtures/EuroCurrency.csv');
         }
 
         $this->configuration = new DummyConfiguration();

--- a/Tests/LegacyFunctional/OldModel/LegacyRegistrationTest.php
+++ b/Tests/LegacyFunctional/OldModel/LegacyRegistrationTest.php
@@ -65,20 +65,7 @@ final class LegacyRegistrationTest extends FunctionalTestCase
 
         $currenciesConnection = $this->get(ConnectionPool::class)->getConnectionForTable('static_currencies');
         if ($currenciesConnection->count('*', 'static_currencies', []) === 0) {
-            $currenciesConnection->insert(
-                'static_currencies',
-                [
-                    'uid' => 49,
-                    'cu_iso_3' => 'EUR',
-                    'cu_iso_nr' => 978,
-                    'cu_name_en' => 'Euro',
-                    'cu_symbol_left' => '€',
-                    'cu_thousands_point' => '.',
-                    'cu_decimal_point' => ',',
-                    'cu_decimal_digits' => 2,
-                    'cu_sub_divisor' => 100,
-                ],
-            );
+            $this->importCSVDataSet(__DIR__ . '/../../Functional/Fixtures/EuroCurrency.csv');
         }
 
         $this->configuration = new DummyConfiguration();


### PR DESCRIPTION
With the testing framework V8, static data is not automatically imported (e.g. from the static-info-tables extension).

So we'll need to make sure to create some testing data if there is none in the tests.

Fixes #5202