### PR TITLE
[FEATURE] Add ARIA labels for the FE event single view links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Add a `TimeSlot` model and repository (#5039)
 - Add more columns to the FE list views
   (#5119, #5131, #5150, #5152, #5171, #5177, #5182)
-- Restyle the FE list views (#5043, #5117)
+- Restyle the FE list views (#5043, #5117, #5229)
 - Add the venue to the "my registrations" list (#4982)
 - Add the city to the "my registrations" list (#4981)
 - Also show nonbinding reservations in the BE module (#4862)

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -1908,6 +1908,9 @@
       <trans-unit id="plugin.eventArchive.events.property.eventUid.number">
         <source>#%1$u</source>
       </trans-unit>
+      <trans-unit id="plugin.eventArchive.events.property.singleViewLink.ariaLabel">
+        <source>Show details for the event &quot;%1$s&quot;</source>
+      </trans-unit>
       <trans-unit id="plugin.eventOutlook">
         <source>Event outlook</source>
       </trans-unit>
@@ -2015,6 +2018,9 @@
       </trans-unit>
       <trans-unit id="plugin.eventOutlook.events.property.eventUid.number">
         <source>#%1$u</source>
+      </trans-unit>
+      <trans-unit id="plugin.eventOutlook.events.property.singleViewLink.ariaLabel">
+        <source>Show details for the event &quot;%1$s&quot;</source>
       </trans-unit>
       <trans-unit id="plugin.eventOutlook.events.property.price">
         <source>Price</source>

--- a/Resources/Private/Partials/Event/ArchiveList.html
+++ b/Resources/Private/Partials/Event/ArchiveList.html
@@ -58,6 +58,8 @@
             </thead>
             <tbody>
                 <f:for each="{events}" as="event">
+                    <f:variable name="singleViewLinkAriaLabel"
+                                value="{f:translate(key: 'plugin.eventArchive.events.property.singleViewLink.ariaLabel', arguments: {0: event.displayTitle})}"/>
                     <tr>
                         <oelib:isFieldEnabled fieldName="date">
                             <td>
@@ -74,7 +76,8 @@
                         <oelib:isFieldEnabled fieldName="topic">
                             <td>
                                 <f:link.action action="show" arguments="{event: event}"
-                                               pageUid="{settings.singleViewPage}">
+                                               pageUid="{settings.singleViewPage}"
+                                               additionalAttributes="{'aria-label': '{singleViewLinkAriaLabel}'}">
                                     {event.displayTitle}
                                 </f:link.action>
                             </td>

--- a/Resources/Private/Partials/Event/OutlookList.html
+++ b/Resources/Private/Partials/Event/OutlookList.html
@@ -73,6 +73,9 @@
             </thead>
             <tbody>
                 <f:for each="{events}" as="event">
+                    <f:variable name="singleViewLinkAriaLabel"
+                                value="{f:translate(key: 'plugin.eventOutlook.events.property.singleViewLink.ariaLabel', arguments: {0: event.displayTitle})}"/>
+
                     <tr>
                         <oelib:isFieldEnabled fieldName="date">
                             <td>
@@ -89,7 +92,8 @@
                         <oelib:isFieldEnabled fieldName="topic">
                             <td>
                                 <f:link.action action="show" arguments="{event: event}"
-                                               pageUid="{settings.singleViewPage}">
+                                               pageUid="{settings.singleViewPage}"
+                                               additionalAttributes="{'aria-label': '{singleViewLinkAriaLabel}'}">
                                     {event.displayTitle}
                                 </f:link.action>
                             </td>

--- a/Tests/Functional/Controller/EventControllerTest.php
+++ b/Tests/Functional/Controller/EventControllerTest.php
@@ -123,7 +123,7 @@ final class EventControllerTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function archiveActionLinksEventTitleToSingleView(): void
+    public function archiveActionForSingleEventLinksEventTitleToSingleView(): void
     {
         $this->importCSVDataSet(self::FIXTURES_PATH . '/archiveAction/EventArchiveContentElement.csv');
         $this->importCSVDataSet(self::FIXTURES_PATH . '/archiveAction/PastSingleEvent.csv');
@@ -132,7 +132,31 @@ final class EventControllerTest extends FunctionalTestCase
 
         $html = (string)$this->executeFrontendSubRequest($request)->getBody();
 
-        self::assertMatchesRegularExpression('#<a href="/event-single-view/1">.*Extension Development#s', $html);
+        $expected = '#<a [^>]*href="/event-single-view/1"[^>]*>\\s*Extension Development#s';
+        self::assertMatchesRegularExpression($expected, $html);
+    }
+
+    /**
+     * @test
+     */
+    public function archiveActionForSingleEventLinksEventTitleWithAriaText(): void
+    {
+        $this->importCSVDataSet(self::FIXTURES_PATH . '/archiveAction/EventArchiveContentElement.csv');
+        $this->importCSVDataSet(self::FIXTURES_PATH . '/archiveAction/PastSingleEvent.csv');
+
+        $request = (new InternalRequest())->withPageId(1);
+
+        $html = (string)$this->executeFrontendSubRequest($request)->getBody();
+
+        $label = LocalizationUtility::translate(
+            'plugin.eventArchive.events.property.singleViewLink.ariaLabel',
+            'seminars',
+            ['Extension Development with Extbase and Fluid'],
+        );
+        self::assertIsString($label);
+        $encodedLabel = \htmlspecialchars($label, ENT_QUOTES | ENT_HTML5);
+        $expected = '#<a [^>]*aria-label="' . $encodedLabel . '"[^>]*>\\s*Extension Development#s';
+        self::assertMatchesRegularExpression($expected, $html);
     }
 
     /**
@@ -153,7 +177,7 @@ final class EventControllerTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function archiveActionRendersPastDateWithTitleFromTopic(): void
+    public function archiveActionForEventDateLinksEventTitleFromTopicToSingleView(): void
     {
         $this->importCSVDataSet(self::FIXTURES_PATH . '/archiveAction/EventArchiveContentElement.csv');
         $this->importCSVDataSet(self::FIXTURES_PATH . '/archiveAction/PastDateWithTopic.csv');
@@ -162,7 +186,31 @@ final class EventControllerTest extends FunctionalTestCase
 
         $html = (string)$this->executeFrontendSubRequest($request)->getBody();
 
-        self::assertStringContainsString('Extension Development with Extbase and Fluid', $html);
+        $expected = '#<a [^>]*href="/event-single-view/2"[^>]*>\\s*Extension Development#s';
+        self::assertMatchesRegularExpression($expected, $html);
+    }
+
+    /**
+     * @test
+     */
+    public function archiveActionForEventDateLinksEventTitleFromTopicWithAriaText(): void
+    {
+        $this->importCSVDataSet(self::FIXTURES_PATH . '/archiveAction/EventArchiveContentElement.csv');
+        $this->importCSVDataSet(self::FIXTURES_PATH . '/archiveAction/PastDateWithTopic.csv');
+
+        $request = (new InternalRequest())->withPageId(1);
+
+        $html = (string)$this->executeFrontendSubRequest($request)->getBody();
+
+        $label = LocalizationUtility::translate(
+            'plugin.eventArchive.events.property.singleViewLink.ariaLabel',
+            'seminars',
+            ['Extension Development with Extbase and Fluid'],
+        );
+        self::assertIsString($label);
+        $encodedLabel = \htmlspecialchars($label, ENT_QUOTES | ENT_HTML5);
+        $expected = '#<a [^>]*aria-label="' . $encodedLabel . '"[^>]*>\\s*Extension Development#s';
+        self::assertMatchesRegularExpression($expected, $html);
     }
 
     /**
@@ -454,7 +502,7 @@ final class EventControllerTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function outlookActionLinksEventTitleToSingleView(): void
+    public function outlookActionForSingleEventLinksEventTitleToSingleView(): void
     {
         $this->importCSVDataSet(self::FIXTURES_PATH . '/outlookAction/EventOutlookContentElement.csv');
         $this->importCSVDataSet(self::FIXTURES_PATH . '/outlookAction/FutureSingleEvent.csv');
@@ -463,7 +511,31 @@ final class EventControllerTest extends FunctionalTestCase
 
         $html = (string)$this->executeFrontendSubRequest($request)->getBody();
 
-        self::assertMatchesRegularExpression('#<a href="/event-single-view/1">.*Extension Development#s', $html);
+        $expected = '#<a [^>]*href="/event-single-view/1"[^>]*>\\s*Extension Development#s';
+        self::assertMatchesRegularExpression($expected, $html);
+    }
+
+    /**
+     * @test
+     */
+    public function outlookActionForSingleEventLinksEventTitleWithAriaText(): void
+    {
+        $this->importCSVDataSet(self::FIXTURES_PATH . '/outlookAction/EventOutlookContentElement.csv');
+        $this->importCSVDataSet(self::FIXTURES_PATH . '/outlookAction/FutureSingleEvent.csv');
+
+        $request = (new InternalRequest())->withPageId(1);
+
+        $html = (string)$this->executeFrontendSubRequest($request)->getBody();
+
+        $label = LocalizationUtility::translate(
+            'plugin.eventOutlook.events.property.singleViewLink.ariaLabel',
+            'seminars',
+            ['Extension Development with Extbase and Fluid'],
+        );
+        self::assertIsString($label);
+        $encodedLabel = \htmlspecialchars($label, ENT_QUOTES | ENT_HTML5);
+        $expected = '#<a [^>]*aria-label="' . $encodedLabel . '"[^>]*>\\s*Extension Development#s';
+        self::assertMatchesRegularExpression($expected, $html);
     }
 
     /**
@@ -484,7 +556,7 @@ final class EventControllerTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function outlookActionRendersFutureDateWithTitleFromTopic(): void
+    public function outlookActionForEventDateLinksEventTitleFromTopicToSingleView(): void
     {
         $this->importCSVDataSet(self::FIXTURES_PATH . '/outlookAction/EventOutlookContentElement.csv');
         $this->importCSVDataSet(self::FIXTURES_PATH . '/outlookAction/FutureDateWithTopic.csv');
@@ -493,7 +565,31 @@ final class EventControllerTest extends FunctionalTestCase
 
         $html = (string)$this->executeFrontendSubRequest($request)->getBody();
 
-        self::assertStringContainsString('Extension Development with Extbase and Fluid', $html);
+        $expected = '#<a [^>]*href="/event-single-view/2"[^>]*>\\s*Extension Development#s';
+        self::assertMatchesRegularExpression($expected, $html);
+    }
+
+    /**
+     * @test
+     */
+    public function outlookActionForEventDateLinksEventTitleFromTopicWithAriaText(): void
+    {
+        $this->importCSVDataSet(self::FIXTURES_PATH . '/outlookAction/EventOutlookContentElement.csv');
+        $this->importCSVDataSet(self::FIXTURES_PATH . '/outlookAction/FutureDateWithTopic.csv');
+
+        $request = (new InternalRequest())->withPageId(1);
+
+        $html = (string)$this->executeFrontendSubRequest($request)->getBody();
+
+        $label = LocalizationUtility::translate(
+            'plugin.eventOutlook.events.property.singleViewLink.ariaLabel',
+            'seminars',
+            ['Extension Development with Extbase and Fluid'],
+        );
+        self::assertIsString($label);
+        $encodedLabel = \htmlspecialchars($label, ENT_QUOTES | ENT_HTML5);
+        $expected = '#<a [^>]*aria-label="' . $encodedLabel . '"[^>]*>\\s*Extension Development#s';
+        self::assertMatchesRegularExpression($expected, $html);
     }
 
     /**


### PR DESCRIPTION
Also add some more tests for the existing single view links and tighten the regular expressions used to check those.

Also make some test name more specific.

Part of #5207