### PR TITLE
[TASK] Drop some nonsensical tests

### DIFF
--- a/Tests/Functional/Domain/Repository/Event/EventRepositoryTest.php
+++ b/Tests/Functional/Domain/Repository/Event/EventRepositoryTest.php
@@ -1628,19 +1628,6 @@ final class EventRepositoryTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function hideViaDataHandlerWithUidOfDeletedVisibleEventKeepsDeletedEventVisible(): void
-    {
-        $this->initializeBackEndUser();
-        $this->importCSVDataSet(__DIR__ . '/Fixtures/DeletedSingleEventOnPage.csv');
-
-        $this->subject->hideViaDataHandler(1);
-
-        $this->assertCSVDataSet(__DIR__ . '/Assertions/DeletedSingleEventOnPage.csv');
-    }
-
-    /**
-     * @test
-     */
     public function unhideViaDataHandlerWithUidOfExistingHiddenEventMarksEventAsVisible(): void
     {
         $this->initializeBackEndUser();
@@ -1675,19 +1662,6 @@ final class EventRepositoryTest extends FunctionalTestCase
         $this->subject->unhideViaDataHandler(1);
 
         $this->assertCSVDataSet(__DIR__ . '/Assertions/SingleEventOnPage.csv');
-    }
-
-    /**
-     * @test
-     */
-    public function unhideViaDataHandlerWithUidOfDeletedHiddenEventKeepsDeletedEventHidden(): void
-    {
-        $this->initializeBackEndUser();
-        $this->importCSVDataSet(__DIR__ . '/Fixtures/DeletedHiddenSingleEventOnPage.csv');
-
-        $this->subject->unhideViaDataHandler(1);
-
-        $this->assertCSVDataSet(__DIR__ . '/Assertions/DeletedHiddenSingleEventOnPage.csv');
     }
 
     /**

--- a/Tests/Functional/Domain/Repository/Event/Fixtures/DeletedHiddenSingleEventOnPage.csv
+++ b/Tests/Functional/Domain/Repository/Event/Fixtures/DeletedHiddenSingleEventOnPage.csv
@@ -1,7 +1,0 @@
-"pages"
-,"uid","pid","doktype","title"
-,1,0,254,"Record for pages"
-
-"tx_seminars_seminars"
-,"uid","pid","object_type","deleted","hidden"
-,1,1,0,1,1


### PR DESCRIPTION
Hiding and unhiding deleted events is not something that will occur in real life. So there is no point having tests for that.