### PR TITLE
[TASK] Simplify `SalutationAwareTranslateViewHelper` arguments

### DIFF
--- a/Classes/ViewHelpers/SalutationAwareTranslateViewHelper.php
+++ b/Classes/ViewHelpers/SalutationAwareTranslateViewHelper.php
@@ -74,10 +74,10 @@ class SalutationAwareTranslateViewHelper extends AbstractViewHelper
         $defaultArguments = $arguments;
         $defaultArguments['extensionName'] = 'seminars';
         $defaultArguments['default'] = $key;
-        $defaultArguments['languageKey'] = $arguments['languageKey'] ?? null;
+        $defaultArguments['languageKey'] = '';
         $defaultArguments['key'] = $key;
         $defaultArguments['id'] = $key;
-        $defaultArguments['alternativeLanguageKeys'] = $arguments['alternativeLanguageKeys'] ?? null;
+        $defaultArguments['alternativeLanguageKeys'] = [];
 
         return $defaultArguments;
     }


### PR DESCRIPTION
There is no point in trying to read view helper arguments that our view helper does not support.

This is a preparational cleanup PR for #3344.