### PR TITLE
[BUGFIX] Specify return type for `getRawData`

### DIFF
--- a/Classes/Domain/Model/Event/NullEventTopic.php
+++ b/Classes/Domain/Model/Event/NullEventTopic.php
@@ -158,6 +158,13 @@ class NullEventTopic extends AbstractDomainObject implements EventTopicInterface
         throw new \BadMethodCallException('NullEventTopic does not have any prices.', 1757951370);
     }
 
+    /**
+     * Returns the raw data as it is stored in the database.
+     *
+     * @return array<string, string|int|float|null>|null
+     *
+     * @internal
+     */
     public function getRawData(): ?array
     {
         return null;


### PR DESCRIPTION
In #5249 a bug occurs, that the return type is not iterable. So must be more "speciefied"