### PR TITLE
[BUGFIX] Avoid `TypoScriptFrontendController::getLanguage()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -246,6 +246,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- Avoid the deprecated `TypoScriptFrontendController::getLanguage()` (#5224)
 - Avoid deprecated query methods in `AbstractBag` (#5203)
 - Fix property mapping with timeslots and registrations (#5155)
 - Use the correct no-wrap Bootstrap class (#5151)

--- a/Classes/Templating/TemplateHelper.php
+++ b/Classes/Templating/TemplateHelper.php
@@ -7,8 +7,10 @@ namespace OliverKlee\Seminars\Templating;
 use OliverKlee\Oelib\Exception\NotFoundException;
 use OliverKlee\Oelib\Templating\Template;
 use OliverKlee\Oelib\Templating\TemplateRegistry;
+use Psr\Http\Message\ServerRequestInterface;
 use TYPO3\CMS\Core\Localization\Locales;
 use TYPO3\CMS\Core\Localization\LocalizationFactory;
+use TYPO3\CMS\Core\Site\Entity\SiteLanguage;
 use TYPO3\CMS\Core\Utility\ArrayUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Utility\HttpUtility;
@@ -179,7 +181,11 @@ abstract class TemplateHelper
             }
         }
         $this->extractPiVars();
-        $this->LLkey = $this->frontendController->getLanguage()->getTypo3Language();
+        $request = $GLOBALS['TYPO3_REQUEST'] ?? null;
+        \assert($request instanceof ServerRequestInterface);
+        $siteLanguage = $request->getAttribute('language');
+        \assert($siteLanguage instanceof SiteLanguage);
+        $this->LLkey = $siteLanguage->getTypo3Language();
 
         $locales = GeneralUtility::makeInstance(Locales::class);
         if (\in_array($this->LLkey, $locales->getLocales(), true)) {

--- a/Tests/Unit/Configuration/LegacyConfigurationTest.php
+++ b/Tests/Unit/Configuration/LegacyConfigurationTest.php
@@ -7,6 +7,8 @@ namespace OliverKlee\Seminars\Tests\Unit\Configuration;
 use OliverKlee\Seminars\Configuration\LegacyConfiguration;
 use OliverKlee\Seminars\Templating\TemplateHelper;
 use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Http\Message\ServerRequestInterface;
+use TYPO3\CMS\Core\Site\Entity\SiteLanguage;
 use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
 use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
 use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
@@ -30,6 +32,10 @@ final class LegacyConfigurationTest extends UnitTestCase
     {
         parent::setUp();
 
+        $requestMock = $this->createMock(ServerRequestInterface::class);
+        $requestMock->method('getAttribute')->with('language')->willReturn($this->createStub(SiteLanguage::class));
+        $GLOBALS['TYPO3_REQUEST'] = $requestMock;
+
         $frontEndControllerMock = $this->createMock(TypoScriptFrontendController::class);
         $this->contentObjectMock = $this->createMock(ContentObjectRenderer::class);
         $frontEndControllerMock->cObj = $this->contentObjectMock;
@@ -40,7 +46,7 @@ final class LegacyConfigurationTest extends UnitTestCase
 
     protected function tearDown(): void
     {
-        unset($GLOBALS['TSFE']);
+        unset($GLOBALS['TSFE'], $GLOBALS['TYPO3_REQUEST']);
         parent::tearDown();
     }
 


### PR DESCRIPTION
This method is internal and is no longer available in TYPO3 13LTS:

https://review.typo3.org/c/Packages/TYPO3.CMS/+/82510