### PR TITLE
[BUGFIX] Be more lenient with self-closing tags in a functional test

### DIFF
--- a/Tests/Functional/Controller/FrontEndEditorControllerTest.php
+++ b/Tests/Functional/Controller/FrontEndEditorControllerTest.php
@@ -793,7 +793,7 @@ final class FrontEndEditorControllerTest extends FunctionalTestCase
         $html = (string)$this->executeFrontendSubRequest($request, $context)->getBody();
 
         self::assertStringContainsString(
-            '<input type="hidden" name="tx_seminars_frontendeditor[event][__identity]" value="1" />',
+            '<input type="hidden" name="tx_seminars_frontendeditor[event][__identity]" value="1"',
             $html,
         );
         self::assertStringContainsString('event with owner', $html);
@@ -1348,7 +1348,7 @@ final class FrontEndEditorControllerTest extends FunctionalTestCase
         $html = (string)$this->executeFrontendSubRequest($request, $context)->getBody();
 
         self::assertStringContainsString(
-            '<input type="hidden" name="tx_seminars_frontendeditor[event][__identity]" value="1" />',
+            '<input type="hidden" name="tx_seminars_frontendeditor[event][__identity]" value="1"',
             $html,
         );
         self::assertStringContainsString('event with owner', $html);


### PR DESCRIPTION
In TYPO3 13LTS, the `identity` hidden field is written as a HTML5-style self-closing tag (i.e., without the `/`), while in TYPO3 <= 12 LTS, the `/>` variant is used.

Make the tests more lenient to allow both variants.