### PR TITLE
[DOCS] Switch the early access ad from 12LTS to 13LTS

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ Most of the documentation is in ReST format
 [in the Documentation/ folder](Documentation/) and is rendered
 [as part of the TYPO3 documentation](https://docs.typo3.org/typo3cms/extensions/seminars/).
 
-## Compatibility with TYPO3 12LTS/12.4
+## Compatibility with TYPO3 13LTS/13.4
 
-A TYPO3-12LTS-compatible version of this extension is available via an
+A TYPO3-13LTS-compatible version of this extension is available via an
 [early-acces program](https://github.com/oliverklee-de/seminars/wiki/Early-access-program-for-newer-TYPO3-versions).
 
 ## Give it a try!

--- a/Resources/Private/Partials/BackEnd/EarlyAccess.html
+++ b/Resources/Private/Partials/BackEnd/EarlyAccess.html
@@ -1,8 +1,8 @@
 <html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers" data-namespace-typo3-fluid="true">
-    <f:be.infobox title="Early-access program for TYPO3 12LTS support" state="-1">
+    <f:be.infobox title="Early-access program for TYPO3 13LTS support" state="-1">
         <p>
-            The seminars extension offers support for TYPO3 12LTS via an early-access program.
-            Order it now to be 12LTS-compatible and to support the work of the extension author.
+            The seminars extension offers support for TYPO3 13LTS via an early-access program.
+            Order it now to be 13LTS-compatible and to support the work of the extension author.
         </p>
         <p>
             <a class="btn btn-info" role="button" target="_blank"


### PR DESCRIPTION
Now that the public version of the extension will soon have compatibility with TYPO3 12LTS, and now that the 13LTS-compatible early-access version is on the horizon, we should switch the early-access ad from 12LTS to 13LTS.