### PR TITLE
[TASK] Make the configuration for the event outlook consistent

### DIFF
--- a/Configuration/FlexForms/EventOutlook.xml
+++ b/Configuration/FlexForms/EventOutlook.xml
@@ -135,15 +135,15 @@
                                     </numIndex>
                                     <numIndex index="3" type="array">
                                         <numIndex index="0">
-                                            LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:plugin.eventOutlook.settings.displayOptions.columns.venue
-                                        </numIndex>
-                                        <numIndex index="1">venue</numIndex>
-                                    </numIndex>
-                                    <numIndex index="4" type="array">
-                                        <numIndex index="0">
                                             LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:plugin.eventOutlook.settings.displayOptions.columns.city
                                         </numIndex>
                                         <numIndex index="1">city</numIndex>
+                                    </numIndex>
+                                    <numIndex index="4" type="array">
+                                        <numIndex index="0">
+                                            LLL:EXT:seminars/Resources/Private/Language/locallang.xlf:plugin.eventOutlook.settings.displayOptions.columns.venue
+                                        </numIndex>
+                                        <numIndex index="1">venue</numIndex>
                                     </numIndex>
                                     <numIndex index="5" type="array">
                                         <numIndex index="0">

--- a/Tests/Functional/Controller/Fixtures/EventController/outlookAction/EventOutlookContentElement.csv
+++ b/Tests/Functional/Controller/Fixtures/EventController/outlookAction/EventOutlookContentElement.csv
@@ -22,7 +22,7 @@
                                                                  <sheet index=""displayOptions"">
                                                                      <language index=""lDEF"">
                                                                         <field index=""settings.fieldsToShow"">
-                                                                            <value index=""vDEF"">date,topic,organizer,venue,city,speakers,price,eventType,eventFormat,categories,eventUid,singleViewLink,registration,vacancies</value>
+                                                                            <value index=""vDEF"">date,topic,organizer,city,venue,speakers,price,eventType,eventFormat,categories,eventUid,singleViewLink,registration,vacancies</value>
                                                                         </field>
                                                                     </language>
                                                                 </sheet>


### PR DESCRIPTION
After the latest changes to the event outlook Fluid template, the city now comes before the venue.

The order of things in the flexforms, in the labels and the DB fixtures should reflect that.

Part of #4988