### PR TITLE
[CLEANUP] Fix Typo in `NullEventTopicTest`

### DIFF
--- a/Tests/Unit/Domain/Model/Event/NullEventTopicTest.php
+++ b/Tests/Unit/Domain/Model/Event/NullEventTopicTest.php
@@ -135,7 +135,7 @@ final class NullEventTopicTest extends UnitTestCase
     /**
      * @test
      */
-    public function getInternalTitleRetursEmptyString(): void
+    public function getInternalTitleReturnsEmptyString(): void
     {
         self::assertSame('', $this->subject->getInternalTitle());
     }


### PR DESCRIPTION
Checked for missing Unit tests, thats only little thing i found